### PR TITLE
feat: normalize get/set methods for camera, add getLayers and getDefaultLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v4000.0.0
+# v4000.0.0 (unreleased)
 
 - Added clipLineToRect
 - Replaced the Separating Axis Theorem (SAT) with the Gilbert–Johnson–Keerthi
@@ -22,12 +22,17 @@
 
 # v3001.1.0: A perfectionist skull (unreleased)
 
-## Documentation
-
 - Added many JSDoc specifiers on many functions (@require, @deprecated, @since,
   @group, etc)
+- Added `getLayers()` to get the layers list
+- Added `getDefaulLayer()` to get the default layer
+- Deprecated camera methods `camScale()`, `camPos()` and `camRot()` in favor of
+  `setCamScale()`, `getCamScale()`, `setCamPos()`, `getCamPos()`, `setCamRot()`
+  and `getCamRot`.
+- Deprecated `camFlash()` in favor of `flash()`, for a `shake()`-like name.
+- Deprecated `camTransform()` in favor of `getCamTransform()`.
 
-# v3001.0.0
+# v3001.0.0: Spooky Beans!
 
 ## Input
 

--- a/examples/camera.js
+++ b/examples/camera.js
@@ -54,12 +54,12 @@ const player = level.get("player")[0];
 // Will run every frame
 player.onUpdate(() => {
     // Set the viewport center to player.pos
-    camPos(player.worldPos());
+    setCamPos(player.worldPos());
 });
 
 // Set the viewport center to player.pos whenever their physics are resolved
 player.onPhysicsResolve(() => {
-    camPos(player.worldPos());
+    setCamPos(player.worldPos());
 });
 
 // When the player collides with a coin object
@@ -69,7 +69,7 @@ player.onCollide("coin", (coin) => {
     play("score");
     score++;
     // Zoooom in!
-    camScale(2);
+    setCamScale(2);
 });
 
 // Movements

