### PR TITLE
perf: make events somewhat faster

### DIFF
--- a/examples/curves.js
+++ b/examples/curves.js
@@ -4,12 +4,12 @@ kaplay();
 
 function addPoint(c, ...args) {
     return add([
-        "point",
         rect(8, 8),
         anchor("center"),
         pos(...args),
         area(),
         color(c),
+        "point",
     ]);
 }
 

--- a/src/events/globalEvents.ts
+++ b/src/events/globalEvents.ts
@@ -41,7 +41,7 @@ export function on<Ev extends GameObjEventNames>(
             obj2Handler.delete(obj);
         }
     });
-    _k.game.root.get("*", { recursive: true }).forEach(handleNew);
+    _k.game.root.get(tag, { recursive: true }).forEach(handleNew);
 
 
     return {

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -49,9 +49,6 @@ export const initGame = () => {
             sceneEnter: [string];
         }>(),
 
-        // object events
-        objEvents: new KEventHandler<GameObjEvents>(),
-
         // root game object
         root: make([]) as GameObj<TimerComp>,
 

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -1,6 +1,5 @@
 import type { Asset } from "../assets";
 import type { TimerComp } from "../components";
-import type { GameObjEventMap, GameObjEvents } from "../events";
 import { Mat23, Vec2 } from "../math/math";
 import { type GameObj, type Key, type MouseButton } from "../types";
 import { KEventHandler } from "../utils";

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -17,7 +17,7 @@ import {
 } from "../gfx";
 import { _k } from "../kaplay";
 import { Mat23 } from "../math/math";
-import { calcTransform } from "../math/various";
+import { calcTransform } from "../math";
 import {
     type Comp,
     type CompList,
@@ -27,8 +27,7 @@ import {
     type QueryOpt,
     type Tag,
 } from "../types";
-import { KEventController, KEventHandler, uid } from "../utils";
-import type { Game } from "./game";
+import { KEvent, KEventController, KEventHandler, uid } from "../utils";
 
 export enum KeepFlags {
     Pos = 1,
@@ -46,6 +45,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
     const anonymousCompStates: Comp[] = [];
     const cleanups = {} as Record<string, (() => unknown)[]>;
     const events = new KEventHandler();
+    const fixedUpdateEvents = new KEvent<[]>();
+    const updateEvents = new KEvent<[]>();
+    const drawEvents = new KEvent<[]>();
     const inputEvents: KEventController[] = [];
     const tags = new Set<Tag>("*");
     const treatTagsAsComponents = _k.globalOpt.tagsAsComponents;
@@ -165,7 +167,8 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
             this.children
                 /*.sort((o1, o2) => (o1.z ?? 0) - (o2.z ?? 0))*/
                 .forEach((child) => child.fixedUpdate());
-            this.trigger("fixedUpdate");
+            fixedUpdateEvents.trigger();
+            _k.game.objEvents.trigger("fixedUpdate", this);
         },
 
         update(this: GameObj) {
@@ -173,7 +176,8 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
             this.children
                 /*.sort((o1, o2) => (o1.z ?? 0) - (o2.z ?? 0))*/
                 .forEach((child) => child.update());
-            this.trigger("update");
+            updateEvents.trigger();
+            _k.game.objEvents.trigger("update", this);
         },
 
         draw(
@@ -211,11 +215,13 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                         children[i].draw();
                     }
                 }, () => {
-                    this.trigger("draw");
+                    drawEvents.trigger();
+                    _k.game.objEvents.trigger("draw", this);
                 });
             }
             else {
-                this.trigger("draw");
+                drawEvents.trigger();
+                _k.game.objEvents.trigger("draw", this);
                 for (let i = 0; i < children.length; i++) {
                     children[i].draw();
                 }
@@ -642,7 +648,14 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
             name: string,
             action: (...args: unknown[]) => void,
         ): KEventController {
-            const ctrl = events.on(name, action.bind(this));
+            const ctrl = ((func) => {
+                switch (name) {
+                    case "fixedUpdate": return fixedUpdateEvents.add(func);
+                    case "update": return updateEvents.add(func);
+                    case "draw": return drawEvents.add(func);
+                    default: return events.on(name, func);
+                }
+            })(action.bind(this));
             if (onCurCompCleanup) {
                 onCurCompCleanup(() => ctrl.cancel());
             }
@@ -716,6 +729,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
 
         clearEvents() {
             events.clear();
+            fixedUpdateEvents.clear();
+            updateEvents.clear();
+            drawEvents.clear();
         },
     };
 

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -168,7 +168,6 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 /*.sort((o1, o2) => (o1.z ?? 0) - (o2.z ?? 0))*/
                 .forEach((child) => child.fixedUpdate());
             fixedUpdateEvents.trigger();
