### PR TITLE
docs: fix usage of incorrect JSDoc prefix

### DIFF
--- a/src/components/draw/particles.ts
+++ b/src/components/draw/particles.ts
@@ -41,23 +41,23 @@ class Particle {
  * Options for the {@link particles `particles()`}'s component
  */
 export type EmitterOpt = {
-    /*
+    /**
      * Shape of the emitter. If given, particles spawn within this shape.
      */
     shape?: ShapeType;
-    /*
+    /**
      * Lifetime of the emitter.
      */
     lifetime?: number;
-    /*
+    /**
      * Rate of emission in particles per second if the emitter should emit out of itself.
      */
     rate?: number;
-    /*
+    /**
      * Direction of emission.
      */
     direction: number;
-    /*
+    /**
      * Spread (cone) of emission around the direction.
      */
     spread: number;
@@ -69,51 +69,51 @@ export type EmitterOpt = {
  * @group Component Types
  */
 export type ParticlesOpt = {
-    /*
+    /**
      * Maximum number of simultaneously rendered particles.
      */
     max: number;
-    /*
+    /**
      * Minimum and maximum lifetime of a particle in seconds.
      */
     lifeTime?: [number, number];
-    /*
+    /**
      * Minimum and maximum speed of a particle in pixels per second.
      */
     speed?: [number, number];
-    /*
+    /**
      * Minimum and maximum acceleration of a particle in pixels per second^2.
      */
     acceleration?: [Vec2, Vec2];
-    /*
+    /**
      * Minimum and maximum damping of a particle.
      */
     damping?: [number, number];
-    /*
+    /**
      * Minimum and maximum start angle of a particle.
      */
     angle?: [number, number];
-    /*
+    /**
      * Minimum and maximum angular velocity of a particle.
      */
     angularVelocity?: [number, number];
-    /*
+    /**
      * Scale from start to end for a particle.
      */
     scales?: number[];
-    /*
+    /**
      * Colors from start to end for a particle.
      */
     colors?: Color[];
-    /*
+    /**
      * Opacity from start to end for a particle.
      */
     opacities?: number[];
-    /*
+    /**
      * Quads from start to end for a particle.
      */
     quads?: Quad[];
-    /*
+    /**
      * Texture used for the particle.
      */
     texture: Texture;
@@ -125,11 +125,11 @@ export type ParticlesOpt = {
  * @group Component Types
  */
 export interface ParticlesComp extends Comp {
-    /*
+    /**
      * Emit a number of particles
      */
     emit(n: number): void;
-    /*
+    /**
      * Called when the emitter expires
      */
     onEnd(cb: () => void): void;

--- a/src/components/level/pathfinder.ts
+++ b/src/components/level/pathfinder.ts
@@ -4,7 +4,7 @@ import type { Comp, GameObj } from "../../types";
 import type { PosComp } from "../transform/pos";
 
 export interface PathfinderMapComp extends Comp {
-    /*
+    /**
      * Get navigation waypoints to reach the given target from the given origin.
      */
     navigate(
@@ -12,14 +12,14 @@ export interface PathfinderMapComp extends Comp {
         target: Vec2,
         navigationOpt: any,
     ): Vec2[] | undefined;
-    /*
+    /**
      * The graph to use for navigation.
      */
     graph: Graph | undefined;
 }
 
 export interface PathfinderMapCompOpt {
-    /*
+    /**
      * The graph to use for navigation. If null, the ancestors are queried for a pathfinderMap component.
      */
     graph?: Graph;
@@ -49,22 +49,22 @@ export function pathfinderMap(
 }
 
 export interface PathfinderComp extends Comp {
-    /*
+    /**
      * Get navigation waypoints to reach the given target from the current position.
      */
     navigateTo(target: Vec2): Vec2[] | undefined;
-    /*
+    /**
      * Get the graph used for navigastion if any.
      */
     graph: Graph | undefined;
 }
 
 export interface PathfinderCompOpt {
-    /*
+    /**
      * The graph to use for navigation. If null, the ancestors are queried for a pathfinderMap component.
      */
     graph?: Graph;
-    /*
+    /**
      * The navigation options depending on the kind of graph used.
      */
     navigationOpt?: any;

--- a/src/components/level/patrol.ts
+++ b/src/components/level/patrol.ts
@@ -4,15 +4,15 @@ import type { KEventController } from "../../utils/";
 import type { PosComp } from "../transform/pos";
 
 export interface PatrolComp extends Comp {
-    /*
+    /**
      * Path to follow. If null, doesn't move.
      */
     waypoints: Vec2[] | undefined;
-    /*
+    /**
      * Speed of the movement during patrol.
      */
     patrolSpeed: number;
-    /*
+    /**
      * Current subgoal, if any.
      */
     nextLocation: Vec2 | undefined;
@@ -32,15 +32,15 @@ type PatrolEndBehavior =
     | "stop";
 
 export interface PatrolCompOpt {
-    /*
+    /**
      * Path to follow. If null, starts suspended.
      */
     waypoints?: Vec2[];
-    /*
+    /**
      * Speed of the movement during patrol.
      */
     speed?: number;
-    /*
+    /**
      * What to do after the last waypoint has been reached.
      */
     endBehavior?: PatrolEndBehavior;

--- a/src/components/level/sentry.ts
+++ b/src/components/level/sentry.ts
@@ -12,19 +12,19 @@ import type { PosComp } from "../transform/pos";
  * @group Component Types
  */
 export interface SentryComp extends Comp {
-    /*
+    /**
      * The direction the sentry is pointing to.
      */
     direction?: Vec2;
-    /*
+    /**
      * The direction of the sentry as an angle in degrees.
      */
     directionAngle?: number;
-    /*
+    /**
      * The field of view of the sentry in degrees.
      */
     fieldOfView?: number;
-    /*
+    /**
      * The objects spotted most recently.
      */
     spotted: GameObj<any>[];
@@ -57,23 +57,23 @@ export interface SentryComp extends Comp {
  * @group Component Types
  */
 export interface SentryCompOpt {
-    /*
+    /**
      * The direction the sentry is pointing to. If undefined, direction has no influence.
      */
     direction?: Vec2 | number;
-    /*
+    /**
      * The field of view of the sentry in degrees. If undefined, defaults to human fov of 200 degrees.
      */
     fieldOfView?: number;
-    /*
+    /**
      * If true, line of sight matters. This means that objects which are blocked from view by areas are invisible.
      */
     lineOfSight?: boolean;
-    /*
+    /**
      * When using line of sight, the objects which are transparent for the ray. Include at least a tag identifying the sentry.
      */
     raycastExclude?: string[];
-    /*
+    /**
      * The frequency of checking, defaults to every second.
      */
     checkFrequency?: number;


### PR DESCRIPTION
When browsing the code I discovered that some attempted doc comments used the incorrect JSDoc prefix (`/*` instead of `/**`). This results in those comments not being picked up by JSDoc, and thus not in the documentation or in-editor hints.
