### PR TITLE
fix: stay events reference is not updated on event swich

### DIFF
--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -596,7 +596,7 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
 
     for (const e of evs) {
         obj[e] = (...args: [any]) => {
-            let ev = app[e]?.(...args);
+            const ev = app[e]?.(...args);
             inputEvents.push(ev);
 
             obj.onDestroy(() => ev.cancel());
@@ -607,12 +607,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 // create a new event with the same arguments
                 const newEv = app[e]?.(...args);
 
-                // Replace the old event functions with the new ones
+                // Replace the old event handler with the new one
                 // old KEventController.cancel() => new KEventController.cancel()
                 KEventController.replace(ev, newEv);
-                // Save the reference to the new event so replace work every scene change
-                // There's always only 2 events connected, old and new
-                ev = newEv;
                 inputEvents.push(ev);
             });
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -35,7 +35,7 @@ export class KEventController {
     /** If the event is paused */
     paused: boolean = false;
     /** Cancel the event */
-    readonly cancel: () => void;
+    cancel: () => void;
 
     constructor(cancel: () => void) {
         this.cancel = cancel;
@@ -50,6 +50,16 @@ export class KEventController {
         });
         ev.paused = false;
         return ev;
+    }
+    static replace(oldEv: KEventController, newEv: KEventController) {
+        oldEv.cancel = () => newEv.cancel();
+        newEv.paused = oldEv.paused;
+        Object.defineProperty(oldEv, "paused", {
+            get: () => newEv.paused,
+            set: (p: boolean) => newEv.paused = p,
+        });
+
+        return oldEv;
     }
 }
 


### PR DESCRIPTION


## Description

My previous PR doing this was a problem. The KEventController wasn't updated. This one adds it.