### PR TITLE
feat: get sprite anims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,21 @@ obj.scale = vec2(3, 4);
 obj.sprite = "bag";
 ```
 
+- `sprite()` new methods, `getAnim`, `hasAnim`, `getCurAnim()`,
+
+```js
+const obj = add([
+    sprite("bean"),
+]);
+
+// get the current animation name
+debug.log(obj.getCurAnim().name);
+// check if an animation exists
+debug.log(obj.hasAnim("walk"));
+// get the animation data
+debug.log(obj.getAnim("walk"));
+```
+
 ## Misc
 
 - added `loadMusic()` to load streaming audio (doesn't block in loading screen)
@@ -142,7 +157,7 @@ obj.sprite = "bag";
 - added quadratic bezier and Catmull-Rom evaluation
 - added evaluation of the first and second derivatives for all splines
 - added higher order easing functions linear, steps and cubic-bezier
-- added a text input component
+- added `textInput()` component
 
 ## Bug fixes
 

--- a/src/components/draw/sprite.ts
+++ b/src/components/draw/sprite.ts
@@ -1,7 +1,7 @@
 // TODO: accept canvas
 
 import { dt } from "../../app";
-import type { Asset, SpriteData } from "../../assets";
+import type { Asset, SpriteAnim, SpriteData } from "../../assets";
 import { resolveSprite } from "../../assets/sprite";
 import { onLoad } from "../../game";
 import { getRenderProps } from "../../game/utils";
@@ -66,6 +66,14 @@ export interface SpriteComp extends Comp {
      * @deprecated Use `getCurrentAnim().name` instead.
      */
     curAnim(): string | undefined;
+    /**
+     * Check if object's sprite has an animation.
+     */
+    hasAnim(name: string): boolean;
+    /**
+     * Get an animation.
+     */
+    getAnim(name: string): SpriteAnim | null;
     /**
      * Speed multiplier for all animations (for the actual fps for an anim use .play("anim", { speed: 10 })).
      */
@@ -456,6 +464,14 @@ export function sprite(
 
         curAnim() {
             return curAnim?.name;
+        },
+
+        getAnim(name) {
+            return spriteData?.anims[name] ?? null;
+        },
+
+        hasAnim(name) {
+            return Boolean(this.getAnim(name));
         },
 
         onAnimEnd(


### PR DESCRIPTION
From Changelog:


- `sprite()` new methods, `getAnim`, `hasAnim`

```js
const obj = add([
    sprite("bean"),
]);

// check if an animation exists
debug.log(obj.hasAnim("walk"));
// get the animation data
debug.log(obj.getAnim("walk"));
```


- Close #265 