### PR TITLE
fix: restitution was acting like friction when 0 < restitution < friction

### DIFF
--- a/src/components/physics/body.ts
+++ b/src/components/physics/body.ts
@@ -302,15 +302,8 @@ export function body(opt: BodyCompOpt = {}): BodyComp {
 
                     // Clear the velocity in the direction of the normal, as we've hit something
                     if (this.vel.dot(col.normal) < 0) {
-                        if (restitution == 0) {
-                            this.vel = rejection;
-                        }
-                        else {
-                            // Modulate the velocity tangential to the normal
-                            this.vel = this.vel.reflect(col.normal).scale(
-                                restitution,
-                            );
-                        }
+                        // Modulate the velocity tangential to the normal
+                        this.vel = rejection.sub(projection.scale(restitution));
                     }
 
                     if (friction != 0) {


### PR DESCRIPTION
turn restitution to 0.5 in the `restitution` example, the bean will eventually stop moving, but friction is 0 so that is wrong

this fixes that