--- a/examples/concert.js
+++ b/examples/concert.js
@@ -158,8 +158,8 @@ player.onHeadbutt((block) => {
 
 onUpdate(() => {
     if (!burping) return;
-    camPos(camPos().lerp(player.pos, dt() * 3));
-    camScale(camScale().lerp(vec2(5), dt() * 3));
+    setCamPos(getCamPos().lerp(player.pos, dt() * 3));
+    setCamScale(getCamScale().lerp(vec2(5), dt() * 3));
 });
 
 const lyrics =

--- a/examples/largeTexture.js
+++ b/examples/largeTexture.js
@@ -5,7 +5,7 @@ kaplay();
 // Loads a random 2500px image
 loadSprite("bigyoshi", "/examples/sprites/YOSHI.png");
 
-let cameraPosition = camPos();
+let cameraPosition = getCamPos();
 let cameraScale = 1;
 
 add([
@@ -30,11 +30,11 @@ onUpdate(() => {
         cameraPosition = cameraPosition.sub(
             mouseDeltaPos().scale(1 / cameraScale),
         );
-        camPos(cameraPosition);
+        setCamPos(cameraPosition);
     }
 });
 
 onScroll((delta) => {
     cameraScale = cameraScale * (1 - 0.1 * Math.sign(delta.y));
-    camScale(cameraScale);
+    setCamScale(cameraScale);
 });

--- a/examples/platformBox.js
+++ b/examples/platformBox.js
@@ -71,5 +71,5 @@ onKeyDown("right", () => {
 });
 
 onUpdate(() => {
-    camPos(player.worldPos());
+    setCamPos(player.worldPos());
 });

--- a/examples/platformEffector.js
+++ b/examples/platformEffector.js
@@ -57,7 +57,7 @@ const player = level.get("player")[0];
 
 // Always look at player
 onUpdate(() => {
-    camPos(player.worldPos());
+    setCamPos(player.worldPos());
 });
 
 // Movements

--- a/examples/platformer.js
+++ b/examples/platformer.js
@@ -219,7 +219,7 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
     // action() runs every frame
     player.onUpdate(() => {
         // center camera to player
-        camPos(player.pos);
+        setCamPos(player.pos);
         // check fall death
         if (player.pos.y >= FALL_DEATH) {
             go("lose");
@@ -234,7 +234,7 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
 
     player.onPhysicsResolve(() => {
         // Set the viewport center to player.pos
-        camPos(player.pos);
+        setCamPos(player.pos);
     });
 
     // if player onCollide with any obj with "danger" tag, lose

--- a/examples/spriteatlas.js
+++ b/examples/spriteatlas.js
@@ -320,12 +320,12 @@ const dirs = {
 };
 
 player.onUpdate(() => {
-    camPos(player.pos);
+    setCamPos(player.pos);
 });
 
 player.onPhysicsResolve(() => {
     // Set the viewport center to player.pos
-    camPos(player.pos);
+    setCamPos(player.pos);
 });
 
 onKeyDown("right", () => {

--- a/src/audio/volume.ts
+++ b/src/audio/volume.ts
@@ -1,9 +1,20 @@
 import { _k } from "../kaplay";
+import { deprecate, deprecateMsg } from "../utils";
+
+export function setVolume(v: number) {
+    _k.audio.masterNode.gain.value = v;
+}
+
+export function getVolume() {
+    return _k.audio.masterNode.gain.value;
+}
 
 // get / set master volume
 export function volume(v?: number): number {
+    deprecateMsg("volume", "setVolume / getVolume");
+
     if (v !== undefined) {
-        _k.audio.masterNode.gain.value = v;
+        setVolume(v);
     }
-    return _k.audio.masterNode.gain.value;
+    return getVolume();
 }

--- a/src/game/camera.ts
+++ b/src/game/camera.ts
@@ -3,30 +3,38 @@ import { center, height, width } from "../gfx";
 import { _k } from "../kaplay";
 import { type Color, rgb } from "../math/color";
 import { type Mat23, type Vec2, vec2, type Vec2Args } from "../math/math";
+import { deprecateMsg } from "../utils";
 import { destroy } from ".";
 
-export function camPos(...pos: Vec2Args): Vec2 {
-    if (pos.length > 0) {
-        _k.game.cam.pos = vec2(...pos);
-    }
+export function setCamPos(...pos: Vec2Args) {
+    _k.game.cam.pos = vec2(...pos);
+}
+
+export function getCamPos(): Vec2 {
     return _k.game.cam.pos ? _k.game.cam.pos.clone() : center();
 }
 
-export function camScale(...scale: Vec2Args): Vec2 {
-    if (scale.length > 0) {
-        _k.game.cam.scale = vec2(...scale);
-    }
+export function setCamScale(...scale: Vec2Args) {
+    _k.game.cam.scale = vec2(...scale);
+}
+
+export function getCamScale(): Vec2 {
     return _k.game.cam.scale.clone();
 }
 
-export function camRot(angle: number): number {
-    if (angle !== undefined) {
-        _k.game.cam.angle = angle;
-    }
+export function setCamRot(angle: number) {
+    _k.game.cam.angle = angle;
+}
+
+export function getCamRot(): number {
     return _k.game.cam.angle;
 }
 
-export function camFlash(
+export function getCamTransform(): Mat23 {
+    return _k.game.cam.transform.clone();
+}
+
+export function flash(
     flashColor: Color = rgb(255, 255, 255),
     fadeOutTime: number = 1,
 ) {
@@ -41,10 +49,6 @@ export function camFlash(
     return fade;
 }
 
-export function camTransform(): Mat23 {
-    return _k.game.cam.transform.clone();
-}
-
 export function shake(intensity: number = 12) {
     _k.game.cam.shake += intensity;
 }
@@ -55,4 +59,46 @@ export function toScreen(p: Vec2): Vec2 {
 
 export function toWorld(p: Vec2): Vec2 {
     return _k.game.cam.transform.inverse.transformPoint(p, vec2());
+}
+
+export function camPos(...pos: Vec2Args): Vec2 {
+    deprecateMsg("camPos", "setCamPos / getCamPos");
+
+    if (pos.length > 0) {
+        setCamPos(...pos);
+    }
+    return getCamPos();
+}
+
+export function camScale(...scale: Vec2Args): Vec2 {
+    deprecateMsg("camScale", "setCamScale / getCamScale");
+
+    if (scale.length > 0) {
+        setCamScale(...scale);
+    }
+    return getCamScale();
+}
+
+export function camRot(angle: number): number {
+    deprecateMsg("camRot", "setCamRot / getCamRot");
+
+    if (angle !== undefined) {
+        setCamRot(angle);
+    }
+    return getCamRot();
+}
+
+export function camFlash(
+    flashColor: Color = rgb(255, 255, 255),
+    fadeOutTime: number = 1,
+) {
+    deprecateMsg("camFlash", "flash");
+
+    return flash(flashColor, fadeOutTime);
+}
+
+export function camTransform(): Mat23 {
+    deprecateMsg("camTransform", "getCamTransform");
+
+    return getCamTransform();
 }

--- a/src/game/layers.ts
+++ b/src/game/layers.ts
@@ -1,6 +1,7 @@
 import { _k } from "../kaplay";
+import { deprecateMsg } from "../utils";
 
-export const layers = function(layerNames: string[], defaultLayer: string) {
+export function setLayers(layerNames: string[], defaultLayer: string) {
     if (_k.game.layers) {
         throw Error("Layers can only be assigned once.");
     }
@@ -12,4 +13,17 @@ export const layers = function(layerNames: string[], defaultLayer: string) {
     }
     _k.game.layers = layerNames;
     _k.game.defaultLayerIndex = defaultLayerIndex;
-};
+}
+
+export function getLayers() {
+    return _k.game.layers;
+}
+
+export function getDefaultLayer() {
+    return _k.game.layers?.[_k.game.defaultLayerIndex] ?? null;
+}
+
+export function layers(layerNames: string[], defaultLayer: string) {
+    deprecateMsg("layers", "setLayers");
+    setLayers(layerNames, defaultLayer);
+}

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -230,7 +230,7 @@ import {
 } from "./components";
 
 import { dt, fixedDt, restDt } from "./app";
-import { burp, initAudio, play, volume } from "./audio";
+import { burp, getVolume, initAudio, play, setVolume, volume } from "./audio";
 
 import {
     addKaboom,
@@ -241,8 +241,15 @@ import {
     camScale,
     camTransform,
     destroy,
+    flash,
+    getCamPos,
+    getCamRot,
+    getCamScale,
+    getCamTransform,
+    getDefaultLayer,
     getGravity,
     getGravityDirection,
+    getLayers,
     getSceneName,
     getTreeRoot,
     go,
@@ -270,8 +277,12 @@ import {
     onSceneLeave,
     onUpdate,
     scene,
+    setCamPos,
+    setCamRot,
+    setCamScale,
     setGravity,
     setGravityDirection,
+    setLayers,
     shake,
     toScreen,
     toWorld,
@@ -481,7 +492,9 @@ const kaplay = <
                 flush();
                 fb.unbind();
             },
-            get fb() { return fb; }
+            get fb() {
+                return fb;
+            },
         };
     }
 
@@ -1165,6 +1178,14 @@ const kaplay = <
         onError,
         onCleanup,
         // misc
+        flash: flash,
+        setCamPos: setCamPos,
+        getCamPos: getCamPos,
+        setCamRot: setCamRot,
+        getCamRot: getCamRot,
+        setCamScale: setCamScale,
+        getCamScale: getCamScale,
+        getCamTransform: getCamTransform,
         camPos,
         camScale,
         camFlash,
@@ -1305,6 +1326,8 @@ const kaplay = <
         wait,
         // audio
         play,
+        setVolume: setVolume,
+        getVolume: getVolume,
         volume,
         burp,
         audioCtx: audio.ctx,
@@ -1406,7 +1429,10 @@ const kaplay = <
         go,
         onSceneLeave,
         // layers
-        layers,
+        layers: layers,
+        getLayers: getLayers,
+        setLayers: setLayers,
+        getDefaultLayer: getDefaultLayer,
         // level
         addLevel,
         // storage

--- a/src/types.ts
+++ b/src/types.ts
@@ -782,7 +782,7 @@ export interface KAPLAYCtx<
      *
      * @returns The layer comp.
      * @since v3001.0
-     * @group Components
+     * @group Layer
      */
     layer(name: string): LayerComp;
     /**
@@ -3115,6 +3115,91 @@ export interface KAPLAYCtx<
      */
     charInputted(): string[];
     /**
+     * Set camera position.
+     *
+     * @param pos - The position to set the camera to.
+     *
+     * @example
+     * ```js
+     * // move camera to (100, 100)
+     * setCamPos(100, 100);
+     * setCamPos(vec2(100, 100));
+     * setCamPos(100); // x and y are the same
+     * ```
+     *
+     * @since v3001.1
+     * @group Camera
+     */
+    setCamPos(pos: Vec2): void;
+    setCamPos(x: number, y: number): void;
+    setCamPos(xy: number): void;
+    /**
+     * Get camera position.
+     *
+     * @returns The current camera position.
+     * @since v3001.1
+     * @group Camera
+     */
+    getCamPos(): Vec2;
+    /**
+     * Set camera scale.
+     *
+     * @param scale - The scale to set the camera to.
+     *
+     * @example
+     * ```js
+     * // set camera scale to (2, 2)
+     * setCamScale(2, 2);
+     * setCamScale(vec2(2, 2));
+     * setCamScale(2); // x and y are the same
+     * ```
+     *
+     * @since v3001.1
+     * @group Camera
+     */
+    setCamScale(scale: Vec2): void;
+    setCamScale(x: number, y: number): void;
+    setCamScale(xy: number): void;
+    /**
+     * Get camera scale.
+     *
+     * @returns The current camera scale.
+     * @since v3001.1
+     * @group Camera
+     */
+    getCamScale(): Vec2;
+    /**
+     * Set camera rotation.
+     *
+     * @param angle - The angle to rotate the camera.
+     *
+     * @example
+     * ```js
+     * // rotate camera 90 degrees
+     * setCamRot(90);
+     * ```
+     *
+     * @since v3001.1
+     * @group Camera
+     */
+    setCamRot(angle: number): void;
+    /**
+     * Get camera rotation.
+     *
+     * @returns The current camera rotation.
+     * @since v3001.1
+     * @group Camera
+     */
+    getCamRot(): number;
+    /**
+     * Get camera transform.
+     *
+     * @returns The current camera transform.
+     * @since v3001.1
+     * @group Camera
+     */
+    getCamTransform(): Mat23;
+    /**
      * Camera shake.
      *
      * @param intensity - The intensity of the shake. Default to 12.
@@ -3132,6 +3217,28 @@ export interface KAPLAYCtx<
      */
     shake(intensity?: number): void;
     /**
+     * Camera flash.
+     *
+     * @param flashColor - The color of the flash.
+     * @param fadeOutTime - The time it takes for the flash to fade out.
+     *
+     * @example
+     * ```js
+     * onClick(() => {
+     *     // flashed
+     *     flash(WHITE, 0.5);
+     * });
+     * ```
+     *
+     * @returns A timer controller.
+     * @since v3001.0
+     * @group Camera
+     */
+    flash(flashColor: Color, fadeOutTime: number): TimerController;
+    // #region DEPRECATED CAMERA METHODS ---------------------------------------
+    /**
+     * @deprecated Use {@link setCamPos} and {@link getCamPos} instead.
+     *
      * Get / set camera position.
      *
      * @param pos - The position to set the camera to.
@@ -3149,10 +3256,16 @@ export interface KAPLAYCtx<
      * @group Camera
      */
     camPos(pos: Vec2): Vec2;
+    /** @deprecated */
     camPos(x: number, y: number): Vec2;
+    /** @deprecated */
     camPos(xy: number): Vec2;
+    /** @deprecated */
+
     camPos(): Vec2;
     /**
+     * @deprecated Use {@link setCamScale} and {@link getCamScale} instead.
+     *
      * Get / set camera scale.
      *
      * @param scale - The scale to set the camera to.
@@ -3162,10 +3275,15 @@ export interface KAPLAYCtx<
      * @group Camera
      */
     camScale(scale: Vec2): Vec2;
+    /** @deprecated */
     camScale(x: number, y: number): Vec2;
+    /** @deprecated */
     camScale(xy: number): Vec2;
+    /** @deprecated */
     camScale(): Vec2;
     /**
+     * @deprecated Use {@link setCamRot} and {@link getCamRot} instead.
+     *
      * Get / set camera rotation.
      *
      * @param angle - The angle to rotate the camera.
@@ -3176,6 +3294,8 @@ export interface KAPLAYCtx<
      */
     camRot(angle?: number): number;
     /**
+     * @deprecated use {@link flash} instead.
+     *
      * Flash the camera.
      *
      * @param flashColor - The color of the flash.
@@ -3195,11 +3315,14 @@ export interface KAPLAYCtx<
      */
     camFlash(flashColor: Color, fadeOutTime: number): TimerController;
     /**
+     * @deprecated use {@link getCamTransform} instead.
+     *
      * Get camera transform.
      *
      * @group Camera
      */
     camTransform(): Mat23;
+    // #endregion DEPRECATED CAMERA METHODS ------------------------------------
     /**
      * Transform a point from world position (relative to the root) to screen position (relative to the screen).
      *
@@ -3440,6 +3563,30 @@ export interface KAPLAYCtx<
      */
     burp(options?: AudioPlayOpt): AudioPlay;
     /**
+     * Set the global volume.
+     *
+     * @param v - The volume to set.
+     *
+     * @example
+     * ```js
+     * setVolume(0.5)
+     * ```
+     *
+     * @since v3001.1
+     * @group Audio
+     */
+    setVolume(v: number): void;
+    /**
+     * Get the global volume.
+     *
+     * @returns The current volume.
+     * @since v3001.1
+     * @group Audio
+     */
+    getVolume(): number;
+    /**
+     * @deprecated Use {@link setVolume} and {@link getVolume} instead.
+     *
      * Sets global volume.
      *
      * @example
@@ -4209,6 +4356,50 @@ export interface KAPLAYCtx<
      * @example
      * ```js
      * layers(["bg", "obj", "ui"], "obj")
+     *
+     * // no layer specified, will be added to "obj"
+     * add([
+     *      sprite("bean"),
+     * ]);
+     *
+     * // add to "bg" layer
+     * add([
+     *     sprite("bg"),
+     *     layer("bg"),
+     * ]);
+     * ```
+     *
+     * @since v3001.1
+     * @group Layers
+     */
+    setLayers(layers: string[], defaultLayer: string): void;
+    /**
+     * Get the layer names.
+     *
+     * @returns The layer names or null if not set.
+     * @since v3001.1
+     * @group Layers
+     */
+    getLayers(): string[] | null;
+    /**
+     * Get the default layer name.
+     *
+     * @returns The default layer name or null if not set.
+     * @since v3001.1
+     * @group Layers
+     */
+    getDefaultLayer(): string | null;
+    /**
+     * @deprecated Use {@link setLayers} instead.
+     *
+     * Define the layer names. Should be called before any objects are made.
+     *
+     * @param layers - The layer names.
+     * @param defaultLayer - The default layer name.
+     *
+     * @example
+     * ```js
+     * setLayers(["bg", "obj", "ui"], "obj")
      *
      * // no layer specified, will be added to "obj"
      * add([


### PR DESCRIPTION
- Added `getLayers()` to get the layers list
- Added `getDefaulLayer()` to get the default layer
- Deprecated camera methods `camScale()`, `camPos()` and `camRot()` in favor of
  `setCamScale()`, `getCamScale()`, `setCamPos()`, `getCamPos()`, `setCamRot()`
  and `getCamRot`.
- Deprecated `camFlash()` in favor of `flash()`, for a `shake()`-like name.
- Deprecated `camTransform()` in favor of `getCamTransform()`.