### PR TITLE
fix: rewrite compileStyledText parser

### DIFF
--- a/examples/audio.js
+++ b/examples/audio.js
@@ -33,7 +33,7 @@ Time: ${music.time().toFixed(2)}
 Volume: ${music.volume.toFixed(2)}
 Speed: ${music.speed.toFixed(2)}
 
-[space] play/pause
+\\[space] play/pause
 [up/down] volume
 [left/right] speed
 	`.trim();

--- a/examples/weirdTextTags.js
+++ b/examples/weirdTextTags.js
@@ -1,0 +1,24 @@
+kaplay();
+
+const txtEl = add([
+    text("", {
+        styles: {
+            pink: {
+                color: MAGENTA,
+            },
+        }
+    }),
+    pos(100, 100),
+]);
+const base = "[pink]hello\n[/pink]ohhi\n";
+const txt = "foo\n\\[1]\nbar";
+var i = -1;
+const c = loop(0.5, () => {
+    if (txt[i] === "\\") i++;
+    i++;
+    txtEl.text = base + txt.slice(0, i) + "[pink]bye[/pink]";
+    if (i > txt.length) {
+        console.log(txtEl.text);
+        c.cancel();
+    }
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,7 +96,6 @@ export const COMP_EVENTS = new Set([
     "inspect",
     "drawInspect",
 ]);
-export const MULTI_WORD_RE = /^\w+$/;
 export const DEF_OFFSCREEN_DIS = 200;
 // maximum y velocity with body()
 export const DEF_JUMP_FORCE = 640;


### PR DESCRIPTION
now throws errors if the tags aren't proper or otherwise escaped

closes #448 