### PR TITLE
fix: pointer lock undefined catch error for non-promise version

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -191,7 +191,7 @@ export const initApp = (opt: {
             try {
                 const res = state.canvas
                     .requestPointerLock() as unknown as Promise<void>;
-                if (res.catch) {
+                if (res?.catch) {
                     res.catch((e) => console.error(e));
                 }
             } catch (e) {


### PR DESCRIPTION
## Description

Fixes console undefined error when using [setCursorLocked()](https://kaplayjs.com/doc/ctx/setCursorLocked/#setCursorLocked). Problem is when the browser uses non-promise version of `requestPointerLock`. Code doesn't check for optional `catch` property properly.