### PR TITLE
fix: wrong calculation in vector dot

### DIFF
--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -476,7 +476,7 @@ export class Vec2 {
      * @since v3000.0
      */
     static dot(v: Vec2, other: Vec2): number {
-        return v.x * v.x + v.y * v.y;
+        return v.x * other.x + v.y * other.y;
     }
 
     /**

--- a/src/math/vec3.ts
+++ b/src/math/vec3.ts
@@ -9,7 +9,7 @@ export class Vec3 {
     }
 
     dot(other: Vec3) {
-        return this.x * this.x + this.y * this.y + this.z * this.z;
+        return this.x * other.x + this.y * other.y + this.z * other.z;
     }
 
     cross(other: Vec3) {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- Read the Contributing Guide: https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md (necessary)
- Create small PRs. In most cases this will be possible.
-->

## Description

The static `dot` method on `Vec2` and the regular `dot` on `Vec3` were calculated wrongly. This PR resolved these miscalculations.
