### PR TITLE
chore: fix typo in current anim name hint

### DIFF
--- a/src/components/draw/sprite.ts
+++ b/src/components/draw/sprite.ts
@@ -63,7 +63,7 @@ export interface SpriteComp extends Comp {
     /**
      * Get current anim name.
      *
-     * @deprecated Use `getCurrentAnim().name` instead.
+     * @deprecated Use `getCurAnim().name` instead.
      */
     curAnim(): string | undefined;
     /**


### PR DESCRIPTION
## Description
Fixes typo in deprecation comment.
`getCurrentAnim().name` -> `getCurAnim().name` as `getCurrentAnim()` does not exist.
