### PR TITLE
fix: Update platformEffector.js for tag methods

### DIFF
--- a/examples/platformEffector.js
+++ b/examples/platformEffector.js
@@ -78,7 +78,7 @@ onKeyDown("right", () => {
 // Fall through when down is pressed
 onKeyDown("down", () => {
     const p = player.curPlatform();
-    if (p != null && p.is("platformEffector")) {
+    if (p != null && p.has("platformEffector")) {
         p.platformIgnore.add(player);
     }
 });


### PR DESCRIPTION
It was using .is() with a component ID. In v4000 this doesn't work anymore.