### PR TITLE
chore: correct misspelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Collections of games made with KAPLAY (and Kaboom), selected by KAPLAY:
 - Thanks to [Pixabay](https://pixabay.com/users/pixabay-1/) for the great
   [burp](https://pixabay.com/sound-effects/burp-104984/) sound, used in `burp()`
   function
-- Thansk to [Kenney](https://kenney.nl/) for all used assets for examples
+- Thanks to [Kenney](https://kenney.nl/) for all used assets for examples
   - [Impact Sound Pack](https://kenney.nl/assets/impact-sounds)
   - [1-Bit Platformer Pack](https://kenney.nl/assets/1-bit-platformer-pack)
 - Thanks to [abrudz](https://github.com/abrudz) for the amazing


### PR DESCRIPTION
## Description
The `README.md` file misspells "thanks" as "thansk"
