### PR TITLE
docs(examples): link for BodyComp api

### DIFF
--- a/examples/gravity.js
+++ b/examples/gravity.js
@@ -60,4 +60,4 @@ add([
     pos(12, 12),
 ]);
 
-// Check out https://kaboomjs.com#BodyComp for everything body() provides
+// Check out https://kaplayjs.com/doc/BodyComp for everything body() provides


### PR DESCRIPTION
## Description

In examples/gravity, the given link is "https://kaboomjs.com#BodyComp", I replaced it with "https://kaplayjs.com/doc/BodyComp"