### PR TITLE
feat: add k.cancel()

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,3 +100,4 @@ export const DEF_OFFSCREEN_DIS = 200;
 // maximum y velocity with body()
 export const DEF_JUMP_FORCE = 640;
 export const MAX_VEL = 65536;
+export const EVENT_CANCEL_SYMBOL = Symbol.for("kaplay.cancel");

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -77,6 +77,7 @@ import {
     ASCII_CHARS,
     BG_GRID_SIZE,
     DBG_FONT,
+    EVENT_CANCEL_SYMBOL,
     LOG_MAX,
     MAX_TEXT_CACHE_SIZE,
 } from "./constants";
@@ -1466,6 +1467,7 @@ const kaplay = <
         KEvent,
         KEventHandler,
         KEventController,
+        cancel: () => EVENT_CANCEL_SYMBOL
     };
 
     _k.k = ctx;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5510,6 +5510,19 @@ export interface KAPLAYCtx<
      */
     KEventController: typeof KEventController;
     /**
+     * Cancels the event if returned.
+     * 
+     * @since v3001.1
+     * @group Events
+     * @example
+     * ```js
+     * onKeyPress((key) => {
+     *     if (key === "q") return k.cancel();
+     * });
+     * ```
+     */
+    cancel: () => Symbol,
+    /**
      * Current KAPLAY library version.
      *
      * @since v3000.0

--- a/src/types.ts
+++ b/src/types.ts
@@ -5510,16 +5510,18 @@ export interface KAPLAYCtx<
      */
     KEventController: typeof KEventController;
     /**
-     * Cancels the event if returned.
+     * Cancels the event by returning the cancel symbol.
      * 
-     * @since v3001.1
-     * @group Events
      * @example
      * ```js
      * onKeyPress((key) => {
-     *     if (key === "q") return k.cancel();
+     *     if (key === "q") return cancel();
      * });
      * ```
+     * 
+     * @returns The cancel event symbol.
+     * @since v3001.1
+     * @group Events
      */
     cancel: () => Symbol,
     /**

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,3 +1,5 @@
+import { EVENT_CANCEL_SYMBOL } from "../constants";
+
 export class Registry<T> extends Map<number, T> {
     private lastID: number = 0;
     push(v: T): number {
@@ -64,14 +66,18 @@ export class KEventController {
 }
 
 export class KEvent<Args extends any[] = any[]> {
-    private handlers: Registry<(...args: Args) => void> = new Registry();
+    private cancellers: WeakMap<(...args: Args) => unknown, () => void> = new WeakMap();
+    private handlers: Registry<(...args: Args) => unknown> = new Registry();
 
-    add(action: (...args: Args) => void): KEventController {
-        const cancel = this.handlers.pushd((...args: Args) => {
+    add(action: (...args: Args) => unknown): KEventController {
+        function handler(...args: Args) {
             if (ev.paused) return;
-            action(...args);
-        });
+            return action(...args);
+        }
+
+        const cancel = this.handlers.pushd(handler);
         const ev = new KEventController(cancel);
+        this.cancellers.set(handler, cancel);
         return ev;
     }
     addOnce(
@@ -87,7 +93,13 @@ export class KEvent<Args extends any[] = any[]> {
         return new Promise((res) => this.addOnce(res));
     }
     trigger(...args: Args) {
-        this.handlers.forEach((action) => action(...args));
+        this.handlers.forEach((action) => {
+            const result = action(...args);
+            let cancel;
+
+            if (result === EVENT_CANCEL_SYMBOL && (cancel = this.cancellers.get(action)))
+                cancel();
+        });
     }
     numListeners(): number {
         return this.handlers.size;


### PR DESCRIPTION
## Description
Adds support for `k.cancel()`, a new way to cancel events in KAPLAY. As discussed on Discord, `k.cancel` is a method (when it could just be a property) to signify that it has an "action", to maybe help beginners better understand it.

```js
k.onKeyPress((key) => {
    if (key === "q") return k.cancel();
});
```