### PR TITLE
fix: catch errors for missing dependencies in object creation

### DIFF
--- a/src/components/physics/body.ts
+++ b/src/components/physics/body.ts
@@ -200,7 +200,6 @@ export function body(opt: BodyCompOpt = {}): BodyComp {
         // TODO: prefer density * area
         mass: opt.mass ?? 1,
         add(this: GameObj<PosComp | BodyComp | AreaComp>) {
-            console.log("executing body.add");
             prevPhysicsPos = this.pos.clone();
             nextPhysicsPos = this.pos.clone();
             prevDrawPos = this.pos.clone();

--- a/src/components/physics/body.ts
+++ b/src/components/physics/body.ts
@@ -200,6 +200,7 @@ export function body(opt: BodyCompOpt = {}): BodyComp {
         // TODO: prefer density * area
         mass: opt.mass ?? 1,
         add(this: GameObj<PosComp | BodyComp | AreaComp>) {
+            console.log("executing body.add");
             prevPhysicsPos = this.pos.clone();
             nextPhysicsPos = this.pos.clone();
             prevDrawPos = this.pos.clone();

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -280,12 +280,16 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
             // check for component dependencies
             const checkDeps = () => {
                 if (!comp.require) return;
-                for (const dep of comp.require) {
-                    if (!this.c(dep)) {
-                        throw new Error(
-                            `Component "${comp.id}" requires component "${dep}"`,
-                        );
+                try {
+                    for (const dep of comp.require) {
+                        if (!this.c(dep)) {
+                            throw new Error(
+                                `Component "${comp.id}" requires component "${dep}"`,
+                            );
+                        }
                     }
+                } catch (e) {
+                    _k.handleErr(e);
                 }
             };
 

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -127,7 +127,12 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
             obj.parent = this;
             calcTransform(obj, obj.transform);
             // TODO: trigger add for children
-            obj.trigger("add", obj);
+
+            try {
+                obj.trigger("add", obj);
+            } catch (e) {
+                _k.handleErr(e);
+            }
             _k.game.events.trigger("add", obj);
             return obj;
         },
@@ -272,6 +277,41 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                 anonymousCompStates.push(comp);
             }
 
+            // check for component dependencies
+            const checkDeps = () => {
+                if (!comp.require) return;
+                for (const dep of comp.require) {
+                    if (!this.c(dep)) {
+                        throw new Error(
+                            `Component "${comp.id}" requires component "${dep}"`,
+                        );
+                    }
+                }
+            };
+
+            if (comp.destroy) {
+                gc.push(comp.destroy.bind(this));
+            }
+
+            // manually trigger add event if object already exist
+            if (this.exists()) {
+                checkDeps();
+                if (comp.add) {
+                    onCurCompCleanup = (c: any) => gc.push(c);
+                    comp.add.call(this);
+                    onCurCompCleanup = null;
+                }
+                if (comp.id) {
+                    this.trigger("use", comp.id);
+                    _k.game.events.trigger("use", this, comp.id);
+                }
+            }
+            else {
+                if (comp.require) {
+                    gc.push(this.on("add", checkDeps).cancel);
+                }
+            }
+
             for (const k in comp) {
                 if (COMP_DESC.has(k)) {
                     continue;
@@ -330,41 +370,6 @@ export function make<T>(comps: CompList<T> = []): GameObj<T> {
                                     : ""),
                         );
                     }
-                }
-            }
-
-            // check for component dependencies
-            const checkDeps = () => {
-                if (!comp.require) return;
-                for (const dep of comp.require) {
-                    if (!this.c(dep)) {
-                        throw new Error(
-                            `Component "${comp.id}" requires component "${dep}"`,
-                        );
-                    }
-                }
-            };
-
-            if (comp.destroy) {
-                gc.push(comp.destroy.bind(this));
-            }
-
-            // manually trigger add event if object already exist
-            if (this.exists()) {
-                checkDeps();
-                if (comp.add) {
-                    onCurCompCleanup = (c: any) => gc.push(c);
-                    comp.add.call(this);
-                    onCurCompCleanup = null;
-                }
-                if (comp.id) {
-                    this.trigger("use", comp.id);
-                    _k.game.events.trigger("use", this, comp.id);
-                }
-            }
-            else {
-                if (comp.require) {
-                    gc.push(this.on("add", checkDeps).cancel);
                 }
             }
         },

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -329,6 +329,9 @@ export const _k = {
     ],
 } as unknown as KAPLAYInternal;
 
