### PR TITLE
feat: connect play() audio to somewhere other than default node

### DIFF
--- a/src/audio/play.ts
+++ b/src/audio/play.ts
@@ -49,6 +49,11 @@ export interface AudioPlayOpt {
      * Defaults to 0.0.
      */
     pan?: number;
+    /**
+     * If the audio node should start out connected to another audio node rather than
+     * Kaplay's default volume node. Defaults to undefined, i.e. use Kaplay's volume node.
+     */
+    connectTo?: AudioNode
 }
 
 export interface AudioPlay {
@@ -122,6 +127,12 @@ export interface AudioPlay {
      */
     onEnd(action: () => void): KEventController;
     then(action: () => void): KEventController;
+    /**
+     * Disconnect the audio node from whatever it is currently connected to
+     * and connect it to the passed-in audio node, or to Kaplay's default volume node
+     * if no node is passed.
+     */
+    connect(node?: AudioNode): void;
 }
 
 export function play(
@@ -308,6 +319,11 @@ export function play(
 
         then(action: () => void) {
             return this.onEnd(action);
+        },
+
+        connect(node: AudioNode = null) {
+            gainNode.disconnect();
+            gainNode.connect(node ?? audio.masterNode);
         },
     };
 }

--- a/src/audio/play.ts
+++ b/src/audio/play.ts
@@ -321,7 +321,7 @@ export function play(
             return this.onEnd(action);
         },
 
-        connect(node: AudioNode = null) {
+        connect(node?: AudioNode) {
             gainNode.disconnect();
             gainNode.connect(node ?? audio.masterNode);
         },

--- a/src/audio/play.ts
+++ b/src/audio/play.ts
@@ -51,7 +51,7 @@ export interface AudioPlayOpt {
     pan?: number;
     /**
      * If the audio node should start out connected to another audio node rather than
-     * Kaplay's default volume node. Defaults to undefined, i.e. use Kaplay's volume node.
+     * KAPLAY's default volume node. Defaults to undefined, i.e. use KAPLAY's volume node.
      */
     connectTo?: AudioNode
 }

--- a/src/audio/play.ts
+++ b/src/audio/play.ts
@@ -173,7 +173,7 @@ export function play(
     };
     panNode.pan.value = opt.pan ?? 0;
     panNode.connect(gainNode);
-    gainNode.connect(audio.masterNode);
+    gainNode.connect(opt.connectTo ?? audio.masterNode);
     gainNode.gain.value = opt.volume ?? 1;
 
     const start = (data: SoundData) => {

--- a/src/audio/playMusic.ts
+++ b/src/audio/playMusic.ts
@@ -8,7 +8,7 @@ export function playMusic(url: string, opt: AudioPlayOpt = {}): AudioPlay {
     const el = new Audio(url);
     const src = audio.ctx.createMediaElementSource(el);
 
-    src.connect(audio.masterNode);
+    src.connect(opt.connectTo ?? audio.masterNode);
 
     function resumeAudioCtx() {
         if (debug.paused) return;
@@ -101,6 +101,11 @@ export function playMusic(url: string, opt: AudioPlayOpt = {}): AudioPlay {
 
         then(action: () => void) {
             return this.onEnd(action);
+        },
+
+        connect(node?: AudioNode) {
+            src.disconnect();
+            src.connect(node ?? audio.masterNode);
         },
     };
 }


### PR DESCRIPTION
allows the user to redirect the audio from play() to a different audio node other than Kaplay's global gain node