### PR TITLE
feat: strict .use()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Replaced the Separating Axis Theorem (SAT) with the "Gilbert–Johnson–Keerthi"
   (`GJK`) distance algorithm.
 - Changed default behaviour of `kaplay({ tagsAsComponents: false })` to `false`.
+- Now if you pass a nullish value to `.use()` it throws an error
+
+## [3001.0.7] - TBD
+
+### Changed
+
+- Now you cannot pass parameters that are not a component or string to `.use()`.
+  Otherwise it will throw an error
 
 ## [3001.0.6] "Santa Events" - 2024-12-27
 

--- a/src/components/draw/text.ts
+++ b/src/components/draw/text.ts
@@ -149,7 +149,7 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
             // TODO: shouldn't run when object / ancestor is paused
             transform: obj.textTransform,
             styles: obj.textStyles,
-            indentAll: opt.indentAll
+            indentAll: opt.indentAll,
         }));
 
         if (!opt.width) {

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -253,9 +253,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 // for use add(["tag"])
                 return tags.add(comp);
             }
-            else if (typeof comp != "object") {
+            else if (!comp || typeof comp != "object") {
                 throw new Error(
-                    `You can only pass a component or a string to .use(), you passed: ${typeof comp}`,
+                    `You can only pass a component or a string to .use(), you passed a "${typeof comp}"`,
                 );
             }
 

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -74,8 +74,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 _parent.children.splice(index, 1);
             }
             _parent = p;
-            if (p)
+            if (p) {
                 p.children.push(this as GameObj);
+            }
         },
 
         setParent(p: GameObj, opt: SetParentOpt) {
@@ -248,9 +249,14 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
 
         // use a comp
         use(this: GameObj, comp: Comp) {
-            // tag
-            if (typeof comp === "string") {
+            if (typeof comp == "string") {
+                // for use add(["tag"])
                 return tags.add(comp);
+            }
+            else if (typeof comp != "object") {
+                throw new Error(
+                    `You can only pass a component or a string to .use(), you passed: ${typeof comp}`,
+                );
             }
 
             let gc = [];
@@ -261,13 +267,12 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 cleanups[comp.id] = [];
                 gc = cleanups[comp.id];
                 compStates.set(comp.id, comp);
+                // supporting tagsAsComponents
+                if (treatTagsAsComponents) tags.add(comp.id);
             }
             else {
                 anonymousCompStates.push(comp);
             }
-
-            // add component id as tag
-            if (treatTagsAsComponents) tags.add(comp.id!);
 
             for (const k in comp) {
                 if (COMP_DESC.has(k)) {
@@ -302,15 +307,15 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                             comp[k]?.();
                             onCurCompCleanup = null;
                         }
-                        : comp[<keyof typeof comp>k];
-                    gc.push(this.on(k, <any>func).cancel);
+                        : comp[<keyof typeof comp> k];
+                    gc.push(this.on(k, <any> func).cancel);
                 }
                 else {
                     if (this[k] === undefined) {
                         // assign comp fields to game obj
                         Object.defineProperty(this, k, {
-                            get: () => comp[<keyof typeof comp>k],
-                            set: (val) => comp[<keyof typeof comp>k] = val,
+                            get: () => comp[<keyof typeof comp> k],
+                            set: (val) => comp[<keyof typeof comp> k] = val,
                             configurable: true,
                             enumerable: true,
                         });
@@ -322,9 +327,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                         )?.id;
                         throw new Error(
                             `Duplicate component property: "${k}" while adding component "${comp.id}"`
-                            + (originalCompId
-                                ? ` (originally added by "${originalCompId}")`
-                                : ""),
+                                + (originalCompId
+                                    ? ` (originally added by "${originalCompId}")`
+                                    : ""),
                         );
                     }
                 }

--- a/src/gfx/draw/drawText.ts
+++ b/src/gfx/draw/drawText.ts
@@ -71,7 +71,7 @@ export type DrawTextOpt = RenderProps & {
      * If true, any (whitespace) indent on the first line of the paragraph
      * will be copied to all of the lines for those parts that text-wrap.
      */
-    indentAll?: boolean
+    indentAll?: boolean;
 };
 
 /**
@@ -120,7 +120,7 @@ export interface CharTransform {
      * will override, rather than compose with, the default styles given in {@link DrawTextOpt.transform} and by other
      * components' styles.
      */
-    override?: boolean
+    override?: boolean;
 }
 
 /**

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -350,7 +350,9 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                     lastSpace = curLine.length;
                     lastSpaceWidth = curX;
                 }
-                if (opt.indentAll && paraIndentX === undefined && /\S/.test(ch)) {
+                if (
+                    opt.indentAll && paraIndentX === undefined && /\S/.test(ch)
+                ) {
                     paraIndentX = curX;
                 }
 

--- a/tests/playtests/styleOverride.js
+++ b/tests/playtests/styleOverride.js
@@ -8,10 +8,10 @@ add([
         },
         styles: {
             foo: {
-                color: RED
-            }
-        }
-    })
+                color: RED,
+            },
+        },
+    }),
 ]);
 
 add([
@@ -23,10 +23,10 @@ add([
         styles: {
             foo: {
                 color: RED,
-                override: true
-            }
-        }
-    })
+                override: true,
+            },
+        },
+    }),
 ]);
 
 add([
@@ -35,9 +35,9 @@ add([
         styles: {
             foo: {
                 color: RED,
-                override: true
-            }
-        }
+                override: true,
+            },
+        },
     }),
     color(WHITE.darken(200)),
 ]);

--- a/tests/playtests/textwrap.js
+++ b/tests/playtests/textwrap.js
@@ -4,7 +4,7 @@ const theText = `MAN PAGE
     Very long description paragraph. Very long description paragraph. Very long description paragraph. Very long description paragraph. Very long description paragraph. Very long description paragraph. Very long description paragraph.
 
 ANOTHER SECTION
-    Yet some more text here. Yet some more text here. Yet some more text here. Yet some more text here.`
+    Yet some more text here. Yet some more text here. Yet some more text here. Yet some more text here.`;
 
 add([
     pos(100, 100),
@@ -19,6 +19,6 @@ add([
     text(theText, {
         size: 16,
         width: 17 * 16,
-        indentAll: true
+        indentAll: true,
     }),
 ]);


### PR DESCRIPTION
This changes applies for both versions, v3001 and v4000 and makes strict() only acceept type object or string, otherwise will throw an error. I hope it will help with cases like passing smt is returning undefined, or an extra comma.