### PR TITLE
docs: Added correct function call for loadShaderURL

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2573,7 +2573,7 @@ export interface KAPLAYCtx<
      * @example
      * ```js
      * // load only a fragment shader from URL
-     * loadShader("outline", null, "/shaders/outline.glsl", true)
+     * loadShaderURL("outline", null, "/shaders/outline.glsl")
      * ```
      *
      * @retunrs The asset data.


### PR DESCRIPTION
## Description
Documentation for loadShaderURL was using text from loadShader. Found this while loading a shader during KAJAM