### PR TITLE
allow specific objects in collisionIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src-tauri/target/
 replit.nix
 /.obsidian
 .pnpm-store
+package-lock.json

--- a/src/components/physics/area.ts
+++ b/src/components/physics/area.ts
@@ -54,7 +54,7 @@ export interface AreaComp extends Comp {
      *
      * @since v3000.0
      */
-    collisionIgnore: Tag[];
+    collisionIgnore: (Tag | GameObj)[];
     /**
      * If was just clicked on last frame.
      */

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -330,8 +330,7 @@ const kaplay = <
 >(
     gopt: KAPLAYOpt<TPlugins, TButtons> = {},
 ): TPlugins extends [undefined] ? KAPLAYCtx<TButtons, TButtonsName>
-    : KAPLAYCtx<TButtons, TButtonsName> & MergePlugins<TPlugins> =>
-{
+    : KAPLAYCtx<TButtons, TButtonsName> & MergePlugins<TPlugins> => {
     globalOpt = gopt;
     const root = gopt.root ?? document.body;
 
@@ -804,12 +803,20 @@ const kaplay = <
                                 if (!other.exists()) continue;
                                 if (checked.has(other.id)) continue;
                                 for (const tag of aobj.collisionIgnore) {
-                                    if (other.is(tag)) {
+                                    if (typeof tag === "string") {
+                                        if (other.is(tag)) {
+                                            continue check;
+                                        }
+                                    } else if (tag === other) {
                                         continue check;
                                     }
                                 }
                                 for (const tag of other.collisionIgnore) {
-                                    if (aobj.is(tag)) {
+                                    if (typeof tag === "string") {
+                                        if (aobj.is(tag)) {
+                                            continue check;
+                                        }
+                                    } else if (tag === aobj) {
                                         continue check;
                                     }
                                 }
@@ -855,7 +862,7 @@ const kaplay = <
 
         // TODO: this should only run once
         app.run(
-            () => {},
+            () => { },
             () => {
                 frameStart();
 
@@ -918,7 +925,7 @@ const kaplay = <
             // clear canvas
             gl.clear(
                 gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT
-                    | gl.STENCIL_BUFFER_BIT,
+                | gl.STENCIL_BUFFER_BIT,
             );
 
             // unbind everything
@@ -1337,7 +1344,7 @@ const kaplay = <
     // export everything to window if global is set
     if (gopt.global !== false) {
         for (const key in k) {
-            (<any> window[<any> key]) = k[key as keyof KAPLAYCtx];
+            (<any>window[<any>key]) = k[key as keyof KAPLAYCtx];
         }
     }
 


### PR DESCRIPTION
Allows the user to put specific objects into collisionIgnore instead of having to generate a unique tag.