### PR TITLE
doc: wrong reference

### DIFF
--- a/src/components/misc/textInput.ts
+++ b/src/components/misc/textInput.ts
@@ -4,7 +4,7 @@ import type { KEventController } from "../../utils";
 import type { TextComp } from "../draw/text";
 
 /**
- * The {@link stay `stay()`} component.
+ * The {@link textInput `textInput()`} component.
  *
  * @group Component Types
  */


### PR DESCRIPTION
textInput claimed it was the stay component