### PR TITLE
fix: unexpected re-route when audio playback is manipulated

### DIFF
--- a/src/audio/play.ts
+++ b/src/audio/play.ts
@@ -208,7 +208,7 @@ export function play(
         newNode.playbackRate.value = oldNode.playbackRate.value;
         newNode.detune.value = oldNode.detune.value;
         newNode.onended = oldNode.onended;
-        newNode.connect(gainNode);
+        newNode.connect(panNode);
         return newNode;
     };
 


### PR DESCRIPTION
#331 / #335 implemented the panning but I just noticed that if the audio is paused/stopped/seeked the audio will stop going through the pan node, this PR fixes that.
