### PR TITLE
fix: text artifacts in TrueType fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v4000.0.0 (unreleased)
 
-- Added clipLineToRect
-- Replaced the Separating Axis Theorem (SAT) with the Gilbert–Johnson–Keerthi
-  (GJK) distance algorithm.
+- Added `clipLineToRect()`
+- Replaced the Separating Axis Theorem (SAT) with the "Gilbert–Johnson–Keerthi"
+  (`GJK`) distance algorithm.
 - Added circle and (rotated) ellipse collision shapes.
 - Added `ellipse()` component.
 - Circle area is no longer a box.
@@ -31,6 +31,7 @@
   and `getCamRot`.
 - Deprecated `camFlash()` in favor of `flash()`, for a `shake()`-like name.
 - Deprecated `camTransform()` in favor of `getCamTransform()`.
+- Fixed artifacts present in some TrueType fonts.
 
 # v3001.0.0: Spooky Beans!
 

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -165,14 +165,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
             outline: opts.outline,
         };
 
-        drawUVQuad({
-            tex: atlas.font.tex,
-            height: atlas.font.tex.height,
-            width: atlas.font.tex.width,
-            pos: vec2(0, center().y),
-            scale: vec2(2),
-        });
-
         if (!fontAtlases[fontName]) {
             fontAtlases[fontName] = atlas;
         }

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -11,13 +11,15 @@ import { Quad, Vec2, vec2 } from "../math/math";
 import { type Outline, type TexFilter } from "../types";
 import { runes } from "../utils";
 import { alignPt } from "./anchor";
-import type {
-    CharTransform,
-    DrawTextOpt,
-    FormattedChar,
-    FormattedText,
+import {
+    type CharTransform,
+    type DrawTextOpt,
+    drawUVQuad,
+    type FormattedChar,
+    type FormattedText,
 } from "./draw";
 import { Texture } from "./gfx";
+import { center } from "./stack";
 
 type FontAtlas = {
     font: BitmapFontData;
@@ -148,15 +150,28 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         // TODO: customizable font tex filter
         const atlas: FontAtlas = fontAtlases[fontName] ?? {
             font: {
-                tex: new Texture(_k.gfx.ggl, FONT_ATLAS_WIDTH, FONT_ATLAS_HEIGHT, {
-                    filter: opts.filter,
-                }),
+                tex: new Texture(
+                    _k.gfx.ggl,
+                    FONT_ATLAS_WIDTH,
+                    FONT_ATLAS_HEIGHT,
+                    {
+                        filter: opts.filter,
+                    },
+                ),
                 map: {},
                 size: DEF_TEXT_CACHE_SIZE,
             },
             cursor: new Vec2(0),
             outline: opts.outline,
         };
+
+        drawUVQuad({
+            tex: atlas.font.tex,
+            height: atlas.font.tex.height,
+            width: atlas.font.tex.width,
+            pos: vec2(0, center().y),
+            scale: vec2(2),
+        });
 
         if (!fontAtlases[fontName]) {
             fontAtlases[fontName] = atlas;
@@ -180,6 +195,7 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                     _k.fontCacheCanvas.width,
                     _k.fontCacheCanvas.height,
                 );
+
                 c2d.font = `${font.size}px ${fontName}`;
                 c2d.textBaseline = "top";
                 c2d.textAlign = "left";
@@ -187,7 +203,8 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                 const m = c2d.measureText(ch);
                 let w = Math.ceil(m.width);
                 if (!w) continue;
-                let h = m.fontBoundingBoxAscent + m.fontBoundingBoxDescent;
+                let h = Math.ceil(Math.abs(m.actualBoundingBoxAscent))
+                    + Math.ceil(Math.abs(m.actualBoundingBoxDescent));
 
                 // TODO: Test if this works with the verification of width and color
                 if (
@@ -213,7 +230,12 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                     atlas.outline?.width ?? 0,
                 );
 
-                const img = c2d.getImageData(0, 0, w, h);
+                const img = c2d.getImageData(
+                    0,
+                    0,
+                    w,
+                    h,
+                );
 
                 // if we are about to exceed the X axis of the texture, go to another line
                 if (atlas.cursor.x + w > FONT_ATLAS_WIDTH) {
@@ -228,13 +250,15 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                 }
 
                 font.tex.update(img, atlas.cursor.x, atlas.cursor.y);
+
                 font.map[ch] = new Quad(
                     atlas.cursor.x,
                     atlas.cursor.y,
                     w,
                     h,
                 );
-                atlas.cursor.x += w;
+
+                atlas.cursor.x += w + 1;
             }
         }
     }

--- a/src/gfx/gfx.ts
+++ b/src/gfx/gfx.ts
@@ -57,6 +57,7 @@ export class Texture {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrap);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrap);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
         this.unbind();
     }
 

--- a/src/gfx/gfxApp.ts
+++ b/src/gfx/gfxApp.ts
@@ -60,7 +60,7 @@ export const initAppGfx = (gopt: KAPLAYOpt, ggl: GfxCtx) => {
 
     gl.enable(gl.BLEND);
     gl.blendFuncSeparate(
-        gl.SRC_ALPHA,
+        gl.ONE,
         gl.ONE_MINUS_SRC_ALPHA,
         gl.ONE,
         gl.ONE_MINUS_SRC_ALPHA,


### PR DESCRIPTION
This fixes strange artifacts appearing with some fonts loaded with `loadFont`