### PR TITLE
update velocity when moving if available

### DIFF
--- a/src/components/transform/pos.ts
+++ b/src/components/transform/pos.ts
@@ -83,7 +83,7 @@ export function pos(...args: Vec2Args): PosComp {
             const vel = vec2(...args).scale(k.dt());
             this.moveBy(vel);
             if (this.c("body")) {
-                this.vel = vel;
+                this.vel.add(vel);
             }
         },
 

--- a/src/components/transform/pos.ts
+++ b/src/components/transform/pos.ts
@@ -80,7 +80,11 @@ export function pos(...args: Vec2Args): PosComp {
 
         // move with velocity (pixels per second)
         move(...args: Vec2Args) {
-            this.moveBy(vec2(...args).scale(k.dt()));
+            const vel = vec2(...args).scale(k.dt());
+            this.moveBy(vel);
+            if (this.c("body")) {
+                this.vel = vel;
+            }
         },
 
         // move to a destination, with optional speed

--- a/src/components/transform/pos.ts
+++ b/src/components/transform/pos.ts
@@ -4,6 +4,7 @@ import { k } from "../../kaplay";
 import { Vec2, vec2, type Vec2Args } from "../../math/math";
 import type { Comp, GameObj } from "../../types";
 import type { FixedComp } from "./fixed";
+import type { BodyComp } from "../physics";
 
 /**
  * The {@link pos `pos()`} component.
@@ -79,7 +80,7 @@ export function pos(...args: Vec2Args): PosComp {
         },
 
         // move with velocity (pixels per second)
-        move(...args: Vec2Args) {
+        move(this: GameObj<PosComp | BodyComp>, ...args: Vec2Args) {
             const vel = vec2(...args).scale(k.dt());
             if (this.c("body")) {
                 this.vel = this.vel.reject(vel).add(vel);

--- a/src/components/transform/pos.ts
+++ b/src/components/transform/pos.ts
@@ -81,9 +81,10 @@ export function pos(...args: Vec2Args): PosComp {
         // move with velocity (pixels per second)
         move(...args: Vec2Args) {
             const vel = vec2(...args).scale(k.dt());
-            this.moveBy(vel);
             if (this.c("body")) {
-                this.vel.add(vel);
+                this.vel = this.vel.reject(vel).add(vel);
+            } else {
+                this.moveBy(vel);
             }
         },
 


### PR DESCRIPTION
I was trying to write some code that used the player's velocity to make footstep noises when the player moves, but the pos component's move function just updates the position, not the velocity. I had some horribly ugly hacks in place to get it working.

Why not add the move()'s "simulated velocity" to the real velocity to make it work instead? Then you can check the velocity to get the the actual motion of the object.

(I will test this and close the PR if it obviously doesn't work.)