### PR TITLE
fix: change collisionIgnore to set to speed up collsion testing

### DIFF
--- a/src/components/physics/area.ts
+++ b/src/components/physics/area.ts
@@ -16,9 +16,8 @@ import {
     Polygon,
     Rect,
     rgb,
-    testPolygonPoint,
     Vec2,
-    vec2,
+    vec2
 } from "../../math";
 import type {
     Collision,
@@ -71,7 +70,7 @@ export interface AreaComp extends Comp {
      *
      * @since v3000.0
      */
-    collisionIgnore: Tag[];
+    collisionIgnore: Set<Tag>;
     restitution?: number;
     friction?: number;
     /**
@@ -261,7 +260,7 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
 
     return {
         id: "area",
-        collisionIgnore: opt.collisionIgnore ?? [],
+        collisionIgnore: new Set(opt.collisionIgnore ?? []),
         restitution: opt.restitution,
         friction: opt.friction,
 
@@ -596,9 +595,8 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
                 return `area: ${this.area.scale?.x?.toFixed(1)}x`;
             }
             else {
-                return `area: (${this.area.scale?.x?.toFixed(1)}x, ${
-                    this.area.scale.y?.toFixed(1)
-                }y)`;
+                return `area: (${this.area.scale?.x?.toFixed(1)}x, ${this.area.scale.y?.toFixed(1)
+                    }y)`;
             }
         },
     };

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -111,6 +111,10 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
             return paused;
         },
 
+        get tagsAsSet() {
+            return tags;
+        },
+
         get tags() {
             return Array.from(tags);
         },

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -825,16 +825,8 @@ const kaplay = <
     ): boolean {
         if (other.paused) return false;
         if (!other.exists()) return false;
-        for (const tag of obj.collisionIgnore) {
-            if (other.is(tag)) {
-                return false;
-            }
-        }
-        for (const tag of other.collisionIgnore) {
-            if (obj.is(tag)) {
-                return false;
-            }
-        }
+        if (obj.collisionIgnore.intersection(other.tagsAsSet).size > 0) return false;
+        if (other.collisionIgnore.intersection(obj.tagsAsSet).size > 0) return false;
         const res = gjkShapeIntersection(
             obj.worldArea(),
             other.worldArea(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -6144,6 +6144,13 @@ export interface GameObjRaw {
      */
     tags: string[];
     /**
+     * @readonly
+     * Get the tags of a game object as a set, for faster comparison.
+     *
+     * @since v4000.0
+     */
+    tagsAsSet: Set<string>;
+    /**
      * Update this game object and all children game objects.
      *
      * @since v3001.0

--- a/tests/playtests/collisionIgnore.js
+++ b/tests/playtests/collisionIgnore.js
@@ -1,0 +1,20 @@
+kaplay();
+loadBean();
+
+var n = 1000;
+function randomTagsList() {
+    return new Array(5).fill().map(() => (++n).toString());
+}
+
+for (var i = 0; i < 500; i++) {
+    add([
+        sprite("bean"),
+        pos(rand(vec2(0), vec2(100))),
+        area({ collisionIgnore: randomTagsList() }),
+        ...randomTagsList(),
+    ]);
+}
+
+onUpdate(() => {
+    debug.log(debug.fps());
+});


### PR DESCRIPTION
The new playtest is supposed to test the performance of collsionIgnore checking, but for some reason I haven't noticed very much speedup using that test. Maybe it is just a lousy test.