### PR TITLE
feat: add better error message to say which components conflict

### DIFF
--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -277,16 +277,12 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                         const originalCompId = compStates.values().find(c =>
                             (c as any)[k] !== undefined
                         )?.id;
-                        if (originalCompId === undefined) {
-                            throw new Error(
-                                `Duplicate component property: "${k}"`,
-                            );
-                        }
-                        else {
-                            throw new Error(
-                                `While adding component "${comp.id}": Duplicate property "${k}" (originally added by component "${originalCompId}")`,
-                            );
-                        }
+                        throw new Error(
+                            `Duplicate component property: "${k}" while adding component "${comp.id}"`
+                                + (originalCompId
+                                    ? ` (originally added by "${originalCompId}")`
+                                    : ""),
+                        );
                     }
                 }
             }

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -274,9 +274,19 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                         gc.push(() => delete this[k]);
                     }
                     else {
-                        throw new Error(
-                            `Duplicate component property: "${k}"`,
-                        );
+                        const originalCompId = compStates.values().find(c =>
+                            (c as any)[k] !== undefined
+                        )?.id;
+                        if (originalCompId === undefined) {
+                            throw new Error(
+                                `Duplicate component property: "${k}"`,
+                            );
+                        }
+                        else {
+                            throw new Error(
+                                `While adding component "${comp.id}": Duplicate property "${k}" (originally added by component "${originalCompId}")`,
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<img width="511" alt="Screenshot 2024-11-14 at 4 58 29 PM" src="https://github.com/user-attachments/assets/99783e35-7708-4bcf-97c6-201dc02d627b">

previously, it would just say "duplicate property width" and you'd be left wondering which components conflict