### PR TITLE
fix: randi now returns 0 or 1 instead of 0 when no args

### DIFF
--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1132,9 +1132,8 @@ export function rand<T = number>(...args: [] | [T] | [T, T]) {
     return defRNG.genAny(...args);
 }
 
-// TODO: randi() to return 0 / 1?
 export function randi(...args: [] | [number] | [number, number]) {
-    return Math.floor(rand(...args));
+    return Math.floor(rand(...(args.length > 0 ? args : [2])));
 }
 
 export function chance(p: number): boolean {


### PR DESCRIPTION
It burned me as in docs it says:

> [randi](https://kaplayjs.com/doc/ctx/randi/#randi)(): number
> rand() but floored to integer.
> 
> `randi() // returns either 0 or 1`

So this will be true after the fix. Because now it always returns 0.

I labeled this as a fix, cause even if it's marked as a Todo in the code, docs made you believe it should work which resulted in bugs.