### PR TITLE
fix: brackets causing issues in debug.log + enhance logging of single object

### DIFF
--- a/examples/prettyDebug.js
+++ b/examples/prettyDebug.js
@@ -6,6 +6,7 @@ const pretty = {
     even: {
         nested: "objects",
     },
+    arrays: ["show", "like", "you", "would", "write", "them"],
     "own toString is used": vec2(10, 10)
 }
 

--- a/examples/prettyDebug.js
+++ b/examples/prettyDebug.js
@@ -1,0 +1,17 @@
+kaplay();
+
+const pretty = {
+    i: "am pretty",
+    all: "own properties are shown",
+    even: {
+        nested: "objects",
+    },
+    "own toString is used": vec2(10, 10)
+}
+
+debug.log("Text in [brackets] doesn't cause issues");
+
+debug.log(pretty);
+
+debug.error("This is an error message");
+

--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -1,7 +1,7 @@
 import { DBG_FONT, LOG_TIME } from "../../constants";
 import { app, debug, game, globalOpt } from "../../kaplay";
 import { rgb } from "../../math/color";
-import { Vec2, vec2, wave } from "../../math/math";
+import { vec2, wave } from "../../math/math";
 import { formatText } from "../formatText";
 import {
     contentToView,
@@ -178,9 +178,7 @@ export function drawDebug() {
                 const style = log.msg instanceof Error ? "error" : "info";
                 str += `[time]${log.time.toFixed(2)}[/time]`;
                 str += " ";
-                str += `[${style}]${
-                    typeof log?.msg === "string" ? log.msg : String(log.msg)
-                }[/${style}]`;
+                str += `[${style}]${prettyDebug(log.msg)}[/${style}]`;
                 logs.push(str);
             }
 
@@ -219,4 +217,24 @@ export function drawDebug() {
             popTransform();
         });
     }
+}
+
+function prettyDebug(object: any | undefined, inside: boolean = false): string {
+    if (inside && typeof object === "string") {
+        object = JSON.stringify(object);
+    }
+    if (typeof object === "object"
+        && object.toString === Object.prototype.toString) {
+            var outStr = "", tmp;
+            if (object.constructor !== Object) outStr += object.constructor.name + " ";
+            outStr += [
+                "{",
+                (tmp = Object.getOwnPropertyNames(object)
+                    .map(p => `${/^\w+$/.test(p) ? p : JSON.stringify(p)}: ${prettyDebug(object[p], true)}`)
+                    .join(", ")) ? ` ${tmp} ` : "",
+                "}"
+            ].join("");
+            object = outStr;
+    }
+    return String(object).replaceAll(/(?<!\\)\[/g, "\\[");
 }

--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -220,12 +220,20 @@ export function drawDebug() {
 }
 
 function prettyDebug(object: any | undefined, inside: boolean = false): string {
+    var outStr = "", tmp;
     if (inside && typeof object === "string") {
         object = JSON.stringify(object);
     }
+    if (Array.isArray(object)) {
+        outStr = [
+            "[",
+            object.map(e => prettyDebug(e, true)).join(", "),
+            "]"
+        ].join("");
+        object = outStr;
+    }
     if (typeof object === "object"
         && object.toString === Object.prototype.toString) {
-            var outStr = "", tmp;
             if (object.constructor !== Object) outStr += object.constructor.name + " ";
             outStr += [
                 "{",

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -546,7 +546,7 @@ const kaplay = <
         clearLog: () => game.logs = [],
         log: (...msgs) => {
             const max = gopt.logMax ?? LOG_MAX;
-            const msg = msgs.concat(" ").join(" ");
+            const msg = msgs.length > 1 ? msgs.concat(" ").join(" ") : msgs[0];
 
             game.logs.unshift({
                 msg: msg,


### PR DESCRIPTION
the new parser I added in #472 is so strict that if you do `debug.log("[boom]")` it crashes the game.

this fixes that, and also causes it to display a dump of the object when you log an object by itself instead of just doing `[object Object]`.