### PR TITLE
chore:  incorrect await example is removed from tween docs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4292,9 +4292,6 @@ export interface KAPLAYCtx<
      * ```js
      * // tween bean to mouse position
      * tween(bean.pos, mousePos(), 1, (p) => bean.pos = p, easings.easeOutBounce)
-     *
-     * // tween() returns a then-able that can be used with await
-     * await tween(bean.opacity, 1, 0.5, (val) => bean.opacity = val, easings.easeOutQuad)
      * ```
      *
      * @group Math


### PR DESCRIPTION
per @mflerackers request