### PR TITLE
fix: don't blow stack on recursive object

### DIFF
--- a/examples/prettyDebug.js
+++ b/examples/prettyDebug.js
@@ -10,6 +10,8 @@ const pretty = {
     "own toString is used": vec2(10, 10),
 };
 
+pretty.recursive = pretty;
+
 debug.log("Text in [brackets] doesn't cause issues");
 
 debug.log(pretty);

--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -219,7 +219,8 @@ export function drawDebug() {
     }
 }
 
-function prettyDebug(object: any | undefined, inside: boolean = false): string {
+function prettyDebug(object: any | undefined, inside: boolean = false, seen: Set<any> = new Set): string {
+    if (seen.has(object)) return "<recursive>";
     var outStr = "", tmp;
     if (inside && typeof object === "string") {
         object = JSON.stringify(object);
@@ -227,7 +228,7 @@ function prettyDebug(object: any | undefined, inside: boolean = false): string {
     if (Array.isArray(object)) {
         outStr = [
             "[",
-            object.map(e => prettyDebug(e, true)).join(", "),
+            object.map(e => prettyDebug(e, true, seen.union(new Set([object])))).join(", "),
             "]",
         ].join("");
         object = outStr;
@@ -244,7 +245,7 @@ function prettyDebug(object: any | undefined, inside: boolean = false): string {
             (tmp = Object.getOwnPropertyNames(object)
                     .map(p =>
                         `${/^\w+$/.test(p) ? p : JSON.stringify(p)}: ${
-                            prettyDebug(object[p], true)
+                            prettyDebug(object[p], true, seen.union(new Set([object])))
                         }`
                     )
                     .join(", "))


### PR DESCRIPTION
would previously throw a RecursionError if you try to debug.log a recursive / self-referential object, now it doesn't and just shows `<recursive>` instead