### PR TITLE
docs: change non-existing component in addLevel example

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3010,7 +3010,7 @@ export interface KAPLAYCtx<
      *         "=": () => [
      *             sprite("floor"),
      *             area(),
-     *             solid(),
+     *             body({ isStatic: true }),
      *         ],
      *         "$": () => [
      *             sprite("coin"),


### PR DESCRIPTION
Change non-existing component `solid()` to its homologous `body({ isStatic: true })` inside the addLevel example.

