### PR TITLE
Fix Debug UI size on small `letterbox` resolution

### DIFF
--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -52,161 +52,161 @@ export function drawDebug() {
     }
 
     if (_k.debug.paused) {
-            // top right corner
-            pushTransform();
-            pushTranslate(width(), 0);
-            pushTranslate(-8, 8);
+        // top right corner
+        pushTransform();
+        pushTranslate(width(), 0);
+        pushTranslate(-8, 8);
 
-            const size = 32;
+        const size = 32;
 
-            // bg
+        // bg
+        drawRect({
+            width: size,
+            height: size,
+            anchor: "topright",
+            color: rgb(0, 0, 0),
+            opacity: 0.8,
+            radius: 4,
+            fixed: true,
+        });
+
+        // pause icon
+        for (let i = 1; i <= 2; i++) {
             drawRect({
-                width: size,
-                height: size,
-                anchor: "topright",
-                color: rgb(0, 0, 0),
-                opacity: 0.8,
-                radius: 4,
+                width: 4,
+                height: size * 0.6,
+                anchor: "center",
+                pos: vec2(-size / 3 * i, size * 0.5),
+                color: rgb(255, 255, 255),
+                radius: 2,
                 fixed: true,
             });
+        }
 
-            // pause icon
-            for (let i = 1; i <= 2; i++) {
-                drawRect({
-                    width: 4,
-                    height: size * 0.6,
-                    anchor: "center",
-                    pos: vec2(-size / 3 * i, size * 0.5),
-                    color: rgb(255, 255, 255),
-                    radius: 2,
-                    fixed: true,
-                });
-            }
-
-            popTransform();
+        popTransform();
     }
 
     if (_k.debug.timeScale !== 1) {
-            // bottom right corner
-            pushTransform();
-            pushTranslate(width(), height());
-            pushTranslate(-8, -8);
+        // bottom right corner
+        pushTransform();
+        pushTranslate(width(), height());
+        pushTranslate(-8, -8);
 
-            const pad = 8;
+        const pad = 8;
 
-            // format text first to get text size
-            const ftxt = formatText({
-                text: _k.debug.timeScale.toFixed(1),
-                font: DBG_FONT,
-                size: 16,
+        // format text first to get text size
+        const ftxt = formatText({
+            text: _k.debug.timeScale.toFixed(1),
+            font: DBG_FONT,
+            size: 16,
+            color: rgb(255, 255, 255),
+            pos: vec2(-pad),
+            anchor: "botright",
+            fixed: true,
+        });
+
+        // bg
+        drawRect({
+            width: ftxt.width + pad * 2 + pad * 4,
+            height: ftxt.height + pad * 2,
+            anchor: "botright",
+            color: rgb(0, 0, 0),
+            opacity: 0.8,
+            radius: 4,
+            fixed: true,
+        });
+
+        // fast forward / slow down icon
+        for (let i = 0; i < 2; i++) {
+            const flipped = _k.debug.timeScale < 1;
+            drawTriangle({
+                p1: vec2(-ftxt.width - pad * (flipped ? 2 : 3.5), -pad),
+                p2: vec2(
+                    -ftxt.width - pad * (flipped ? 2 : 3.5),
+                    -pad - ftxt.height,
+                ),
+                p3: vec2(
+                    -ftxt.width - pad * (flipped ? 3.5 : 2),
+                    -pad - ftxt.height / 2,
+                ),
+                pos: vec2(-i * pad * 1 + (flipped ? -pad * 0.5 : 0), 0),
                 color: rgb(255, 255, 255),
-                pos: vec2(-pad),
-                anchor: "botright",
                 fixed: true,
             });
+        }
 
-            // bg
-            drawRect({
-                width: ftxt.width + pad * 2 + pad * 4,
-                height: ftxt.height + pad * 2,
-                anchor: "botright",
-                color: rgb(0, 0, 0),
-                opacity: 0.8,
-                radius: 4,
-                fixed: true,
-            });
+        // text
+        drawFormattedText(ftxt);
 
-            // fast forward / slow down icon
-            for (let i = 0; i < 2; i++) {
-                const flipped = _k.debug.timeScale < 1;
-                drawTriangle({
-                    p1: vec2(-ftxt.width - pad * (flipped ? 2 : 3.5), -pad),
-                    p2: vec2(
-                        -ftxt.width - pad * (flipped ? 2 : 3.5),
-                        -pad - ftxt.height,
-                    ),
-                    p3: vec2(
-                        -ftxt.width - pad * (flipped ? 3.5 : 2),
-                        -pad - ftxt.height / 2,
-                    ),
-                    pos: vec2(-i * pad * 1 + (flipped ? -pad * 0.5 : 0), 0),
-                    color: rgb(255, 255, 255),
-                    fixed: true,
-                });
-            }
-
-            // text
-            drawFormattedText(ftxt);
-
-            popTransform();
+        popTransform();
     }
 
     if (_k.debug.curRecording) {
-            pushTransform();
-            pushTranslate(0, height());
-            pushTranslate(24, -24);
+        pushTransform();
+        pushTranslate(0, height());
+        pushTranslate(24, -24);
 
-            drawCircle({
-                radius: 12,
-                color: rgb(255, 0, 0),
-                opacity: wave(0, 1, _k.app.time() * 4),
-                fixed: true,
-            });
+        drawCircle({
+            radius: 12,
+            color: rgb(255, 0, 0),
+            opacity: wave(0, 1, _k.app.time() * 4),
+            fixed: true,
+        });
 
-            popTransform();
+        popTransform();
     }
 
     if (_k.debug.showLog && _k.game.logs.length > 0) {
-            pushTransform();
-            pushTranslate(0, height());
-            pushTranslate(8, -8);
+        pushTransform();
+        pushTranslate(0, height());
+        pushTranslate(8, -8);
 
-            const pad = 8;
-            const logs = [];
+        const pad = 8;
+        const logs = [];
 
-            for (const log of _k.game.logs) {
-                let str = "";
-                const style = log.msg instanceof Error ? "error" : "info";
-                str += `[time]${log.time.toFixed(2)}[/time]`;
-                str += " ";
-                str += `[${style}]${prettyDebug(log.msg)}[/${style}]`;
-                logs.push(str);
-            }
+        for (const log of _k.game.logs) {
+            let str = "";
+            const style = log.msg instanceof Error ? "error" : "info";
+            str += `[time]${log.time.toFixed(2)}[/time]`;
+            str += " ";
+            str += `[${style}]${prettyDebug(log.msg)}[/${style}]`;
+            logs.push(str);
+        }
 
-            _k.game.logs = _k.game.logs
-                .filter((log) =>
-                    _k.app.time() - log.time
-                        < (_k.globalOpt.logTime || LOG_TIME)
-                );
+        _k.game.logs = _k.game.logs
+            .filter((log) =>
+                _k.app.time() - log.time
+                    < (_k.globalOpt.logTime || LOG_TIME)
+            );
 
-            const ftext = formatText({
-                text: logs.join("\n"),
-                font: DBG_FONT,
-                pos: vec2(pad, -pad),
-                anchor: "botleft",
-                size: 16,
-                width: width() * 0.6,
-                lineSpacing: pad / 2,
-                fixed: true,
-                styles: {
-                    "time": { color: rgb(127, 127, 127) },
-                    "info": { color: rgb(255, 255, 255) },
-                    "error": { color: rgb(255, 0, 127) },
-                },
-            });
+        const ftext = formatText({
+            text: logs.join("\n"),
+            font: DBG_FONT,
+            pos: vec2(pad, -pad),
+            anchor: "botleft",
+            size: 16,
+            width: width() * 0.6,
+            lineSpacing: pad / 2,
+            fixed: true,
+            styles: {
+                "time": { color: rgb(127, 127, 127) },
+                "info": { color: rgb(255, 255, 255) },
+                "error": { color: rgb(255, 0, 127) },
+            },
+        });
 
-            drawRect({
-                width: ftext.width + pad * 2,
-                height: ftext.height + pad * 2,
-                anchor: "botleft",
-                color: rgb(0, 0, 0),
-                radius: 4,
-                opacity: 0.8,
-                fixed: true,
-            });
+        drawRect({
+            width: ftext.width + pad * 2,
+            height: ftext.height + pad * 2,
+            anchor: "botleft",
+            color: rgb(0, 0, 0),
+            radius: 4,
+            opacity: 0.8,
+            fixed: true,
+        });
 
-            drawFormattedText(ftext);
-            popTransform();
+        drawFormattedText(ftext);
+        popTransform();
     }
 }
 

--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -4,7 +4,6 @@ import { rgb } from "../../math/color";
 import { vec2, wave } from "../../math/math";
 import { formatText } from "../formatText";
 import {
-    contentToView,
     height,
     mousePos,
     popTransform,
@@ -17,7 +16,6 @@ import { drawFormattedText } from "./drawFormattedText";
 import { drawInspectText } from "./drawInspectText";
 import { drawRect } from "./drawRect";
 import { drawTriangle } from "./drawTriangle";
-import { drawUnscaled } from "./drawUnscaled";
 
 export function drawDebug() {
     if (_k.debug.inspect) {
@@ -47,14 +45,13 @@ export function drawDebug() {
                 }
             }
 
-            drawInspectText(contentToView(mousePos()), lines.join("\n"));
+            drawInspectText(mousePos(), lines.join("\n"));
         }
 
         drawInspectText(vec2(8), `FPS: ${_k.debug.fps()}`);
     }
 
     if (_k.debug.paused) {
-        drawUnscaled(() => {
             // top right corner
             pushTransform();
             pushTranslate(width(), 0);
@@ -87,11 +84,9 @@ export function drawDebug() {
             }
 
             popTransform();
-        });
     }
 
     if (_k.debug.timeScale !== 1) {
-        drawUnscaled(() => {
             // bottom right corner
             pushTransform();
             pushTranslate(width(), height());
@@ -144,11 +139,9 @@ export function drawDebug() {
             drawFormattedText(ftxt);
 
             popTransform();
-        });
     }
 
     if (_k.debug.curRecording) {
-        drawUnscaled(() => {
             pushTransform();
             pushTranslate(0, height());
             pushTranslate(24, -24);
@@ -161,11 +154,9 @@ export function drawDebug() {
             });
 
             popTransform();
-        });
     }
 
     if (_k.debug.showLog && _k.game.logs.length > 0) {
-        drawUnscaled(() => {
             pushTransform();
             pushTranslate(0, height());
             pushTranslate(8, -8);
@@ -216,7 +207,6 @@ export function drawDebug() {
 
             drawFormattedText(ftext);
             popTransform();
-        });
     }
 }
 

--- a/src/gfx/draw/drawInspectText.ts
+++ b/src/gfx/draw/drawInspectText.ts
@@ -11,43 +11,42 @@ import {
 } from "../stack";
 import { drawFormattedText } from "./drawFormattedText";
 import { drawRect } from "./drawRect";
-import { drawUnscaled } from "./drawUnscaled";
 
 export function drawInspectText(pos: Vec2, txt: string) {
-        const pad = vec2(8);
+    const pad = vec2(8);
 
-        pushTransform();
-        pushTranslate(pos);
+    pushTransform();
+    pushTranslate(pos);
 
-        const ftxt = formatText({
-            text: txt,
-            font: DBG_FONT,
-            size: 16,
-            pos: pad,
-            color: rgb(255, 255, 255),
-            fixed: true,
-        });
+    const ftxt = formatText({
+        text: txt,
+        font: DBG_FONT,
+        size: 16,
+        pos: pad,
+        color: rgb(255, 255, 255),
+        fixed: true,
+    });
 
-        const bw = ftxt.width + pad.x * 2;
-        const bh = ftxt.height + pad.x * 2;
+    const bw = ftxt.width + pad.x * 2;
+    const bh = ftxt.height + pad.x * 2;
 
-        if (pos.x + bw >= width()) {
-            pushTranslate(vec2(-bw, 0));
-        }
+    if (pos.x + bw >= width()) {
+        pushTranslate(vec2(-bw, 0));
+    }
 
-        if (pos.y + bh >= height()) {
-            pushTranslate(vec2(0, -bh));
-        }
+    if (pos.y + bh >= height()) {
+        pushTranslate(vec2(0, -bh));
+    }
 
-        drawRect({
-            width: bw,
-            height: bh,
-            color: rgb(0, 0, 0),
-            radius: 4,
-            opacity: 0.8,
-            fixed: true,
-        });
+    drawRect({
+        width: bw,
+        height: bh,
+        color: rgb(0, 0, 0),
+        radius: 4,
+        opacity: 0.8,
+        fixed: true,
+    });
 
-        drawFormattedText(ftxt);
-        popTransform();
+    drawFormattedText(ftxt);
+    popTransform();
 }

--- a/src/gfx/draw/drawInspectText.ts
+++ b/src/gfx/draw/drawInspectText.ts
@@ -14,7 +14,6 @@ import { drawRect } from "./drawRect";
 import { drawUnscaled } from "./drawUnscaled";
 
 export function drawInspectText(pos: Vec2, txt: string) {
-    drawUnscaled(() => {
         const pad = vec2(8);
 
         pushTransform();
@@ -51,5 +50,4 @@ export function drawInspectText(pos: Vec2, txt: string) {
 
         drawFormattedText(ftxt);
         popTransform();
-    });
 }


### PR DESCRIPTION
## Description
When you set a `letterbox` config with small resolution (ie: `{ width: 320, height: 240, letterbox: true }`) the debug text size is so small you can't see anything, 

![image](https://github.com/user-attachments/assets/871a2b73-6672-4537-80a0-3fb4084bd327)

Video: https://youtu.be/QuNo67Vp0pU

To deal with this I just remove all `drawUnscaled`.

I would like to mention that we can add a property to control the debug size so devs can have more control, example:
- `debug.scale = 3;`
- `debug.textSize = 24` // in pixels.

I prefer the scale way 😄