+// If KAPLAY crashed
+let crashed = false;
+
 /**
  * Initialize KAPLAY context. The starting point of all KAPLAY games.
  *
@@ -769,7 +772,6 @@ const kaplay = <
     }
 
     function updateFrame() {
-        // update every obj
         game.root.update();
     }
 
@@ -1006,15 +1008,20 @@ const kaplay = <
     }
 
     function handleErr(err: Error) {
+        if (crashed) return;
+        crashed = true;
         console.error(err);
         audio.ctx.suspend();
         const errorMessage = err.message ?? String(err)
             ?? "Unknown error, check console for more info";
+        let errorScreen = false;
 
-        // TODO: this should only run once
         app.run(
             () => {},
             () => {
+                if (errorScreen) return;
+                errorScreen = true;
+
                 frameStart();
 
                 drawUnscaled(() => {
@@ -1163,6 +1170,7 @@ const kaplay = <
                         ) {
                             sys.run();
                         }
+
                         updateFrame();
 
                         for (

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -316,6 +316,7 @@ export const _k = {
     gscale: null,
     kaSprite: null,
     boomSprite: null,
+    handleErr: null,
     systems: [], // all systems added
     // we allocate systems
     systemsByEvent: [
@@ -1063,6 +1064,8 @@ const kaplay = <
             },
         );
     }
+
+    _k.handleErr = handleErr;
 
     function onCleanup(action: () => void) {
         gc.push(action);

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export type KAPLAYInternal = {
     boomSprite: Asset<SpriteData>;
     systems: System[];
     systemsByEvent: System[][];
+    handleErr: (e: any) => void;
 };
 
 /**

--- a/tests/playtests/missing_comps.js
+++ b/tests/playtests/missing_comps.js
@@ -1,0 +1,10 @@
+// Test when a component is missing
+
+const k = kaplay({});
+
+k.add([
+    k.body(),
+]);
+
+
+

--- a/tests/playtests/missing_comps_dynamic.js
+++ b/tests/playtests/missing_comps_dynamic.js
@@ -1,4 +1,4 @@
-// Test when a dependency is missing on obj creation
+// Test when a dependency is missing on obj.use()
 
 const k = kaplay({});
 
@@ -8,9 +8,7 @@ k.onError((e) => {
     }
 });
 
-k.add([
-    k.body(),
-]);
+const dummy = k.add([]);
 
-
+dummy.use(body());
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- Read the Contributing Guide: https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md (necessary)
- Create small PRs. In most cases this will be possible.
-->

## Description

Looks like before and from Kaboom.js, errors in object creation weren't taked in account, so I've added a try catch block for it. The second thing it's that the event that checks dependencies was being running after the comp.add who depends of a dependency, so the first error appearing always was smt like `this.pos it's undefined` (for require: ["pos"] cases)

So the effects of this PR are:

- Add error screen for obj creation errores
- Add the `checkDeps` event before `comp.add`
- Move `handleErr` (the bluescreen func) to `_k`
- Now `handleErr`, error screen and onError it's executed once (as an old TODO wanted)

I added handleErr directly on `checkDeps`, because you can also run checkDeps using `.use` and that not being handled by any event

### Issues or related

<!--
For pull requests that relate or close an issue, please include them
below.

The text `closes #1234` will connect the current PR to that issue, it also closes
the issue when the PR is merged.
-->

- Closes #637 
