### PR TITLE
feat: added option for sprites to be imported as a separate texture

### DIFF
--- a/src/assets/sprite.ts
+++ b/src/assets/sprite.ts
@@ -67,6 +67,10 @@ export interface LoadSpriteOpt {
      * Animation configuration.
      */
     anims?: SpriteAnims;
+    /**
+     * If the sprite is a single image.
+     */
+    singular?: boolean;
 }
 
 export type NineSlice = {
@@ -135,7 +139,7 @@ export class SpriteData {
         data: ImageSource,
         opt: LoadSpriteOpt = {},
     ): SpriteData {
-        const [tex, quad, packerId] = _k.assets.packer.add(data);
+        const [tex, quad, packerId] = opt.singular ? _k.assets.packer.add_single(data) : _k.assets.packer.add(data);
         const frames = opt.frames
             ? opt.frames.map((f) =>
                 new Quad(

--- a/src/gfx/classes/TexPacker.ts
+++ b/src/gfx/classes/TexPacker.ts
@@ -32,11 +32,16 @@ export default class TexPacker {
         this.c2d = context2D;
     }
 
+    // create a image with a single texture
+    add_single(img: ImageSource): [Texture, Quad, number] {
+        const tex = Texture.fromImage(this.gfx, img);
+        this.bigTextures.push(tex);
+        return [tex, new Quad(0, 0, 1, 1), 0];
+    }
+
     add(img: ImageSource): [Texture, Quad, number] {
         if (img.width > this.canvas.width || img.height > this.canvas.height) {
-            const tex = Texture.fromImage(this.gfx, img);
-            this.bigTextures.push(tex);
-            return [tex, new Quad(0, 0, 1, 1), 0];
+            this.add_single(img)
         }
 
         // next row


### PR DESCRIPTION
Changed the `LoadSpriteOpt` interface to include the `singular` boolean. If this values is equal to true the sprite will be loaded as an separate texture, instead of being placed inside a texture sheet where multiple sprites are placed for optimization on texture loads.

These changes should in no way change the default behaviour.

Preview of changes:
```ts
loadSprite(
  "player",
  "sprites/player.png",
  {
    singular: true
  }
);
```

This pull request is for the v4000 version of kaplay because its closer to a feature rather than a fix. If you think this should be included in the v3001 version please comment.