### PR TITLE
feat: add typescript checkint to all examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,8 @@
 - Now `text()` component doesn't require to pass a string.
 - Now `camScale()` and `camPos()` accept only 1 number as parameter.
 - Now `shake()` can be called without args.
+- Now `loadShader()` and `loadShaderURL()` accepts null for unused parameters.
+- Now `RectCompOpt` accepts a array of numbers for `radius`.
 
 ## Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@
 - Added circle and (rotated) ellipse collision shapes.
 - Added an ellipse component.
 - Circle area is no longer a box.
+- Added a fake cursor API
+
+  ```js
+  const myCursor = add([fakeMouse(), sprite("kat"), pos(100, 100)]);
+
+  myCursor.press(); // trigger onClick events if the mouse is over
+  myCursor.release();
+  myCursor.move(vec2(100, 200)); // move as your wish
+  ```
 
 # v4000.0.0 and v3001.0.0
-
-This version is a double release, with a lot of new features and breaking
-changes. v3001 release are focused in backward compatibility with v3000 with the
-features of v4000, while v4000 will have the most features and breaking changes.
 
 ## Input
 
@@ -73,16 +78,6 @@ features of v4000, while v4000 will have the most features and breaking changes.
   onGamepadButtonPress("south", (btn, gp) => {
       console.log(gp.index); // gamepad number on navigator's gamepad list
   });
-  ```
-
-- added a fake cursor API (**v4000**)
-
-  ```js
-  const myCursor = add([fakeMouse(), sprite("kat"), pos(100, 100)]);
-
-  myCursor.press(); // trigger onClick events if the mouse is over
-  myCursor.release();
-  myCursor.move(vec2(100, 200)); // move as your wish
   ```
 
 ## Physics
@@ -277,17 +272,14 @@ features of v4000, while v4000 will have the most features and breaking changes.
 
 ## Debug mode
 
-- added `outline()`, `shader()`, and `area()` properties to `debug.inspect`
-  (**v3001/4000**)
+- added `outline()`, `shader()`, and `area()` properties to `debug.inspect`.
 - added `KAPLAYOpt.debugKey` for customizing the key used to toggle debug mode.
-  (**v3001/4000**)
 
   ```js
   kaplay({
       debugKey: "l",
   });
   ```
-
 - added compatibility with custom properties in debug mode
 
   ```js
