### PR TITLE
fix: only select an object for inspecting if the object is not paused

### DIFF
--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -24,7 +24,7 @@ export function drawDebug() {
         let inspecting = null;
 
         for (const obj of _k.game.root.get("*", { recursive: true })) {
-            if (obj.c("area") && !obj.paused && obj.isHovering()) {
+            if (obj.c("area") && (_k.globalOpt.inspectOnlyActive ? !obj.paused : true) && obj.isHovering()) {
                 inspecting = obj;
                 break;
             }

--- a/src/gfx/draw/drawDebug.ts
+++ b/src/gfx/draw/drawDebug.ts
@@ -24,7 +24,7 @@ export function drawDebug() {
         let inspecting = null;
 
         for (const obj of _k.game.root.get("*", { recursive: true })) {
-            if (obj.c("area") && obj.isHovering()) {
+            if (obj.c("area") && !obj.paused && obj.isHovering()) {
                 inspecting = obj;
                 break;
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6025,6 +6025,14 @@ export interface KAPLAYOpt<
      * @default 0
      */
     spriteAtlasPadding?: number;
+    /**
+     * If the debug inspect view should ignore objects that are paused when choosing
+     * the object to show the inspect view on.
+     * 
+     * @default false
+     * @experimental
+     */
+    inspectOnlyActive?: boolean;
 }
 
 /**


### PR DESCRIPTION
I have a whole bunch of levels that are swapped in and out by pausing and unpausing them, but the debug inspect doesn't look at whether the object is paused, and the areas from the first level basically "cover" the active level and prevent me from inspecting it.

This changes it so it only inspects the unpaused objects.

@lajbel should this be changeable by a global option?