### PR TITLE
fix: `get fb`

### DIFF
--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -481,6 +481,7 @@ const kaplay = <
                 flush();
                 fb.unbind();
             },
+            get fb() { return fb; }
         };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4717,6 +4717,7 @@ export type Canvas = {
     clear(): void;
     draw(action: () => void): void;
     free(): void;
+    readonly fb: FrameBuffer
 };
 
 export interface Vertex {


### PR DESCRIPTION
add getter to Canvas for low level frame buffer