### PR TITLE
fix: buttonDown event triggered twice for gamepads

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -672,9 +672,14 @@ export const initApp = (opt: {
         state.mouseState.down.forEach((k) =>
             state.events.trigger("mouseDown", k)
         );
-        state.buttonState.down.forEach((btn) =>
-            state.events.trigger("buttonDown", btn)
-        );
+
+        state.buttonState.down.forEach((btn) => {
+            const gamepadBindings = getButton(btn)?.gamepad;
+            if (gamepadBindings && isGamepadButtonDown(gamepadBindings)) return;
+
+            state.events.trigger("buttonDown", btn);
+        });
+
         processGamepad();
     }
 


### PR DESCRIPTION
## Description

Event `buttonDown` is triggered twice for gamepads. Fix just allows gamepad to be processed separately as intended, if the currently held down button has bindings for it.

### Fixes two issues:
- `buttonDown` event triggered twice for gamepad button in use with `onButtonDown()`
- `buttonDown` event triggered three times when holding the same bound buttons at once, e.g. `"dpad-right"` and keyboard `"right"` as defined buttons for input binding `"right"`.

## Example

Player could run at twice the speed when using just gamepad, or even three times fast when using both keyboard and gamepad at the same time. And was called Forrest as a result. 🏃‍♂️

[KAPLAYGROUND example link](https://play.kaplayjs.com/?code=eJx9VE1r20AQvetXDCKEVSPbspum4NQ9lEJ7yCGQQg%2FG4LU0loXlXbG7cghB%2F72zu7IluSa6SJp58%2BbNx%2B6eVyV%2FY%2B8B0LPh6T5XshbZHJafpzFMH2K4n61i762NkULPwYPtU%2BLW9P%2F3%2BLaRXNnw0PrCGEIetvH2yfkBK%2B78Gb1HDrRy7qZDqSLfDXgvuR3Akmd98msJPHJ1xrRZmqCJHoOglDx7qVRhkIW54lpbzol2Fj1xlnEl8pCwfegGuRggreEEDDSaX4ofC%2FPGpkmSWFNKfTPUrSOWTyhys4MFzJKhg0w8y57sJ1s6keEiHCuskBvWC418BevFzXsI1wAwglnULNbxxySruG2wKUr8W2RmN4eH%2B%2Fhs%2Bo1%2BCidbJWn0SecfLAJlmQOLYPEdloN56EF3o%2BGwuELOLmwbmdE6QqFfDDdFOgejaoTmMlKkO6lYmKIwqPq87T7QnJuu83Y%2Bvr9ta6kYRoXB16QN1f3Rtra%2BPCfrZL%2BavGtGXWWcuKKLBU754ZnSml1BSyU1qbtcShpKREuJhrBlqUlxEkPJtflDnxWqrVQHSo5jIV9ZV90Bua4VEsZPwKcttsDu7jzR7e3%2F4bQmnvobuDUFhaZWwqvKcFPn41LmbH3z7jiaicZ03Yo%2By3sE9%2F%2BBxqaTKY9WY1aoTqQ7ONbBrPkTzL5Qxck5i2uYP1znhrXVOu4gkOKJDibrF%2B7wUvxw19VP%2BSrY6S7yKObyjaZR1DJeCThdMP0IH9BEwT9bXWg5)

