### PR TITLE
fix: put physics back on update until it is sped up

### DIFF
--- a/src/components/physics/body.ts
+++ b/src/components/physics/body.ts
@@ -266,7 +266,7 @@ export function body(opt: BodyCompOpt = {}): BodyComp {
             }
         },
 
-        fixedUpdate(this: GameObj<PosComp | BodyComp | AreaComp>) {
+        update(this: GameObj<PosComp | BodyComp | AreaComp>) {
             if (game.gravity && !this.isStatic) {
                 if (willFall) {
                     curPlatform = null;

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -915,14 +915,14 @@ const kaplay = <
     // main game loop
     app.run(
         () => {
-            try {
+            /*try {
                 if (assets.loaded) {
                     checkFrame();
                     if (!debug.paused) fixedUpdateFrame();
                 }
             } catch (e) {
                 handleErr(e as Error);
-            }
+            }*/
         },
         () => {
             try {
@@ -943,6 +943,7 @@ const kaplay = <
                     frameEnd();
                 } else {
                     if (!debug.paused) updateFrame();
+                    checkFrame();
                     frameStart();
                     drawFrame();
                     if (gopt.debug !== false) drawDebug();


### PR DESCRIPTION
Put physics back on update until we have a benchmark for it to know whether it is identical