### PR TITLE
docs: Added many examples for on events

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ import type {
     BuoyancyEffectorComp,
     BuoyancyEffectorCompOpt,
     CircleComp,
+    CircleCompOpt,
     ColorComp,
     ConstantForceComp,
     ConstantForceCompOpt,
@@ -369,7 +370,18 @@ export interface KAPLAYCtx<
      *
      * @param a The angle to rotate by. Defaults to 0.
      *
-     * @group Components
+     * @example
+     * ```js
+     * let bean = add([
+     *     sprite("bean"),
+     *     rotate(),
+     * ])
+     *
+     * // bean will be upside down!
+     * bean.angle = 180
+     * ```
+
+    * @group Components
      */
     rotate(a?: number): RotateComp;
     /**
@@ -393,6 +405,20 @@ export interface KAPLAYCtx<
     color(): ColorComp;
     /**
      * Sets the opacity of a Game Object (0.0 - 1.0).
+     *
+     * @example
+     * ```js
+     * const bean = add([
+     *     sprite("bean"),
+     *     opacity(0.5) // Make bean 50% transparent
+     * ])
+     *
+     * // Make bean invisible
+     * bean.opacity = 0
+     *
+     * // Make bean fully visible
+     * bean.opacity = 1
+     * ```
      *
      * @group Components
      */
@@ -511,7 +537,7 @@ export interface KAPLAYCtx<
      *
      * @group Components
      */
-    circle(radius: number): CircleComp;
+    circle(radius: number, opt?: CircleCompOpt): CircleComp;
     /**
      * Attach and render an ellipse to a Game Object.
      *
@@ -589,11 +615,49 @@ export interface KAPLAYCtx<
     /**
      * Determines the draw order for objects on the same layer. Object will be drawn on top if z value is bigger.
      *
+     * @example
+     * ```js
+     * const bean = add([
+     *    sprite("bean"),
+     *    pos(100, 100),
+     *    z(10), // Bean has a z value of 10
+     * ])
+     *
+     * // Mark has a z value of 20, so he will always be drawn on top of bean
+     * const mark = add([
+     *   sprite("mark"),
+     *   pos(100, 100),
+     *   z(20),
+     * ])
+     *
+     * bean.z = 30 // Bean now has a higher z value, so it will be drawn on top of mark
+     * ```
+     *
      * @group Components
      */
     z(z: number): ZComp;
     /**
      * Determines the layer for objects. Object will be drawn on top if the layer index is higher.
+     *
+     * @example
+     * ```js
+     * // Define layers
+     * layers(["background", "game", "foreground"], "game")
+     *
+     * const bean = add([
+     *     sprite("bean"),
+     *     pos(100, 100),
+     *     layer("background"),
+     * ])
+     *
+     * // Mark is in a higher layer, so he will be drawn on top of bean
+     * const mark = add([
+     *     sprite("mark"),
+     *     pos(100, 100),
+     *     layer("game"),
+     * ])
+     *
+     * bean.layer("foreground") // Bean is now in the foreground layer and will be drawn on top of mark
      *
      * @group Components
      */
@@ -616,11 +680,11 @@ export interface KAPLAYCtx<
      *
      * @param popt The options for the particles.
      * @param eopt The options for the emitter.
-     * 
+     *
      * @example
      * ```js
      * // beansplosion
-     * 
+     *
      * // create the emitter
      * const emitter = add([
      *     pos(center()),
@@ -681,11 +745,11 @@ export interface KAPLAYCtx<
     /**
      * Applies a force on a colliding object in order to make it move along the collision tangent vector.
      * Good for conveyor belts.
-     * 
+     *
      * @example
      * ```js
      * loadSprite("belt", "/sprites/jumpy.png")
-     * 
+     *
      * // conveyor belt
      * add([
      *     pos(center()),
@@ -790,11 +854,35 @@ export interface KAPLAYCtx<
     /**
      * Follow another game obj's position.
      *
+     * @example
+     * ```js
+     * const bean = add(...)
+     *
+     * add([
+     *   sprite("bag"),
+     *   pos(),
+     *   follow(bean) // Follow bean's position
+     * ])
+     * ```
+     *
+     * @example
+     * ```js
+     * const target = add(...)
+     *
+     * const mark = add([
+     *   sprite("mark"),
+     *   pos(),
+     *   follow(target, vec2(32, 32)) // Follow target's position with an offset
+     * ])
+     *
+     * mark.follow.offset = vec2(64, 64) // Change the offset
+     * ```
+     *
      * @group Components
      */
     follow(obj: GameObj | null, offset?: Vec2): FollowComp;
     /**
-     * Custom shader.
+     * Custom shader to manipulate sprite.
      *
      * @group Components
      */
@@ -1012,19 +1100,19 @@ export interface KAPLAYCtx<
     mask(maskType?: Mask): MaskComp;
     /**
      * Specifies the FrameBuffer the object should be drawn on.
-     * 
+     *
      * @example
      * ```js
      * // Draw on another canvas
      * let canvas = makeCanvas(width(), height())
-     * 
+     *
      * let beanOnCanvas = add([
      *     sprite("bean"),
      *     drawon(canvas.fb),
      * ])
      * ```
-     * 
-     * @param canvas 
+     *
+     * @param canvas
      */
     drawon(canvas: FrameBuffer): Comp;
     /**
@@ -1043,6 +1131,22 @@ export interface KAPLAYCtx<
     agent(opt?: AgentCompOpt): AgentComp;
     /**
      * A component to animate properties.
+     *
+     * @example
+     * ```js
+     * let movingBean = add([
+     *       sprite("bean"),
+     *       pos(50, 150),
+     *       anchor("center"),
+     *       animate(),
+     * ]);
+     *
+     * // Moving right to left using ping-pong
+     * movingBean.animate("pos", [vec2(50, 150), vec2(150, 150)], {
+     *     duration: 2,
+     *     direction: "ping-pong",
+     * });
+     * ```
      *
      * @since v3001.0
      * @group Components
@@ -1283,7 +1387,7 @@ export interface KAPLAYCtx<
      * ```
      * @group Events
      */
-    onLoad(action: () => void): void;
+    onLoad(action: () => void): KEventController | undefined;
     /**
      * Register an event that runs every frame when assets are initially loading. Can be used to draw a custom loading screen.
      * 
@@ -1313,7 +1417,7 @@ export interface KAPLAYCtx<
      * @since v3000.0
      * @group Events
      */
-    onLoading(action: (progress: number) => void): void;
+    onLoading(action: (progress: number) => void): KEventController;
     /**
      * Register a custom error handler. Can be used to draw a custom error screen.
      * 
@@ -1349,7 +1453,7 @@ export interface KAPLAYCtx<
      * @since v3000.0
      * @group Events
      */
-    onError(action: (err: Error) => void): void;
+    onError(action: (err: Error) => void): KEventController;
     /**
      * Register an event that runs when the canvas resizes.
      * 
@@ -1373,7 +1477,7 @@ export interface KAPLAYCtx<
      * @since v3000.0
      * @group Events
      */
-    onResize(action: () => void): void;
+    onResize(action: () => void): KEventController;
     /**
      * Cleanup function to run when quit() is called.
      * 
@@ -1405,7 +1509,7 @@ export interface KAPLAYCtx<
      * @since v3000.0
      * @group Input
      */
-    onGamepadConnect(action: (gamepad: KGamepad) => void): void;
+    onGamepadConnect(action: (gamepad: KGamepad) => void): KEventController;
     /**
      * Register an event that runs when a gamepad is disconnected.
      * 
@@ -1420,7 +1524,7 @@ export interface KAPLAYCtx<
      * @since v3000.0
      * @group Input
      */
-    onGamepadDisconnect(action: (gamepad: KGamepad) => void): void;
+    onGamepadDisconnect(action: (gamepad: KGamepad) => void): KEventController;
     /**
      * Register an event that runs once when 2 game objs with certain tags collides (required to have area() component).
      *
@@ -1512,6 +1616,14 @@ export interface KAPLAYCtx<
     onHover(tag: Tag, action: (a: GameObj) => void): KEventController;
     /**
      * Register an event that runs every frame when game objs with certain tags are hovered (required to have area() component).
+     *
+     * @example
+     * ```js
+     * // Rotate bean 90 degrees per second when hovered
+     * onHoverUpdate("bean", (bean) => {
+     *   bean.angle += dt() * 90
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Events
@@ -1826,28 +1938,13 @@ export interface KAPLAYCtx<
     onTouchEnd(action: (pos: Vec2, t: Touch) => void): KEventController;
     /**
      * Register an event that runs when mouse wheel scrolled.
-     * 
+     *
      * @example
      * ```js
-     * // change item selected
-     * let hotbar = [null, null, null, "apple", null, "diamond sword", null, null, null]
-     * let selectedItemIndex = 0
-     * 
-     * // when scrollwheel is moved
-     * onScroll((d) => {
-     *     // if scrollwheel was moved up (negative y is up)
-     *     if (d.y < 0) {
-     *         selectedItemIndex++
-     *     } else if (d.y > 0) {
-     *         selectedItemIndex--
-     *     } else {
-     *         // onScroll accounts for horizontal mwheel scrolling
-     *         debug.log("x-direction scroll")
-     *         return
-     *     }
-     *     // wrap index from 0 to 8
-     *     selectedItemIndex = ((selectedItemIndex % 9) + 9) % 9
-     *     debug.log(`Item: ${hotbar[selectedItemIndex]} at index ${selectedItemIndex}`)
+     * // Zoom camera on scroll
+     * onScroll((delta) => {
+     *     const zoom = delta.y / 500
+     *     camScale(camScale().add(zoom))
      * })
      * ```
      *
@@ -2151,14 +2248,6 @@ export interface KAPLAYCtx<
     onButtonDown(action: (btn: TButton) => void): KEventController;
     /**
      * Register an event that runs when current scene ends.
-     * 
-     * @example
-     * ```js
-     * // run before leaving the scene
-     * onSceneLeave((newScene) => {
-     *     debug.log("we are going to ${newScene}")
-     * })
-     * ```
      *
      * @since v3000.0
      * @group Events
@@ -2325,7 +2414,10 @@ export interface KAPLAYCtx<
      *
      * @group Assets
      */
-    loadSound(name: string | null, src: string | ArrayBuffer): Asset<SoundData>;
+    loadSound(
+        name: string | null,
+        src: string | ArrayBuffer | AudioBuffer,
+    ): Asset<SoundData>;
     /**
      * Like loadSound(), but the audio is streamed and won't block loading. Use this for big audio files like background music.
      *
@@ -2712,6 +2804,34 @@ export interface KAPLAYCtx<
      */
     setButton(button: string, def: ButtonBinding): void;
     /**
+     * Press a button virtually.
+     *
+     * @since v3001.0
+     * @group Input
+     *
+     * @example
+     * ```js
+     * // press "jump" button
+     * pressButton("jump"); // triggers onButtonPress, starts onButtonDown
+     * releaseButton("jump"); // triggers onButtonRelease, stops onButtonDown
+     * ```
+     */
+    pressButton(button: TButton): void;
+    /**
+     * Release a button virtually.
+     *
+     * @since v3001.0
+     * @group Input
+     *
+     * @example
+     * ```js
+     * // press "jump" button
+     * pressButton("jump"); // triggers onButtonPress, starts onButtonDown
+     * releaseButton("jump"); // triggers onButtonRelease, stops onButtonDown
+     * ```
+     */
+    releaseButton(button: TButton): void;
+    /**
      * Get stick axis values from a gamepad.
      *
      * @since v3001.0
@@ -2782,6 +2902,14 @@ export interface KAPLAYCtx<
     camRot(angle?: number): number;
     /**
      * Flash the camera.
+     *
+     * @example
+     * ```js
+     * onClick(() => {
+     *     // flashed
+     *     camFlash(WHITE, 0.5)
+     * })
+     * ```
      *
      * @group Info
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ import type {
     BuoyancyEffectorComp,
     BuoyancyEffectorCompOpt,
     CircleComp,
-    CircleCompOpt,
     ColorComp,
     ConstantForceComp,
     ConstantForceCompOpt,
@@ -370,18 +369,7 @@ export interface KAPLAYCtx<
      *
      * @param a The angle to rotate by. Defaults to 0.
      *
-     * @example
-     * ```js
-     * let bean = add([
-     *     sprite("bean"),
-     *     rotate(),
-     * ])
-     *
-     * // bean will be upside down!
-     * bean.angle = 180
-     * ```
-
-    * @group Components
+     * @group Components
      */
     rotate(a?: number): RotateComp;
     /**
@@ -405,20 +393,6 @@ export interface KAPLAYCtx<
     color(): ColorComp;
     /**
      * Sets the opacity of a Game Object (0.0 - 1.0).
-     *
-     * @example
-     * ```js
-     * const bean = add([
-     *     sprite("bean"),
-     *     opacity(0.5) // Make bean 50% transparent
-     * ])
-     *
-     * // Make bean invisible
-     * bean.opacity = 0
-     *
-     * // Make bean fully visible
-     * bean.opacity = 1
-     * ```
      *
      * @group Components
      */
@@ -537,7 +511,7 @@ export interface KAPLAYCtx<
      *
      * @group Components
      */
-    circle(radius: number, opt?: CircleCompOpt): CircleComp;
+    circle(radius: number): CircleComp;
     /**
      * Attach and render an ellipse to a Game Object.
      *
@@ -615,49 +589,11 @@ export interface KAPLAYCtx<
     /**
      * Determines the draw order for objects on the same layer. Object will be drawn on top if z value is bigger.
      *
-     * @example
-     * ```js
-     * const bean = add([
-     *    sprite("bean"),
-     *    pos(100, 100),
-     *    z(10), // Bean has a z value of 10
-     * ])
-     *
-     * // Mark has a z value of 20, so he will always be drawn on top of bean
-     * const mark = add([
-     *   sprite("mark"),
-     *   pos(100, 100),
-     *   z(20),
-     * ])
-     *
-     * bean.z = 30 // Bean now has a higher z value, so it will be drawn on top of mark
-     * ```
-     *
      * @group Components
      */
     z(z: number): ZComp;
     /**
      * Determines the layer for objects. Object will be drawn on top if the layer index is higher.
-     *
-     * @example
-     * ```js
-     * // Define layers
-     * layers(["background", "game", "foreground"], "game")
-     *
-     * const bean = add([
-     *     sprite("bean"),
-     *     pos(100, 100),
-     *     layer("background"),
-     * ])
-     *
-     * // Mark is in a higher layer, so he will be drawn on top of bean
-     * const mark = add([
-     *     sprite("mark"),
-     *     pos(100, 100),
-     *     layer("game"),
-     * ])
-     *
-     * bean.layer("foreground") // Bean is now in the foreground layer and will be drawn on top of mark
      *
      * @group Components
      */
@@ -680,11 +616,11 @@ export interface KAPLAYCtx<
      *
      * @param popt The options for the particles.
      * @param eopt The options for the emitter.
-     *
+     * 
      * @example
      * ```js
      * // beansplosion
-     *
+     * 
      * // create the emitter
      * const emitter = add([
      *     pos(center()),
@@ -745,11 +681,11 @@ export interface KAPLAYCtx<
     /**
      * Applies a force on a colliding object in order to make it move along the collision tangent vector.
      * Good for conveyor belts.
-     *
+     * 
      * @example
      * ```js
      * loadSprite("belt", "/sprites/jumpy.png")
-     *
+     * 
      * // conveyor belt
      * add([
      *     pos(center()),
@@ -854,35 +790,11 @@ export interface KAPLAYCtx<
     /**
      * Follow another game obj's position.
      *
-     * @example
-     * ```js
-     * const bean = add(...)
-     *
-     * add([
-     *   sprite("bag"),
-     *   pos(),
-     *   follow(bean) // Follow bean's position
-     * ])
-     * ```
-     *
-     * @example
-     * ```js
-     * const target = add(...)
-     *
-     * const mark = add([
-     *   sprite("mark"),
-     *   pos(),
-     *   follow(target, vec2(32, 32)) // Follow target's position with an offset
-     * ])
-     *
-     * mark.follow.offset = vec2(64, 64) // Change the offset
-     * ```
-     *
      * @group Components
      */
     follow(obj: GameObj | null, offset?: Vec2): FollowComp;
     /**
-     * Custom shader to manipulate sprite.
+     * Custom shader.
      *
      * @group Components
      */
@@ -1100,19 +1012,19 @@ export interface KAPLAYCtx<
     mask(maskType?: Mask): MaskComp;
     /**
      * Specifies the FrameBuffer the object should be drawn on.
-     *
+     * 
      * @example
      * ```js
      * // Draw on another canvas
      * let canvas = makeCanvas(width(), height())
-     *
+     * 
      * let beanOnCanvas = add([
      *     sprite("bean"),
      *     drawon(canvas.fb),
      * ])
      * ```
-     *
-     * @param canvas
+     * 
+     * @param canvas 
      */
     drawon(canvas: FrameBuffer): Comp;
     /**
@@ -1131,22 +1043,6 @@ export interface KAPLAYCtx<
     agent(opt?: AgentCompOpt): AgentComp;
     /**
      * A component to animate properties.
-     *
-     * @example
-     * ```js
-     * let movingBean = add([
-     *       sprite("bean"),
-     *       pos(50, 150),
-     *       anchor("center"),
-     *       animate(),
-     * ]);
-     *
-     * // Moving right to left using ping-pong
-     * movingBean.animate("pos", [vec2(50, 150), vec2(150, 150)], {
-     *     duration: 2,
-     *     direction: "ping-pong",
-     * });
-     * ```
      *
      * @since v3001.0
      * @group Components
@@ -1290,18 +1186,82 @@ export interface KAPLAYCtx<
      */
     onDraw(action: () => void): KEventController;
     /**
+     * Register an event that runs when an object with the provided tag is added.
+     * 
+     * @example
+     * ```js
+     * // This will run when the object is added.
+     * onAdd("addTag", () => {
+     *     debug.log("ohhi")
+     * })
+     * 
+     * add([
+     *     pos(),
+     *     "addTag"
+     * ])
+     * ```
+     * 
      * @group Events
      */
     onAdd(tag: Tag, action: (obj: GameObj) => void): KEventController;
     /**
+     * Register an event that runs when an object is added
+     * 
+     * @example
+     * ```js
+     * // This will run when the object is added.
+     * onAdd(() => {
+     *     debug.log("ohhi")
+     * })
+     * 
+     * add([
+     *     pos(),
+     * ])
+     * ```
+     * 
      * @group Events
      */
     onAdd(action: (obj: GameObj) => void): KEventController;
     /**
+     * Register an event that runs when an object with the provided tag is destroyed.
+     * 
+     * @example
+     * ```js
+     * // This will run when the object is destroyed.
+     * onDestroy("destroyTag", () => {
+     *     debug.log("ohbye")
+     * })
+     * 
+     * let objectToDestroy = add([
+     *     pos(),
+     *     "destroyTag"
+     * ])
+     * 
+     * // Destroy the object
+     * destroy(objectToDestroy)
+     * ```
+     * 
      * @group Events
      */
     onDestroy(tag: Tag, action: (obj: GameObj) => void): KEventController;
     /**
+     * Register an event that runs when an object is destroyed.
+     * 
+     * @example
+     * ```js
+     * // This will run when the object is destroyed.
+     * onDestroy(() => {
+     *     debug.log("ohbye")
+     * })
+     * 
+     * let objectToDestroy = add([
+     *     pos(),
+     * ])
+     * 
+     * // Destroy the object
+     * destroy(objectToDestroy)
+     * ```
+     * 
      * @group Events
      */
     onDestroy(action: (obj: GameObj) => void): KEventController;
@@ -1323,30 +1283,109 @@ export interface KAPLAYCtx<
      * ```
      * @group Events
      */
-    onLoad(action: () => void): KEventController | undefined;
+    onLoad(action: () => void): void;
     /**
      * Register an event that runs every frame when assets are initially loading. Can be used to draw a custom loading screen.
+     * 
+     * @example
+     * ```
+     * // progress bar
+     * onLoading((progress) => {
+     *     // Background of the bar
+     *     drawRect({
+     *         width: 240,
+     *         height: 40,
+     *         pos: center().add(-120,0),
+     *         color: BLACK,
+     *         anchor: `left,
+     *     })
+     *     // Progress of the bar
+     *     drawRect({
+     *         width: map(progress, 0, 1, 0, 220),
+     *         height: 32,
+     *         pos: center().add(-116, 0),
+     *         color: BLUE,
+     *         anchor: `left
+     *     })
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Events
      */
-    onLoading(action: (progress: number) => void): KEventController;
+    onLoading(action: (progress: number) => void): void;
     /**
      * Register a custom error handler. Can be used to draw a custom error screen.
+     * 
+     * @example
+     * ```js
+     * // Create custom error handler
+     * onError((err) => {
+     *     drawRect({
+     *         width: width(),
+     *         height: height(),
+     *         pos: center(),
+     *         color: RED,
+     *         anchor: `center,
+     *     })
+     * 
+     *     drawText({
+     *         text: err.message,
+     *         size: 48,
+     *         width: width()/2,
+     *         anchor: `center`,
+     *         align: `center`,
+     *         pos: center(),
+     *         color: BLACK
+     *     })
+     * })
+     * 
+     * // cause common error
+     * let pos = add([
+     *     pos()
+     * ])
+     * ```
      *
      * @since v3000.0
      * @group Events
      */
-    onError(action: (err: Error) => void): KEventController;
+    onError(action: (err: Error) => void): void;
     /**
      * Register an event that runs when the canvas resizes.
+     * 
+     * @example
+     * ```js
+     * // create a rectangle with screen size
+     * let rectangle = add([
+     *     rect(width(), height()),
+     *     color(GREEN),
+     * ])
+     * 
+     * // resize the rectangle to screen size
+     * onResize(() => {
+     *     debug.log(`Old Size: ${rectangle.width}x${rectangle.height}`)
+     *     rectangle.width = width()
+     *     rectangle.height = height()
+     *     debug.log(`New Size: ${rectangle.width}x${rectangle.height}`)
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Events
      */
-    onResize(action: () => void): KEventController;
+    onResize(action: () => void): void;
     /**
      * Cleanup function to run when quit() is called.
+     * 
+     * @example
+     * ```js
+     * // useful externally from KAPLAY
+     * onCleanup(() => {
+     *     console.log(`ohbye :(`)
+     * })
+     * 
+     * quit()
+     * ```
      *
      * @since v3000.0
      * @group Events
@@ -1354,18 +1393,34 @@ export interface KAPLAYCtx<
     onCleanup(action: () => void): void;
     /**
      * Register an event that runs when a gamepad is connected.
+     * 
+     * @example
+     * ```js
+     * // watch for a controller connecting
+     * onGamepadConnect((gp) => {
+     *     debug.log(`ohhi player ${gp.index + 1}`)
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Input
      */
-    onGamepadConnect(action: (gamepad: KGamepad) => void): KEventController;
+    onGamepadConnect(action: (gamepad: KGamepad) => void): void;
     /**
      * Register an event that runs when a gamepad is disconnected.
+     * 
+     * @example
+     * ```js
+     * // watch for a controller disconnecting
+     * onGamepadDisconnect((gp) => {
+     *     debug.log(`ohbye player ${gp.index + 1}`)
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Input
      */
-    onGamepadDisconnect(action: (gamepad: KGamepad) => void): KEventController;
+    onGamepadDisconnect(action: (gamepad: KGamepad) => void): void;
     /**
      * Register an event that runs once when 2 game objs with certain tags collides (required to have area() component).
      *
@@ -1458,14 +1513,6 @@ export interface KAPLAYCtx<
     /**
      * Register an event that runs every frame when game objs with certain tags are hovered (required to have area() component).
      *
-     * @example
-     * ```js
-     * // Rotate bean 90 degrees per second when hovered
-     * onHoverUpdate("bean", (bean) => {
-     *   bean.angle += dt() * 90
-     * })
-     * ```
-     *
      * @since v3000.0
      * @group Events
      */
@@ -1555,11 +1602,33 @@ export interface KAPLAYCtx<
     onKeyPressRepeat(action: (k: Key) => void): KEventController;
     /**
      * Register an event that runs when user release certain keys.
+     * 
+     * @example
+     * ```js
+     * // release `a` or `b` keys
+     * onKeyRelease([`a`, `b`], (k) => {
+     *     debug.log(`Released the ${k} key...`)
+     * })
+     * ```
      *
      * @since v2000.1
      * @group Input
      */
     onKeyRelease(k: Key | Key[], action: (k: Key) => void): KEventController;
+    /**
+     * Register an event that runs when user releases a key.
+     * 
+     * @example
+     * ```js
+     * // release a key
+     * onKeyRelease((k) => {
+     *     debug.log(`Released the ${k} key...`)
+     * })
+     * ```
+     *
+     * @since v2000.1
+     * @group Input
+     */
     onKeyRelease(action: (k: Key) => void): KEventController;
     /**
      * Register an event that runs when user inputs text.
@@ -1578,6 +1647,16 @@ export interface KAPLAYCtx<
     onCharInput(action: (ch: string) => void): KEventController;
     /**
      * Register an event that runs every frame when certain mouse buttons are being held down.
+     * 
+     * @example
+     * ```js
+     * // count time with left mouse button down
+     * let mouseTime = 0
+     * onMouseDown("left", () => {
+     *     mouseTime += dt()
+     *     debug.log(`Time with mouse down: ${mouseTime})
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Input
@@ -1586,31 +1665,139 @@ export interface KAPLAYCtx<
         button: MouseButton | MouseButton[],
         action: (m: MouseButton) => void,
     ): KEventController;
+    /**
+     * Register an event that runs every frame when any mouse button is being held down.
+     * 
+     * @example
+     * ```js
+     * // count time with any mouse button down
+     * let mouseTime = 0
+     * onMouseDown((m) => {
+     *     mouseTime += dt()
+     *     debug.log(`Time with mouse down: ${mouseTime})
+     *     debug.log(`Mouse button down: ${m})
+     * })
+     * ```
+     *
+     * @since v3001.0
+     * @group Input
+     */
     onMouseDown(action: (m: MouseButton) => void): KEventController;
     /**
      * Register an event that runs when user clicks mouse.
+     * 
+     * @example
+     * ```js
+     * // gives cookies on left press, remove on right press
+     * let cookies = 0
+     * onMousePress([`left`, `right`], (m) => {
+     *     if (m == `left`)
+     *         cookies++
+     *     else
+     *         cookies--
+     *     debug.log(`Cookies: ${cookies}`)
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Input
      */
     onMousePress(action: (m: MouseButton) => void): KEventController;
+    /**
+     * Register an event that runs when user clicks mouse.
+     * 
+     * @example
+     * ```js
+     * // gives cookies on any mouse press
+     * let cookies = 0
+     * onMousePress((m) => {
+     *     cookies++
+     *     debug.log(`Cookies: ${cookies}`)
+     * })
+     * ```
+     *
+     * @since v3001.0
+     * @group Input
+     */ 
     onMousePress(
         button: MouseButton | MouseButton[],
         action: (m: MouseButton) => void,
     ): KEventController;
     /**
      * Register an event that runs when user releases mouse.
+     * 
+     * @example
+     * ```js
+     * // spawn bean where right mouse is released
+     * onMouseRelease("right", (m) => {
+     *     debug.log(`${m} released, spawning bean...`)
+     *     add([
+     *         pos(mousePos()),
+     *         sprite("bean"),
+     *         anchor("center"),
+     *     ])
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Input
      */
     onMouseRelease(action: (m: MouseButton) => void): KEventController;
+    /**
+     * Register an event that runs when user releases mouse.
+     * 
+     * @example
+     * ```js
+     * // spawn bean where right mouse is released
+     * onMouseRelease((m) => {
+     *     if (m == "right") {
+     *         debug.log(`${m} released, spawning bean...`)
+     *         add([
+     *             pos(mousePos()),
+     *             sprite("bean"),
+     *             anchor("center"),
+     *         ])
+     *     })
+     * }
+     * ```
+     *
+     * @since v3001.0
+     * @group Input
+     */
     onMouseRelease(
         button: MouseButton | MouseButton[],
         action: (m: MouseButton) => void,
     ): KEventController;
     /**
      * Register an event that runs whenever user move the mouse.
+     * 
+     * @example
+     * ```js
+     * // bean with mouse `trail`
+     * let bean = add([
+     *     pos(mousePos()),
+     *     anchor("center"),
+     *     sprite("bean")
+     * ])
+     * 
+     * let bd = vec2(0)
+     * 
+     * // runs when the mouse has moved
+     * onMouseMove((p, d) => {
+     *     bean.pos = p // set bean position to mouse position
+     *     bd = bean.pos.sub(d.x * 10, d.y * 10) // d is the change in mouse position
+     * })
+     * 
+     * // draw trail to see where mouse moved
+     * onDraw(() => {
+     *     drawLine({
+     *         p1: bean.pos,
+     *         p2: bd,
+     *         width: 4,
+     *         color: rgb(0,0,0)
+     *     })
+     * })
+     * ```
      *
      * @since v2000.1
      * @group Input
@@ -1639,13 +1826,28 @@ export interface KAPLAYCtx<
     onTouchEnd(action: (pos: Vec2, t: Touch) => void): KEventController;
     /**
      * Register an event that runs when mouse wheel scrolled.
-     *
+     * 
      * @example
      * ```js
-     * // Zoom camera on scroll
-     * onScroll((delta) => {
-     *     const zoom = delta.y / 500
-     *     camScale(camScale().add(zoom))
+     * // change item selected
+     * let hotbar = [null, null, null, "apple", null, "diamond sword", null, null, null]
+     * let selectedItemIndex = 0
+     * 
+     * // when scrollwheel is moved
+     * onScroll((d) => {
+     *     // if scrollwheel was moved up (negative y is up)
+     *     if (d.y < 0) {
+     *         selectedItemIndex++
+     *     } else if (d.y > 0) {
+     *         selectedItemIndex--
+     *     } else {
+     *         // onScroll accounts for horizontal mwheel scrolling
+     *         debug.log("x-direction scroll")
+     *         return
+     *     }
+     *     // wrap index from 0 to 8
+     *     selectedItemIndex = ((selectedItemIndex % 9) + 9) % 9
+     *     debug.log(`Item: ${hotbar[selectedItemIndex]} at index ${selectedItemIndex}`)
      * })
      * ```
      *
@@ -1655,6 +1857,26 @@ export interface KAPLAYCtx<
     onScroll(action: (delta: Vec2) => void): KEventController;
     /**
      * Register an event that runs when tab is hidden.
+     * 
+     * @example
+     * ```js
+     * // spooky ghost
+     * let ghosty = add([
+     *     pos(center()),
+     *     sprite("ghosty"),
+     *     anchor("center"),
+     * ])
+     * 
+     * // when switching tabs, this runs
+     * onHide(() => {
+     *     destroy(ghosty)
+     *     add([
+     *         text("There was never aa ghosttttt"),
+     *         pos(center()),
+     *         anchor("center")
+     *     ])
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Events
@@ -1662,6 +1884,14 @@ export interface KAPLAYCtx<
     onHide(action: () => void): KEventController;
     /**
      * Register an event that runs when tab is shown.
+     * 
+     * @example
+     * ```js
+     * // user has returned to this tab
+     * onShow(() => {
+     *     burp()
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Events
@@ -1669,6 +1899,24 @@ export interface KAPLAYCtx<
     onShow(action: () => void): KEventController;
     /**
      * Register an event that runs every frame when certain gamepad buttons are held down.
+     * 
+     * @example
+     * ```js
+     * // basic car
+     * let car = add([
+     *     pos(center()),
+     *     anchor("center"),
+     *     rect(64, 32),
+     *     color(RED),
+     *     area(),
+     *     body(),
+     *     rotate(),
+     * ])
+     * 
+     * onGamepadButtonDown("rtrigger", (gp) => {
+     *     car.addForce(Vec2.fromAngle(car.angle).scale(10))
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Input
@@ -1679,7 +1927,29 @@ export interface KAPLAYCtx<
     ): KEventController;
     /**
      * Register an event that runs every frame when any gamepad buttons are held down.
-     *
+     * 
+     * @example
+     * ```js
+     * // basic car with brakes
+     * let car = add([
+     *     pos(center()),
+     *     anchor("center"),
+     *     rect(64, 32),
+     *     color(RED),
+     *     area(),
+     *     body(),
+     *     rotate(),
+     * ])
+     * 
+     * // when button is being held down
+     * onGamepadButtonDown((btn, gp) => {
+     *     if (btn == "rtrigger") {
+     *         car.addForce(Vec2.fromAngle(car.angle).scale(10))
+     *     } else if (btn == "ltrigger") {
+     *         car.addForce(Vec2.fromAngle(car.angle).scale(-5))
+     *     }
+     * })
+     * ```
      * @since v3001.0
      * @group Input
      */
@@ -1688,6 +1958,24 @@ export interface KAPLAYCtx<
     ): KEventController;
     /**
      * Register an event that runs when user presses certain gamepad button.
+     * 
+     * @example
+     * ```js
+     * // gamepad player jump
+     * setGravity(200)
+     * 
+     * let player = add([
+     *     pos(center()),
+     *     anchor("center"),
+     *     sprite("bean"),
+     *     area(),
+     *     body()
+     * ])
+     * 
+     * onGamepadButtonPress("south", (btn, gp) => {
+     *     player.jump(200)
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Input
@@ -1699,6 +1987,29 @@ export interface KAPLAYCtx<
     /**
      * Register an event that runs when user presses any gamepad button.
      *
+     * @example
+     * ```js
+     * // gamepad player controls
+     * setGravity(200)
+     * 
+     * let player = add([
+     *     pos(center()),
+     *     anchor("center"),
+     *     sprite("bean"),
+     *     area(),
+     *     body()
+     * ])
+     * 
+     * onGamepadButtonPress((btn, gp) => {
+     *     if (btn == "south")
+     *         player.jump(200)     // jump
+     *     else if (btn == "west")
+     *         player.applyImpulse(vec2(-100, 0))   // dash left
+     *     else if (btn == "east")
+     *         player.applyImpulse(vec2(100, 0))    // dash right
+     * })
+     * ```
+     * 
      * @since v3001.0
      * @group Input
      */
@@ -1707,6 +2018,21 @@ export interface KAPLAYCtx<
     ): KEventController;
     /**
      * Register an event that runs when user releases certain gamepad button
+     * 
+     * @example
+     * ```js
+     * // charged attack
+     * let chargeTime = 0
+     * onGamepadButtonPress("west", (btn, gp) => {
+     *     chargeTime = time()
+     * })
+     * 
+     * // when a gamepad button is released, this is run
+     * onGamepadButtonRelease("west", (btn, gp) => {
+     *     let chargedt = time() - chargeTime
+     *     debug.log(`Used ${chargedt * 1000} power!`)
+     * })
+     * ```
      *
      * @since v3001.0
      * @group Input
@@ -1717,6 +2043,40 @@ export interface KAPLAYCtx<
     ): KEventController;
     /**
      * Register an event that runs when user releases any gamepad button.
+     * 
+     * @example
+     * ```js
+     * // fun charged abilities
+     * let chargeTimes = [0,0,0,0]
+     * onGamepadButtonPress((btn, gp) => {
+     *     if (btn == "north") {
+     *         chargeTimes[0] = time()
+     *     } else if (btn == "east") {
+     *         chargeTimes[1] = time()
+     *     } else if (btn == "south") {
+     *         chargeTimes[2] = time()
+     *     } else if (btn == "west") {
+     *         chargeTimes[3] = time()
+     *     }
+     * })
+     * 
+     * // when a gamepad button is released, this is run
+     * onGamepadButtonRelease((btn, gp) => {
+     *     if (btn == "north") {
+     *         let chargedt = time() - chargeTimes[0]
+     *         debug.log(`Used ${chargedt * 1000} power for "bean smack"!`)
+     *     } else if (btn == "east") {
+     *         let chargedt = time() - chargeTimes[1]\
+     *         debug.log(`Used ${chargedt * 1000} power for "mark's mark"!`)
+     *     } else if (btn == "south") {
+     *         let chargedt = time() - chargeTimes[2]
+     *         debug.log(`Used ${chargedt * 1000} power for "bobo splash"!`)
+     *     } else if (btn == "west") {
+     *         let chargedt = time() - chargeTimes[3]
+     *         debug.log(`Used ${chargedt * 1000} power for "kaplay"!`)
+     *     }
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Input
@@ -1726,6 +2086,26 @@ export interface KAPLAYCtx<
     ): KEventController;
     /**
      * Register an event that runs when the gamepad axis exists.
+     * 
+     * @example
+     * ```js
+     * // player move
+     * let player = add([
+     *     pos(center()),
+     *     anchor(`center`),
+     *     sprite(`bean`),
+     *     area(),
+     *     body(),
+     *     {
+     *         SPEED: 200,
+     *     }
+     * ])
+     * 
+     * // when left stick is moved
+     * onGamepadStick("left", (stickVector, gp) => {
+     *     player.move(stickVector.x * player.SPEED, 0);
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Input
@@ -1771,6 +2151,14 @@ export interface KAPLAYCtx<
     onButtonDown(action: (btn: TButton) => void): KEventController;
     /**
      * Register an event that runs when current scene ends.
+     * 
+     * @example
+     * ```js
+     * // run before leaving the scene
+     * onSceneLeave((newScene) => {
+     *     debug.log("we are going to ${newScene}")
+     * })
+     * ```
      *
      * @since v3000.0
      * @group Events
@@ -1937,10 +2325,7 @@ export interface KAPLAYCtx<
      *
      * @group Assets
      */
-    loadSound(
-        name: string | null,
-        src: string | ArrayBuffer | AudioBuffer,
-    ): Asset<SoundData>;
+    loadSound(name: string | null, src: string | ArrayBuffer): Asset<SoundData>;
     /**
      * Like loadSound(), but the audio is streamed and won't block loading. Use this for big audio files like background music.
      *
@@ -2327,34 +2712,6 @@ export interface KAPLAYCtx<
      */
     setButton(button: string, def: ButtonBinding): void;
     /**
-     * Press a button virtually.
-     *
-     * @since v3001.0
-     * @group Input
-     *
-     * @example
-     * ```js
-     * // press "jump" button
-     * pressButton("jump"); // triggers onButtonPress, starts onButtonDown
-     * releaseButton("jump"); // triggers onButtonRelease, stops onButtonDown
-     * ```
-     */
-    pressButton(button: TButton): void;
-    /**
-     * Release a button virtually.
-     *
-     * @since v3001.0
-     * @group Input
-     *
-     * @example
-     * ```js
-     * // press "jump" button
-     * pressButton("jump"); // triggers onButtonPress, starts onButtonDown
-     * releaseButton("jump"); // triggers onButtonRelease, stops onButtonDown
-     * ```
-     */
-    releaseButton(button: TButton): void;
-    /**
      * Get stick axis values from a gamepad.
      *
      * @since v3001.0
@@ -2425,14 +2782,6 @@ export interface KAPLAYCtx<
     camRot(angle?: number): number;
     /**
      * Flash the camera.
-     *
-     * @example
-     * ```js
-     * onClick(() => {
-     *     // flashed
-     *     camFlash(WHITE, 0.5)
-     * })
-     * ```
      *
      * @group Info
      */


### PR DESCRIPTION
Added examples for the following events:
- `onAdd()`
- `onDestroy()`
- `onLoading()`
- `onError()`
- `onResize()`
- `onCleanup()`
- `onGamepadConnect()`
- `onGamepadDisconnect()`
- `onKeyRelease()`
- `onMouseDown()`
- `onMousePress()`
- `onMouseRelease()`
- `onMouseMove()`
- `onHide()`
- `onShow()`
- `onGamepadButtonDown()`
- `onGamepadButtonPress()`
- `onGamepadButtonRelease()`
- `onGamepadStick()`