### PR TITLE
feat: add keyboardCode on input bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ features of v4000, while v4000 will have the most features and breaking changes.
       buttons: {
           jump: {
               keyboard: ["space", "up"],
+              keyboardCode: "Space", // you can also use key codes
               gamepad: ["south"],
           },
       },

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -96,6 +96,7 @@ export const initAppState = (opt: {
         buttonsByKey: new Map<Key, string[]>(),
         buttonsByMouse: new Map<MouseButton, string[]>(),
         buttonsByGamepad: new Map<KGamepadButton, string[]>(),
+        buttonsByKeyCode: new Map<string, string[]>(),
         loopID: null as null | number,
         stopped: false,
         dt: 0,
@@ -962,6 +963,8 @@ export const initApp = (opt: {
         state.events.onOnce("input", () => {
             const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
                 || e.key.toLowerCase();
+            const code = e.code;
+
             if (k === undefined) throw new Error(`Unknown key: ${e.key}`);
             if (k.length === 1) {
                 state.events.trigger("charInput", k);
@@ -985,6 +988,13 @@ export const initApp = (opt: {
                     });
                 }
 
+                if (state.buttonsByKeyCode.has(code)) {
+                    state.buttonsByKeyCode.get(code)?.forEach((btn) => {
+                        state.buttonState.press(btn);
+                        state.events.trigger("buttonPress", btn);
+                    });
+                }
+
                 state.keyState.press(k);
                 state.events.trigger("keyPressRepeat", k);
                 state.events.trigger("keyPress", k);
@@ -996,9 +1006,17 @@ export const initApp = (opt: {
         state.events.onOnce("input", () => {
             const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
                 || e.key.toLowerCase();
+            const code = e.code;
 
             if (state.buttonsByKey.has(k)) {
                 state.buttonsByKey.get(k)?.forEach((btn) => {
+                    state.buttonState.release(btn);
+                    state.events.trigger("buttonRelease", btn);
+                });
+            }
+
+            if (state.buttonsByKeyCode.has(code)) {
+                state.buttonsByKeyCode.get(code)?.forEach((btn) => {
                     state.buttonState.release(btn);
                     state.events.trigger("buttonRelease", btn);
                 });

--- a/src/app/inputBindings.ts
+++ b/src/app/inputBindings.ts
@@ -9,6 +9,7 @@ import { appState } from "./app";
  */
 export type ButtonBinding = {
     keyboard?: Key | Key[];
+    keyboardCode?: string | string[];
     gamepad?: KGamepadButton | KGamepadButton[];
     mouse?: MouseButton | MouseButton[];
 };
@@ -38,12 +39,20 @@ export const parseButtonBindings = () => {
 
     for (const b in btns) {
         const keyboardBtns = btns[b].keyboard && [btns[b].keyboard].flat();
+        const keyboardCodes = btns[b].keyboardCode
+            && [btns[b].keyboardCode].flat();
         const gamepadBtns = btns[b].gamepad && [btns[b].gamepad].flat();
         const mouseBtns = btns[b].mouse && [btns[b].mouse].flat();
 
         if (keyboardBtns) {
             keyboardBtns.forEach((k) => {
                 mapAddOrPush(appState.buttonsByKey, k, b);
+            });
+        }
+
+        if (keyboardCodes) {
+            keyboardCodes.forEach((k) => {
+                mapAddOrPush(appState.buttonsByKeyCode, k, b);
             });
         }
 


### PR DESCRIPTION
New syntax:

```js
kaplay({
    buttons: {
        "jump": {
            "keyboardCode": ["Period", "Space"],
        }
    }
})
```


- Closes #368 