@@ -305,10 +297,9 @@ features of v4000, while v4000 will have the most features and breaking changes.
   // see the custom properties in debug mode
   debug.inspect = true;
   ```
+- Now `debug.log()` accepts multiple argument of any type, like `console.log()`.
 
 ## Helpers
-
-> All changes applies for both v3001 and v4000
 
 - added `getSceneName()` to get the current scene name
 - added `Color.toArray()` to convert a color to an array
@@ -325,12 +316,16 @@ features of v4000, while v4000 will have the most features and breaking changes.
 
 ## TypeScript
 
-- now you can type `get()` with a type parameter and passing component types.
+- Now you can type `get()` with a type parameter and passing component types.
   (**v4000**)
 
   ```ts
   const player = get<BodyComp>("player");
   ```
+- Now `Key` also accepts a string as an acceptable value.
+- Now `text()` component doesn't require to pass a string.
+- Now `camScale()` and `camPos()` accept only 1 number as parameter.
+- Now `shake()` can be called without args.
 
 ## Deprecations
 

--- a/examples/add.js
+++ b/examples/add.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Adding game objects to screen
 
 // Start a KAPLAY game

--- a/examples/ai.js
+++ b/examples/ai.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Use state() component to handle basic AI
 
 // Start kaboom

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Start kaboom
 kaplay();
 
@@ -174,7 +176,7 @@ console.log(JSON.stringify(serializeAnimation(curvingBean, "root"), "", 2));
 
 /*onDraw(() => {
     drawCurve(t => evaluateCatmullRom(
-        vec2(200, 400),
+        vec2(200, 400),\
         vec2(250, 500),
         vec2(300, 400),
         vec2(350, 500), t), { color: RED })

--- a/examples/audio.js
+++ b/examples/audio.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // audio playback & control
 
 kaplay({

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -1,3 +1,5 @@
+// @ts-config
+
 // bench marking sprite rendering performance
 
 kaplay();

--- a/examples/binding.js
+++ b/examples/binding.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     buttons: {
         "jump": {

--- a/examples/burp.js
+++ b/examples/burp.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Start the game in burp mode
 kaplay({
     burp: true,

--- a/examples/button.js
+++ b/examples/button.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Simple Button UI
 
 kaplay({
@@ -16,6 +18,7 @@ function addButton(txt, p, f) {
         scale(1),
         anchor("center"),
         outline(4),
+        color(0, 0, 0),
     ]);
 
     // add a child object that displays the text

--- a/examples/camera.js
+++ b/examples/camera.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Adjust camera / viewport
 
 // Start game
@@ -77,7 +79,8 @@ onKeyDown("right", () => player.move(SPEED, 0));
 
 let score = 0;
 
-// Add a ui layer with fixed() component to make the object not affected by camera
+// Add a ui layer with fixed() component to make the object
+// not affected by camera
 const ui = add([
     fixed(),
 ]);
@@ -94,6 +97,7 @@ ui.add([
 ]);
 
 onClick(() => {
-    // Use toWorld() to transform a screen-space coordinate (like mousePos()) to the world-space coordinate, which has the camera transform applied
+    // Use toWorld() to transform a screen-space coordinate (like mousePos()) to
+    // the world-space coordinate, which has the camera transform applied
     addKaboom(toWorld(mousePos()));
 });

--- a/examples/children.js
+++ b/examples/children.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/collision.js
+++ b/examples/collision.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Collision handling
 
 // Start kaboom

--- a/examples/collisionshapes.js
+++ b/examples/collisionshapes.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 setGravity(300);

--- a/examples/component.js
+++ b/examples/component.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Custom component
 
 kaplay();

--- a/examples/concert.js
+++ b/examples/concert.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // bean is holding a concert to celebrate kaboom2000!
 
 kaplay({

--- a/examples/confetti.js
+++ b/examples/confetti.js
@@ -1,3 +1,7 @@
+// @ts-check
+
+kaplay();
+
 const DEF_COUNT = 80;
 const DEF_GRAVITY = 800;
 const DEF_AIR_DRAG = 0.9;
@@ -8,8 +12,6 @@ const DEF_SPREAD = 60;
 const DEF_SPIN = [2, 8];
 const DEF_SATURATION = 0.7;
 const DEF_LIGHTNESS = 0.6;
-
-kaplay();
 
 add([
     text("click for confetti"),

--- a/examples/curves.js
+++ b/examples/curves.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 function addPoint(c, ...args) {

--- a/examples/dialog.js
+++ b/examples/dialog.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Simple dialogues with character avatars
 
 kaplay({

--- a/examples/doublejump.js
+++ b/examples/doublejump.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     background: [141, 183, 255],
 });
@@ -37,7 +39,7 @@ function spin(speed = 1200) {
 
 scene("game", () => {
     const score = add([
-        text("0", 24),
+        text("0", { size: 24 }),
         pos(24, 24),
         { value: 0 },
     ]);
@@ -111,7 +113,7 @@ scene("game", () => {
         destroy(c);
         play("coin");
         score.value += 1;
-        score.text = score.value;
+        score.text = score.value.toString();
         genCoin(c.idx);
     });
 
@@ -161,7 +163,7 @@ scene("game", () => {
     const timer = add([
         anchor("topright"),
         pos(width() - 24, 24),
-        text(timeLeft),
+        text(timeLeft.toString()),
     ]);
 
     onUpdate(() => {

--- a/examples/drag.js
+++ b/examples/drag.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Drag & drop interaction
 
 kaplay();

--- a/examples/draw.js
+++ b/examples/draw.js
@@ -28,6 +28,7 @@ const py = 160;
 const doodles = [];
 const trail = [];
 
+/** @type { import("../dist/declaration").Outline } */
 const outline = {
     width: 4,
     color: rgb(0, 0, 0),

--- a/examples/draw.js
+++ b/examples/draw.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Kaboom as pure rendering lib (no component / game obj etc.)
 
 kaplay();

--- a/examples/easing.js
+++ b/examples/easing.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 add([

--- a/examples/eatlove.js
+++ b/examples/eatlove.js
@@ -82,7 +82,9 @@ scene("game", () => {
     let score = 0;
 
     const scoreLabel = add([
-        text(score, 32),
+        text(score.toString(), {
+            size: 32,
+        }),
         pos(12, 12),
     ]);
 
@@ -91,7 +93,7 @@ scene("game", () => {
         addKaboom(player.pos);
         score += 1;
         destroy(heart);
-        scoreLabel.text = score;
+        scoreLabel.text = score.toString();
         burp();
         shake(12);
     });

--- a/examples/eatlove.js
+++ b/examples/eatlove.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 const fruits = [

--- a/examples/egg.js
+++ b/examples/egg.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Egg minigames (yes, like Peppa)
 
 kaplay({

--- a/examples/egg.js
+++ b/examples/egg.js
@@ -75,7 +75,7 @@ onKeyPress("enter", () => {
             e.use(sprite("bean"));
             addKaboom(e.pos.sub(0, e.height / 2));
             counter.value += 1;
-            counter.text = counter.value;
+            counter.text = counter.value.toString();
         }
     });
 });

--- a/examples/fadeIn.js
+++ b/examples/fadeIn.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadBean();

--- a/examples/fakeMouse.js
+++ b/examples/fakeMouse.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/fall.js
+++ b/examples/fall.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Build levels with addLevel()
 
 // Start game

--- a/examples/fixedUpdate.js
+++ b/examples/fixedUpdate.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 let fixedCount = 0;

--- a/examples/flamebar.js
+++ b/examples/flamebar.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Mario-like flamebar
 
 // Start kaboom

--- a/examples/flappy.js
+++ b/examples/flappy.js
@@ -111,7 +111,7 @@ scene("game", () => {
 
     // display score
     const scoreLabel = add([
-        text(score),
+        text(score.toString()),
         anchor("center"),
         pos(width() / 2, 80),
         fixed(),
@@ -120,7 +120,7 @@ scene("game", () => {
 
     function addScore() {
         score++;
-        scoreLabel.text = score;
+        scoreLabel.text = score.toString();
         play("score");
     }
 });

--- a/examples/flappy.js
+++ b/examples/flappy.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/gamepad.js
+++ b/examples/gamepad.js
@@ -1,7 +1,11 @@
-kaplay();
-setGravity(2400);
-setBackground(0, 0, 0);
+// @ts-check
+
+kaplay({
+    background: [0, 0, 0],
+});
 loadSprite("bean", "/sprites/bean.png");
+
+setGravity(2400);
 
 scene("nogamepad", () => {
     add([

--- a/examples/ghosthunting.js
+++ b/examples/ghosthunting.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     width: 1024,
     height: 768,

--- a/examples/ghosthunting.js
+++ b/examples/ghosthunting.js
@@ -250,7 +250,7 @@ function addEnemy(p) {
         // Health provides properties and methods to keep track of the enemies health
         health(100),
         // Sentry makes it easy to check for visibility of the player
-        sentry({ includes: "player" }, {
+        sentry({ include: "player" }, {
             lineOfSight: true,
             raycastExclude: ["enemy"],
         }),
@@ -297,7 +297,7 @@ onUpdate("enemy", enemy => {
     }
 });
 
-const SPEED = 100;
+const SPEED = 200;
 
 const dirs = {
     "left": LEFT,

--- a/examples/gravity.js
+++ b/examples/gravity.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Responding to gravity & jumping
 
 // Start kaboom

--- a/examples/hover.js
+++ b/examples/hover.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Differeces between onHover and onHoverUpdate
 
 kaplay({

--- a/examples/inspectExample.js
+++ b/examples/inspectExample.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 // # will delete this file when changes get merged/declined i don't intend this to be an actual example

--- a/examples/jsconfig.json
+++ b/examples/jsconfig.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "types": [
-      "../dist/declaration/global.d.ts"
-    ],
-    "strict": true
-  }
-}

--- a/examples/kaboom.js
+++ b/examples/kaboom.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // You can still use kaboom() instead of kaplay()!
 kaboom();
 

--- a/examples/largeTexture.js
+++ b/examples/largeTexture.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 let cameraPosition = camPos();

--- a/examples/layer.js
+++ b/examples/layer.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/layers.js
+++ b/examples/layers.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 layers(["bg", "game", "ui"], "game");

--- a/examples/level.js
+++ b/examples/level.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Build levels with addLevel()
 
 // Start game

--- a/examples/levelraycast.js
+++ b/examples/levelraycast.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     background: [31, 16, 42],
 });
@@ -19,27 +21,31 @@ const level = addLevel([
         ],
     },
 });
-level.use(rotate(45))
+level.use(rotate(45));
 
 onLoad(() => {
     level.spawn([
         pos(
             level.tileWidth() * 1.5,
-            level.tileHeight() * 1.5
+            level.tileHeight() * 1.5,
         ),
         circle(6),
-        color('#ea6262'),
+        color("#ea6262"),
         {
             add() {
                 const rayHit = level.raycast(
                     this.pos,
-                    Vec2.fromAngle(0).scale(100)
+                    Vec2.fromAngle(0).scale(100),
                 );
 
-                debug.log(`${rayHit != null} ${rayHit && rayHit.object ? rayHit.object.id : -1}`);
+                debug.log(
+                    `${rayHit != null} ${
+                        rayHit && rayHit.object ? rayHit.object.id : -1
+                    }`,
+                );
             },
         },
-    ])
-})
+    ]);
+});
 
-debug.inspect = true
+debug.inspect = true;

--- a/examples/linecap.js
+++ b/examples/linecap.js
@@ -12,7 +12,6 @@ onDraw(() => {
             vec2(50, 200),
         ],
         join: "bevel",
-        cap: "none",
         width: 20,
     });
     drawCircle({
@@ -35,7 +34,6 @@ onDraw(() => {
             vec2(50, 200),
         ],
         join: "round",
-        cap: "none",
         width: 20,
     });
     drawCircle({
@@ -58,7 +56,6 @@ onDraw(() => {
             vec2(50, 200),
         ],
         join: "miter",
-        cap: "none",
         width: 20,
     });
     drawCircle({

--- a/examples/linecap.js
+++ b/examples/linecap.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 onDraw(() => {

--- a/examples/linejoin.js
+++ b/examples/linejoin.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 onDraw(() => {

--- a/examples/loader.js
+++ b/examples/loader.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Customizing the asset loader
 
 kaplay({

--- a/examples/loader.js
+++ b/examples/loader.js
@@ -20,7 +20,7 @@ loadSprite("bean", "/sprites/bean.png").onError(() => {
 
 loadSprite("ghosty", "/sprites/ghosty.png");
 
-// load() adds a Promise under kaboom's management, which affects loadProgress()
+// load() adds a Promise under KAPLAY's management, which affects loadProgress()
 // Here we intentionally stall the loading by 1sec to see the loading screen
 load(
     new Promise((res) => {

--- a/examples/maze.js
+++ b/examples/maze.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     scale: 0.5,
     background: [0, 0, 0],

--- a/examples/mazeRaycastedLight.js
+++ b/examples/mazeRaycastedLight.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     scale: 0.5,
     background: [0, 0, 0],

--- a/examples/movement.js
+++ b/examples/movement.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Input handling and basic player movement
 
 // Start kaboom

--- a/examples/multigamepad.js
+++ b/examples/multigamepad.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 setGravity(2400);
 setBackground(0, 0, 0);

--- a/examples/out.js
+++ b/examples/out.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // detect if obj is out of screen
 
 kaplay();

--- a/examples/overlap.js
+++ b/examples/overlap.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 add([

--- a/examples/particle.js
+++ b/examples/particle.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Particle spawning
 
 kaplay();

--- a/examples/pauseMenu.js
+++ b/examples/pauseMenu.js
@@ -117,7 +117,7 @@ scene("game", () => {
 
     // display score
     const scoreLabel = game.add([
-        text(score),
+        text(score.toString()),
         anchor("center"),
         pos(width() / 2, 80),
         fixed(),
@@ -126,7 +126,7 @@ scene("game", () => {
 
     function addScore() {
         score++;
-        scoreLabel.text = score;
+        scoreLabel.text = score.toString();
         play("score");
     }
 

--- a/examples/pauseMenu.js
+++ b/examples/pauseMenu.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/physics.js
+++ b/examples/physics.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "sprites/bean.png");

--- a/examples/physicsfactory.js
+++ b/examples/physicsfactory.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 setGravity(300);

--- a/examples/platformer.js
+++ b/examples/platformer.js
@@ -267,7 +267,7 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
 
     player.onCollide("enemy", (e, col) => {
         // if it's not from the top, die
-        if (!col.isBottom()) {
+        if (!col?.isBottom()) {
             go("lose");
             play("hit");
         }
@@ -337,11 +337,11 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
     });
 
     onKeyPress("down", () => {
-        player.weight = 3;
+        player.gravityScale = 3;
     });
 
     onKeyRelease("down", () => {
-        player.weight = 1;
+        player.gravityScale = 1;
     });
 
     onGamepadButtonPress("south", jump);

--- a/examples/platformer.js
+++ b/examples/platformer.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     background: [141, 183, 255],
 });

--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -1,6 +1,8 @@
-kaplay();
+// @ts-check
 
-setBackground(0, 0, 0);
+kaplay({
+    background: [0, 0, 0],
+});
 
 add([
     text("Drag corners of the polygon"),

--- a/examples/polygonuv.js
+++ b/examples/polygonuv.js
@@ -1,6 +1,5 @@
-// Adding game objects to screen
+// @ts-check
 
-// Start a kaboom game
 kaplay();
 
 // Load a sprite asset from "sprites/bean.png", with the name "bean"

--- a/examples/pong.js
+++ b/examples/pong.js
@@ -32,13 +32,13 @@ onUpdate("paddle", (p) => {
 let score = 0;
 
 add([
-    text(score),
+    text(score.toString()),
     pos(center()),
     anchor("center"),
     z(50),
     {
         update() {
-            this.text = score;
+            this.text = score.toString();
         },
     },
 ]);

--- a/examples/pong.js
+++ b/examples/pong.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     background: [255, 255, 128],
 });

--- a/examples/postEffect.js
+++ b/examples/postEffect.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Build levels with addLevel()
 
 // Start game

--- a/examples/query.js
+++ b/examples/query.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/raycastLevelTest.js
+++ b/examples/raycastLevelTest.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 const level = addLevel([

--- a/examples/raycastObject.js
+++ b/examples/raycastObject.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 add([

--- a/examples/raycastShape.js
+++ b/examples/raycastShape.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 add([

--- a/examples/raycaster3d.js
+++ b/examples/raycaster3d.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Start kaboom
 kaplay();
 

--- a/examples/rect.js
+++ b/examples/rect.js
@@ -1,6 +1,5 @@
-// Adding game objects to screen
+// @ts-check
 
-// Start a kaboom game
 kaplay();
 
 add([

--- a/examples/rpg.js
+++ b/examples/rpg.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // simple rpg style walk and talk
 
 kaplay({

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -79,14 +79,14 @@ scene("game", () => {
     let score = 0;
 
     const scoreLabel = add([
-        text(score),
+        text(score.toString()),
         pos(24, 24),
     ]);
 
     // increment score every frame
     onUpdate(() => {
         score++;
-        scoreLabel.text = score;
+        scoreLabel.text = score.toString();
     });
 });
 

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const FLOOR_HEIGHT = 48;
 const JUMP_FORCE = 800;
 const SPEED = 480;

--- a/examples/scenes.js
+++ b/examples/scenes.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Extend our game with multiple scenes
 
 // Start game

--- a/examples/shader.js
+++ b/examples/shader.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Custom shader
 kaplay();
 

--- a/examples/shooter.js
+++ b/examples/shooter.js
@@ -1,4 +1,4 @@
-// TODO: document
+// @ts-check
 
 kaplay({
     background: [74, 48, 82],

--- a/examples/shooter.js
+++ b/examples/shooter.js
@@ -272,7 +272,7 @@ scene("battle", () => {
     });
 
     const timer = add([
-        text(0),
+        text("0"),
         pos(12, 32),
         fixed(),
         { time: 0 },

--- a/examples/size.js
+++ b/examples/size.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     // without specifying "width" and "height", kaboom will size to the container (document.body by default)
     width: 200,

--- a/examples/slice9.js
+++ b/examples/slice9.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // 9 slice sprite scaling
 
 kaplay();

--- a/examples/sprite.js
+++ b/examples/sprite.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Sprite animation
 
 // Start a kaboom game

--- a/examples/spriteatlas.js
+++ b/examples/spriteatlas.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     scale: 4,
     background: [0, 0, 0],

--- a/examples/text.js
+++ b/examples/text.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay({
     background: [212, 110, 179],
 });

--- a/examples/textInput.js
+++ b/examples/textInput.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Start kaboom
 kaplay();
 

--- a/examples/tiled.js
+++ b/examples/tiled.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/timer.js
+++ b/examples/timer.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/transformShape.js
+++ b/examples/transformShape.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 kaplay();
 
 add([

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "types": [
+      "../dist/declaration/global.d.ts"
+    ],
+    "target": "ESNext", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "ESNext", /* Specify what module code is generated. */
+    "moduleResolution": "Bundler",
+    "noEmit": true, /* Disable emitting files from a compilation. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    "strict": true,
+    "allowJs": true,
+    "moduleDetection": "force",
+    "noImplicitAny": false
+  }
+}

--- a/examples/tween.js
+++ b/examples/tween.js
@@ -1,3 +1,5 @@
+// @ts-check`
+
 // Tweeeeeening!
 
 kaplay({

--- a/examples/tween.js
+++ b/examples/tween.js
@@ -1,4 +1,4 @@
-// @ts-check`
+// @ts-check
 
 // Tweeeeeening!
 

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -180,7 +180,8 @@ export async function genDTS() {
     // generate global decls for KAPLAYCtx members
     let globalDts = "";
 
-    globalDts += "import { KAPLAYCtx } from \"./types\"\n";
+    globalDts +=
+        "import { KAPLAYCtx } from \"./types\"\nimport { kaplay as KAPLAY } from \"./kaplay\"\n";
     globalDts += "declare global {\n";
 
     for (const stmt of stmts) {
@@ -194,6 +195,9 @@ export async function genDTS() {
             globalGenerated = true;
         }
     }
+
+    globalDts += `\tconst kaplay: typeof KAPLAY\n`;
+    globalDts += `\tconst kaboom: typeof KAPLAY\n`;
 
     globalDts += "}\n";
 

--- a/src/components/draw/rect.ts
+++ b/src/components/draw/rect.ts
@@ -21,7 +21,7 @@ export interface RectComp extends Comp {
     /**
      * The radius of each corner.
      */
-    radius?: number;
+    radius?: number | [number, number, number, number];
     /**
      * @since v3000.0
      */
@@ -37,7 +37,7 @@ export interface RectCompOpt {
     /**
      * Radius of the rectangle corners.
      */
-    radius?: number;
+    radius?: number | [number, number, number, number];
     /**
      * If fill the rectangle (useful if you only want to render outline with outline() component).
      */

--- a/src/components/transform/rotate.ts
+++ b/src/components/transform/rotate.ts
@@ -22,10 +22,10 @@ export interface RotateComp extends Comp {
     rotateTo(s: number): void;
 }
 
-export function rotate(r: number): RotateComp {
+export function rotate(a?: number): RotateComp {
     return {
         id: "rotate",
-        angle: r ?? 0,
+        angle: a ?? 0,
         rotateBy(angle: number) {
             this.angle += angle;
         },

--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -179,7 +179,7 @@ export function drawDebug() {
                 str += `[time]${log.time.toFixed(2)}[/time]`;
                 str += " ";
                 str += `[${style}]${
-                    log.msg?.toString ? log.msg.toString() : log.msg
+                    typeof log?.msg === "string" ? log.msg : String(log.msg)
                 }[/${style}]`;
                 logs.push(str);
             }

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -540,8 +540,10 @@ const kaplay = <
         stepFrame: updateFrame,
         drawCalls: () => gfx.lastDrawCalls,
         clearLog: () => game.logs = [],
-        log: (msg) => {
+        log: (...msgs) => {
             const max = gopt.logMax ?? LOG_MAX;
+            const msg = msgs.concat(" ").join(" ");
+
             game.logs.unshift({
                 msg: msg,
                 time: app.time(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -4629,7 +4629,7 @@ export interface Comp {
     /**
      * Event that runs every frame.
      */
-    update?: (this: GameObj) => void;
+    update?: () => void;
     /**
      * Event that runs every frame after update.
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -623,7 +623,20 @@ export interface KAPLAYCtx<
      *
      * @group Components
      */
-    outline(width?: number, color?: Color): OutlineComp;
+    outline(
+        width?: number,
+        color?: Color,
+        opacity?: number,
+        join?: LineJoin,
+        miterLimit?: number,
+        cap?: LineCap,
+    ): OutlineComp;
+    /**
+     * Attach a particle emitter to a Game Object.
+     *
+     * @param popt The options for the particles.
+     * @param eopt The options for the emitter.
+     */
     particles(popt: ParticlesOpt, eopt: EmitterOpt): ParticlesComp;
     /**
      * Physical body that responds to gravity. Requires "area" and "pos" comp. This also makes the object "solid".
@@ -972,7 +985,7 @@ export interface KAPLAYCtx<
      * @since v3000.0
      * @group Components
      */
-    tile(opt: TileCompOpt): TileComp;
+    tile(opt?: TileCompOpt): TileComp;
     /**
      * An agent which can finds it way on a tilemap.
      *
@@ -1838,8 +1851,8 @@ export interface KAPLAYCtx<
      */
     loadShader(
         name: string | null,
-        vert?: string,
-        frag?: string,
+        vert?: string | null,
+        frag?: string | null,
     ): Asset<ShaderData>;
     /**
      * Load a shader with vertex and fragment code file url.
@@ -1856,8 +1869,8 @@ export interface KAPLAYCtx<
      */
     loadShaderURL(
         name: string | null,
-        vert?: string,
-        frag?: string,
+        vert?: string | null,
+        frag?: string | null,
     ): Asset<ShaderData>;
     /**
      * Add a new loader to wait for before starting the game.

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ import type {
     AgentCompOpt,
     AnchorComp,
     AnimateComp,
+    AnimateCompOpt,
     AreaComp,
     AreaCompOpt,
     AreaEffectorComp,
@@ -108,6 +109,7 @@ import type {
     LineJoin,
     Texture,
 } from "./gfx";
+import { kaplay } from "./kaplay";
 import type { GjkCollisionResult } from "./math";
 import type { Color, RGBAValue, RGBValue } from "./math/color";
 import type {
@@ -385,9 +387,11 @@ export interface KAPLAYCtx<
     /**
      * Rotates a Game Object (in degrees).
      *
+     * @param a The angle to rotate by. Defaults to 0.
+     *
      * @group Components
      */
-    rotate(a: number): RotateComp;
+    rotate(a?: number): RotateComp;
     /**
      * Sets the color of a Game Object (rgb 0-255).
      *
@@ -448,6 +452,9 @@ export interface KAPLAYCtx<
     /**
      * Attach and render a text to a Game Object.
      *
+     * @param txt The text to display.
+     * @param options Options for the text component. See {@link TextCompOpt}.
+     *
      * @example
      * ```js
      * // a simple score counter
@@ -475,7 +482,7 @@ export interface KAPLAYCtx<
      *
      * @group Components
      */
-    text(txt: string, options?: TextCompOpt): TextComp;
+    text(txt?: string, options?: TextCompOpt): TextComp;
     /**
      * Attach and render a polygon to a Game Object.
      *
@@ -979,7 +986,7 @@ export interface KAPLAYCtx<
      * @since v3001.0
      * @group Components
      */
-    animate(): AnimateComp;
+    animate(opt?: AnimateCompOpt): AnimateComp;
     /**
      * A fake mouse that follows the mouse position and triggers events.
      *
@@ -2168,6 +2175,8 @@ export interface KAPLAYCtx<
     /**
      * Camera shake.
      *
+     * @param intensity - The intensity of the shake. Default to 12.
+     *
      * @example
      * ```js
      * // shake intensively when bean collides with a "bomb"
@@ -2178,7 +2187,7 @@ export interface KAPLAYCtx<
      *
      * @group Info
      */
-    shake(intensity: number): void;
+    shake(intensity?: number): void;
     /**
      * Get / set camera position.
      *
@@ -2194,6 +2203,7 @@ export interface KAPLAYCtx<
      */
     camPos(pos: Vec2): Vec2;
     camPos(x: number, y: number): Vec2;
+    camPos(xy: number): Vec2;
     camPos(): Vec2;
     /**
      * Get / set camera scale.
@@ -2202,6 +2212,7 @@ export interface KAPLAYCtx<
      */
     camScale(scale: Vec2): Vec2;
     camScale(x: number, y: number): Vec2;
+    camScale(xy: number): Vec2;
     camScale(): Vec2;
     /**
      * Get / set camera rotation.
@@ -3684,79 +3695,82 @@ export type PluginList<T> = Array<T | KAPLAYPlugin<any>>;
  * @group Input
  */
 export type Key =
-    | "f1"
-    | "f2"
-    | "f3"
-    | "f4"
-    | "f5"
-    | "f6"
-    | "f7"
-    | "f8"
-    | "f9"
-    | "f10"
-    | "f11"
-    | "f12"
-    | "`"
-    | "1"
-    | "2"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "0"
-    | "-"
-    | "="
-    | "q"
-    | "w"
-    | "e"
-    | "r"
-    | "t"
-    | "y"
-    | "u"
-    | "i"
-    | "o"
-    | "p"
-    | "["
-    | "]"
-    | "\\"
-    | "a"
-    | "s"
-    | "d"
-    | "f"
-    | "g"
-    | "h"
-    | "j"
-    | "k"
-    | "l"
-    | ";"
-    | "'"
-    | "z"
-    | "x"
-    | "c"
-    | "v"
-    | "b"
-    | "n"
-    | "m"
-    | ","
-    | "."
-    | "/"
-    | "escape"
-    | "backspace"
-    | "enter"
-    | "tab"
-    | "control"
-    | "alt"
-    | "meta"
-    | "space"
-    | " "
-    | "left"
-    | "right"
-    | "up"
-    | "down"
-    | "shift";
+    | (
+        | "f1"
+        | "f2"
+        | "f3"
+        | "f4"
+        | "f5"
+        | "f6"
+        | "f7"
+        | "f8"
+        | "f9"
+        | "f10"
+        | "f11"
+        | "f12"
+        | "`"
+        | "1"
+        | "2"
+        | "3"
+        | "4"
+        | "5"
+        | "6"
+        | "7"
+        | "8"
+        | "9"
+        | "0"
+        | "-"
+        | "="
+        | "q"
+        | "w"
+        | "e"
+        | "r"
+        | "t"
+        | "y"
+        | "u"
+        | "i"
+        | "o"
+        | "p"
+        | "["
+        | "]"
+        | "\\"
+        | "a"
+        | "s"
+        | "d"
+        | "f"
+        | "g"
+        | "h"
+        | "j"
+        | "k"
+        | "l"
+        | ";"
+        | "'"
+        | "z"
+        | "x"
+        | "c"
+        | "v"
+        | "b"
+        | "n"
+        | "m"
+        | ","
+        | "."
+        | "/"
+        | "escape"
+        | "backspace"
+        | "enter"
+        | "tab"
+        | "control"
+        | "alt"
+        | "meta"
+        | "space"
+        | " "
+        | "left"
+        | "right"
+        | "up"
+        | "down"
+        | "shift"
+    )
+    | string & {};
 
 /**
  * A mouse button.
@@ -4782,11 +4796,11 @@ export interface Debug {
     /**
      * Log some text to on screen debug log.
      */
-    log(msg: string | { toString(): string }): void;
+    log(...msg: any): void;
     /**
      * Log an error message to on screen debug log.
      */
-    error(msg: string | { toString(): string }): void;
+    error(msg: any): void;
     /**
      * The recording handle if currently in recording mode.
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -4629,7 +4629,7 @@ export interface Comp {
     /**
      * Event that runs every frame.
      */
-    update?: () => void;
+    update?: (this: GameObj) => void;
     /**
      * Event that runs every frame after update.
      */


### PR DESCRIPTION
- Now `Key` also accepts a string as an acceptable value.
- Now `text()` component doesn't require to pass a string.
- Now `camScale()` and `camPos()` accept only 1 number as parameter.
- Now `shake()` can be called without args.
- Now `debug.log()` accepts multiple argument of any type, like `console.log()`.
- Now `RectCompOpt` accepts a array of numbers for `radius`.