### PR TITLE
fix: sets loop using passed in AudioPlayOpt when playing music

### DIFF
--- a/src/audio/playMusic.ts
+++ b/src/audio/playMusic.ts
@@ -7,6 +7,8 @@ export function playMusic(url: string, opt: AudioPlayOpt = {}): AudioPlay {
     const onEndEvents = new KEvent();
     const el = new Audio(url);
     el.crossOrigin = "anonymous";
+    el.loop = Boolean(opt.loop);
+
     const src = _k.audio.ctx.createMediaElementSource(el);
 
     src.connect(opt.connectTo ?? _k.audio.masterNode);


### PR DESCRIPTION
## Description

Sets `loop` using the passed in AudioPlayOpt, similar to how `play()` does.

### Issues or related

Closes #527 
