### PR TITLE
fix: Update level spatial map when tiles are moved

### DIFF
--- a/examples/sokoban.js
+++ b/examples/sokoban.js
@@ -1,0 +1,72 @@
+kaplay({
+    background: [45, 33, 51],
+});
+
+loadSprite("bean", "/sprites/bean.png");
+loadSprite("grass", "/sprites/grass.png");
+loadSprite("steel", "/sprites/steel.png");
+
+const level = addLevel([
+    ".......",
+    ".p   d.",
+    ". b b .",
+    ".     .",
+    ".......",
+], {
+    tileWidth: 64,
+    tileHeight: 64,
+    tiles: {
+        p: () => [sprite("bean"), "player"],
+        b: () => [sprite("grass"), "box"],
+        ".": () => [sprite("steel"), "wall"],
+    },
+});
+
+const player = level.get("player")[0];
+
+const hasTag = (objs, tag) => objs.findIndex(obj => obj.is(tag)) !== -1;
+
+const moveObj = (obj, dir) => {
+    if (dir.x == 1) obj.moveRight();
+    if (dir.x == -1) obj.moveLeft();
+    if (dir.y == 1) obj.moveDown();
+    if (dir.y == -1) obj.moveUp();
+};
+
+const move = (dir) => {
+    const moveTo = player.tilePos.add(dir);
+    const occupant = level.getAt(moveTo);
+
+    if (hasTag(occupant, "wall")) {
+        return;
+    }
+
+    if (hasTag(occupant, "box")) {
+        const boxMoveTo = occupant[0].tilePos.add(dir);
+        const boxOccupant = level.getAt(boxMoveTo);
+
+        if (boxOccupant.length !== 0) {
+            return;
+        }
+
+        moveObj(occupant[0], dir);
+    }
+
+    moveObj(player, dir);
+};
+
+onKeyPress("d", () => {
+    move(vec2(1, 0));
+});
+
+onKeyPress("a", () => {
+    move(vec2(-1, 0));
+});
+
+onKeyPress("w", () => {
+    move(vec2(0, -1));
+});
+
+onKeyPress("s", () => {
+    move(vec2(0, 1));
+});

--- a/src/components/level/tile.ts
+++ b/src/components/level/tile.ts
@@ -35,6 +35,7 @@ export interface TileComp extends Comp {
     tilePosOffset: Vec2;
     readonly edgeMask: EdgeMask;
     getLevel(): GameObj<LevelComp>;
+    tileMove(dir: Vec2): void;
     moveLeft(): void;
     moveRight(): void;
     moveUp(): void;
@@ -142,20 +143,28 @@ export function tile(opts: TileCompOpt = {}): TileComp {
             return this.parent as GameObj<LevelComp>;
         },
 
+        tileMove(dir: Vec2) {
+            const level = this.getLevel();
+            level.removeFromSpatialMap(this as unknown as GameObj<TileComp>);
+            this.tilePos = this.tilePos.add(dir);
+            level.insertIntoSpatialMap(this as unknown as GameObj<TileComp>);
+            level.trigger("spatialMapChanged");
+        },
+
         moveLeft() {
-            this.tilePos = this.tilePos.add(vec2(-1, 0));
+            this.tileMove(vec2(-1, 0));
         },
 
         moveRight() {
-            this.tilePos = this.tilePos.add(vec2(1, 0));
+            this.tileMove(vec2(1, 0));
         },
 
         moveUp() {
-            this.tilePos = this.tilePos.add(vec2(0, -1));
+            this.tileMove(vec2(0, -1));
         },
 
         moveDown() {
-            this.tilePos = this.tilePos.add(vec2(0, 1));
+            this.tileMove(vec2(0, 1));
         },
     };
 }

--- a/src/game/level.ts
+++ b/src/game/level.ts
@@ -399,6 +399,10 @@ export function addLevel(
             return spatialMap!;
         },
 
+        removeFromSpatialMap,
+
+        insertIntoSpatialMap,
+
         onSpatialMapChanged(this: GameObj<LevelComp>, cb: () => void) {
             return this.on("spatialMapChanged", cb);
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6513,6 +6513,8 @@ export interface LevelComp extends Comp {
      */
     getPath(from: Vec2, to: Vec2, opts?: PathFindOpt): Vec2[] | null;
     getSpatialMap(): GameObj[][];
+    removeFromSpatialMap(obj: GameObj): void;
+    insertIntoSpatialMap(obj: GameObj): void;
     onSpatialMapChanged(cb: () => void): KEventController;
     onNavigationMapInvalid(cb: () => void): KEventController;
     invalidateNavigationMap(): void;


### PR DESCRIPTION
## Description

- Expose removeFromSpatialMap and insertIntoSpatialMap from level so they can be called from the tile component.
- When calling a move function from tile, remove the current component from the spatial map and add them back with the new position.
- Contribute a Sokoban example that showcases using tile movement to create a tile-based puzzle game.

Here's what the example looks like:

![image](https://github.com/user-attachments/assets/8c4f8b3d-62b9-4e17-b213-39ea7b53f2cb)

## Related issues

- Closes https://github.com/kaplayjs/kaplay/issues/503