### PR TITLE
fix: make offscreen component able to change the offscreen distance

### DIFF
--- a/src/components/transform/offscreen.ts
+++ b/src/components/transform/offscreen.ts
@@ -107,11 +107,11 @@ export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
                 selfRect.pos = this.pos;
                 return selfRect.collides(screenRect);
             }
-            const sdist = Math.pow(this.offscreenDistance
+            const dist = this.offscreenDistance
                 ? this.offscreenDistance
-                : DEF_OFFSCREEN_DIS, 2);
+                : DEF_OFFSCREEN_DIS;
             return !testRectPoint(screenRect, pos)
-                && screenRect.sdistToPoint(pos) > sdist;
+                && screenRect.sdistToPoint(pos) > (dist * dist);
         },
         onExitScreen(this: GameObj, action: () => void): KEventController {
             return this.on("exitView", action);

--- a/src/components/transform/offscreen.ts
+++ b/src/components/transform/offscreen.ts
@@ -13,6 +13,10 @@ import type { PosComp } from "./pos";
  */
 export interface OffScreenComp extends Comp {
     /**
+     * The minimum distance that the object must be off the screen by to be considered "offscreen".
+     */
+    offscreenDistance: number;
+    /**
      * If object is currently out of view.
      */
     isOffScreen(): boolean;
@@ -57,7 +61,6 @@ export interface OffScreenCompOpt {
 }
 
 export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
-    const distance = opt.distance ?? DEF_OFFSCREEN_DIS;
     let isOut = false;
 
     const check = (self: GameObj<OffScreenComp>) => {
@@ -83,7 +86,8 @@ export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
     return {
         id: "offscreen",
         require: ["pos"],
-        isOffScreen(this: GameObj<PosComp>): boolean {
+        offscreenDistance: opt.distance ?? DEF_OFFSCREEN_DIS,
+        isOffScreen(this: GameObj<PosComp | OffScreenComp>): boolean {
             const pos = this.screenPos();
 
             // This is not possible, screenPos() without arguments returns the pos
@@ -91,7 +95,7 @@ export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
 
             const screenRect = new Rect(vec2(0), width(), height());
             return !testRectPoint(screenRect, pos)
-                && screenRect.sdistToPoint(pos) > distance * distance;
+                && screenRect.sdistToPoint(pos) > this.offscreenDistance * this.offscreenDistance;
         },
         onExitScreen(this: GameObj, action: () => void): KEventController {
             return this.on("exitView", action);

--- a/src/components/transform/offscreen.ts
+++ b/src/components/transform/offscreen.ts
@@ -66,6 +66,8 @@ export interface OffScreenCompOpt {
 
 export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
     let isOut = false;
+    const screenRect = new Rect(vec2(0), width(), height());
+    const selfRect = new Rect(vec2(0), 0, 0);
 
     const check = (self: GameObj<OffScreenComp>) => {
         if (self.isOffScreen()) {
@@ -97,9 +99,12 @@ export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
             // This is not possible, screenPos() without arguments returns the pos
             if (!pos) return false;
 
-            const screenRect = new Rect(vec2(0), width(), height());
+            screenRect.width = width();
+            screenRect.height = height();
             if (!this.offscreenDistance && this.width && this.height) {
-                const selfRect = new Rect(pos, this.width, this.height);
+                selfRect.width = this.width;
+                selfRect.height = this.height;
+                selfRect.pos = this.pos;
                 return selfRect.collides(screenRect);
             }
             const sdist = Math.pow(this.offscreenDistance


### PR DESCRIPTION
if the object size is changed to be greater than the initially specified offscreen distance, then this allows the offscreen distance to be changed so it won't actually disappear until it goes offscreen. additionally the object will use whether its bounding rectangle is truly offscreen if the distance is not specified.