-            _k.game.objEvents.trigger("fixedUpdate", this);
         },
 
         update(this: GameObj) {
@@ -177,7 +176,6 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 /*.sort((o1, o2) => (o1.z ?? 0) - (o2.z ?? 0))*/
                 .forEach((child) => child.update());
             updateEvents.trigger();
-            _k.game.objEvents.trigger("update", this);
         },
 
         draw(
@@ -216,12 +214,10 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                     }
                 }, () => {
                     drawEvents.trigger();
-                    _k.game.objEvents.trigger("draw", this);
                 });
             }
             else {
                 drawEvents.trigger();
-                _k.game.objEvents.trigger("draw", this);
                 for (let i = 0; i < children.length; i++) {
                     children[i].draw();
                 }
@@ -664,7 +660,6 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
 
         trigger(name: string, ...args: unknown[]): void {
             events.trigger(name, ...args);
-            _k.game.objEvents.trigger(name, this, ...args);
         },
 
         destroy() {

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -16,8 +16,8 @@ import {
     pushTranslateV,
 } from "../gfx";
 import { _k } from "../kaplay";
-import { Mat23 } from "../math/math";
 import { calcTransform } from "../math";
+import { Mat23 } from "../math/math";
 import {
     type Comp,
     type CompList,
@@ -247,6 +247,8 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
         use(this: GameObj, comp: Comp) {
             if (typeof comp == "string") {
                 // for use add(["tag"])
+                this.trigger("tag", comp);
+                _k.game.events.trigger("tag", this, comp);
                 return tags.add(comp);
             }
             else if (!comp || typeof comp != "object") {
@@ -303,15 +305,15 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                             comp[k]?.();
                             onCurCompCleanup = null;
                         }
-                        : comp[<keyof typeof comp> k];
-                    gc.push(this.on(k, <any> func).cancel);
+                        : comp[<keyof typeof comp>k];
+                    gc.push(this.on(k, <any>func).cancel);
                 }
                 else {
                     if (this[k] === undefined) {
                         // assign comp fields to game obj
                         Object.defineProperty(this, k, {
-                            get: () => comp[<keyof typeof comp> k],
-                            set: (val) => comp[<keyof typeof comp> k] = val,
+                            get: () => comp[<keyof typeof comp>k],
+                            set: (val) => comp[<keyof typeof comp>k] = val,
                             configurable: true,
                             enumerable: true,
                         });
@@ -323,9 +325,9 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                         )?.id;
                         throw new Error(
                             `Duplicate component property: "${k}" while adding component "${comp.id}"`
-                                + (originalCompId
-                                    ? ` (originally added by "${originalCompId}")`
-                                    : ""),
+                            + (originalCompId
+                                ? ` (originally added by "${originalCompId}")`
+                                : ""),
                         );
                     }
                 }

--- a/src/game/scenes.ts
+++ b/src/game/scenes.ts
@@ -22,7 +22,6 @@ export function go(name: SceneName, ...args: unknown[]) {
         _k.game.events.trigger("sceneLeave", name);
         _k.app.events.clear();
         _k.game.events.clear();
-        _k.game.objEvents.clear();
 
         [..._k.game.root.children].forEach((obj) => {
             if (


### PR DESCRIPTION
Hopefully this should make the evnt system a little faster, the tag-based events in particular.

Previously tag-baed events fired on all objects, but just returned early if the object wasn't the right tag; now, using the onTag and onUntag events the handlers are dynamically added and removed when tags change, reducing the overhead on each handler.

The big 3 per-frame events (onUpdate, onfixedUpdate, and onDraw) and also now handled using inlined `KEvent`s so that the routing overhead and extra function calls of looking up the named event handler in `KEventHandler` goes away.