### PR TITLE
fix: inspect view now shows the tags even after the tagsAsComponents refactor

### DIFF
--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -39,13 +39,15 @@ export function drawDebug() {
             for (const tag in data) {
                 if (data[tag]) {
                     // pushes the inspect function (eg: `sprite: "bean"`)
-                    lines.push(`${data[tag]}`);
+                    lines.push(data[tag]);
                 }
                 else {
                     // pushes only the tag (name of the component)
-                    lines.push(`${tag}`);
+                    lines.push(tag);
                 }
             }
+
+            lines.push(...inspecting.tags.map(t => `tag: ${t}`));
 
             drawInspectText(contentToView(mousePos()), lines.join("\n"));
         }


### PR DESCRIPTION
They now show as `tag: happy` instead of just `happy`, but I think that's more clear that it's a tag and not a component, now that tags are not emulated with anonymous components.

I think it's relatively unlikely that someone is going to create a custom component and give it the id "tag" and also have it make an identical inspect() value to what tags show as here.