### PR TITLE
fix: fix unintentional children mutation

### DIFF
--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -140,22 +140,16 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
         },
 
         remove(obj: GameObj): void {
-            const idx = this.children.indexOf(obj);
+            obj.parent = null;
 
-            if (idx !== -1) {
-                obj.parent = null;
-                this.children.splice(idx, 1);
+            const trigger = (o: GameObj) => {
+                o.trigger("destroy");
+                _k.game.events.trigger("destroy", o);
+                o.children.forEach((child) => trigger(child));
+            };
 
-                const trigger = (o: GameObj) => {
-                    o.trigger("destroy");
-                    _k.game.events.trigger("destroy", o);
-                    o.children.forEach((child) => trigger(child));
-                };
-
-                trigger(obj);
-            }
+            trigger(obj);
         },
-
         // TODO: recursive
         removeAll(this: GameObj, tag?: Tag) {
             if (tag) {


### PR DESCRIPTION
In #562, a setter method for the `parent` property was introduced. This setter uses a `.splice` call to modify the children of the game object. However, in the `remove` game object method, we first set the parent to null, which triggers 1 splice call. Immediately after setting the parent to null, we perform another splice call. This is problematic because it results in 2 game objects being removed instead of 1.

Steps to reproduce:

- Use the current `master` branch
- Create a game with at least 2 game objects.
- Delete the game object that was created first

Example:

```js
const a = add([
	text("test 1", {
		size: 50
	}),
	color("#ff0000"),
	pos(width() / 2, height() / 2),
	fixed()
])

const b = add([
	text("test 2", {
		size: 50
	}),
	color("#ff0000"),
	pos(width() / 2, height() / 2 + 50),
	fixed()
])

a.destroy() // Results in both A and B being deleted
```