### PR TITLE
fix: parent set to null

### DIFF
--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -74,7 +74,8 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 _parent.children.splice(index, 1);
             }
             _parent = p;
-            p.children.push(this as GameObj);
+            if (p)
+                p.children.push(this as GameObj);
         },
 
         setParent(p: GameObj, opt: SetParentOpt) {
@@ -301,15 +302,15 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                             comp[k]?.();
                             onCurCompCleanup = null;
                         }
-                        : comp[<keyof typeof comp> k];
-                    gc.push(this.on(k, <any> func).cancel);
+                        : comp[<keyof typeof comp>k];
+                    gc.push(this.on(k, <any>func).cancel);
                 }
                 else {
                     if (this[k] === undefined) {
                         // assign comp fields to game obj
                         Object.defineProperty(this, k, {
-                            get: () => comp[<keyof typeof comp> k],
-                            set: (val) => comp[<keyof typeof comp> k] = val,
+                            get: () => comp[<keyof typeof comp>k],
+                            set: (val) => comp[<keyof typeof comp>k] = val,
                             configurable: true,
                             enumerable: true,
                         });
@@ -321,9 +322,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                         )?.id;
                         throw new Error(
                             `Duplicate component property: "${k}" while adding component "${comp.id}"`
-                                + (originalCompId
-                                    ? ` (originally added by "${originalCompId}")`
-                                    : ""),
+                            + (originalCompId
+                                ? ` (originally added by "${originalCompId}")`
+                                : ""),
                         );
                     }
                 }


### PR DESCRIPTION
remove() / destroy() set parent to null. the parent setter would then try to add `this` to the children of null and crash. now it doesn't.