### PR TITLE
test: add tests to type inferance in Game Obj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src-tauri/target/
 replit.nix
 /.obsidian
 .pnpm-store
+tsconfig.vitest-temp.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "/src/components/misc",
     "/src/components/physics",
     "/src/components/transform"
-  ]
+  ],
+  "typescript.preferences.importModuleSpecifier": "shortest"
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fmt": "dprint fmt",
     "test": "node scripts/test.js",
     "doc-dts": "dts-bundle-generator -o dist/doc.d.ts dist/declaration/index.d.ts",
-    "test:vite": "vitest",
+    "test:vite": "vitest --typecheck",
     "desktop": "tauri dev",
     "prepare": "npm run build",
     "publish:next": "npm publish --tag next"

--- a/src/types.ts
+++ b/src/types.ts
@@ -721,10 +721,10 @@ export interface KAPLAYCtx<
     uvquad(w: number, h: number): UVQuadComp;
     /**
      * Draws a video.
-     * 
+     *
      * @param url The video to play. Needs to be on the same webserver due to CORS.
      * @param opt The video component options
-     * 
+     *
      * @returns The video comp.
      * @since v4000.0
      * @group Components
@@ -732,9 +732,9 @@ export interface KAPLAYCtx<
     video(url: string, opt?: VideoCompOpt): VideoComp;
     /**
      * Draws a picture.
-     * 
+     *
      * @param picture The picture to draw.
-     * 
+     *
      * @returns The picture comp.
      * @since v4000.0
      * @group Components
@@ -5484,7 +5484,7 @@ export interface KAPLAYCtx<
      * Draw a canvas.
      *
      * @param opt The canvas object.
-     * 
+     *
      * @since v4000.0
      * @group Draw
      */
@@ -6089,7 +6089,7 @@ export interface KAPLAYOpt<
     /**
      * If the debug inspect view should ignore objects that are paused when choosing
      * the object to show the inspect view on.
-     * 
+     *
      * @default false
      * @experimental
      */

--- a/tests/auto/kaplay.spec.ts
+++ b/tests/auto/kaplay.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import "vitest-puppeteer";
-import "kaplay/global";
+import "../../dist/declaration/global";
 
 describe("KAPLAY Context Initialization", () => {
     beforeAll(async () => {

--- a/tests/auto/missingComps.spec.ts
+++ b/tests/auto/missingComps.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import "vitest-puppeteer";
-import "kaplay/global";
+import "../../dist/declaration/global";
 
 describe("Missing Comps", async () => {
     beforeAll(async () => {

--- a/tests/types/GameObj.test-d.ts
+++ b/tests/types/GameObj.test-d.ts
@@ -1,0 +1,111 @@
+import { describe, expectTypeOf } from "vitest";
+import type { AreaComp, ScaleComp, SpriteComp } from "../../src/";
+import { kaplay } from "../../src/kaplay";
+import type { GameObj } from "../../src/types";
+
+describe("Type Inference from add()", () => {
+    const k = kaplay();
+
+    test("add() should return GameObj<unknown>", () => {
+        const obj = k.add();
+        //     ^?
+
+        // Actually this test can give falsy true because unknown is acceptable for never
+        expectTypeOf(obj).toEqualTypeOf<GameObj<unknown>>();
+    });
+
+    test("add([]) should return GameObj<never>", () => {
+        const obj = k.add([]);
+        //     ^?
+
+        // Actually this test can give falsy true because unknown is acceptable for never
+        expectTypeOf(obj).toEqualTypeOf<GameObj<never>>();
+    });
+
+    test("add([sprite()] should return GameObj<SpriteComp>", () => {
+        const obj = k.add([
+            k.sprite("bean"),
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<SpriteComp>>();
+    });
+
+    test("add([sprite(), scale()]) should return GameObj<SpriteComp | ScaleComp>", () => {
+        const obj = k.add([
+            k.sprite("bean"),
+            k.scale(),
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<SpriteComp | ScaleComp>>();
+    });
+
+    test("add([area(), \"cat\"]) should return GameObj<AreaComp>", () => {
+        const obj = k.add([
+            k.area(),
+            "cat",
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<AreaComp>>();
+    });
+
+    test("add([make(sprite())]) should return GameObj<SpriteComp>", () => {
+        const base = k.make([
+            k.sprite("bean"),
+        ]);
+
+        const obj = k.add(base);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<SpriteComp>>();
+    });
+
+    test("add([sprite(), sprite()]) should return GameObj<SpriteComp>", () => {
+        const obj = k.add([
+            k.sprite("mark"),
+            k.sprite("bean"),
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<SpriteComp>>();
+    });
+
+    test("add([area(), { require: [] }]) shouldn't let you obj.require", () => {
+        const obj = k.add([
+            k.sprite("mark"),
+            {
+                require: ["love"],
+            },
+        ]);
+
+        // @ts-expect-error
+        obj.require; // require is removed from Types because Omit<T>
+    });
+});
+
+describe("Type Inference from make()", () => {
+    const k = kaplay();
+
+    test("make([sprite()] should return GameObj<SpriteComp>", () => {
+        const obj = k.make([
+            k.sprite("bean"),
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<SpriteComp>>();
+    });
+
+    test("make([sprite(), scale()]) should return GameObj<SpriteComp | ScaleComp>", () => {
+        const obj = k.make([
+            k.sprite("bean"),
+            k.scale(),
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<SpriteComp | ScaleComp>>();
+    });
+
+    test("make([area(), \"cat\"]) should return GameObj<AreaComp>", () => {
+        const obj = k.make([
+            k.area(),
+            "cat",
+        ]);
+
+        expectTypeOf(obj).toEqualTypeOf<GameObj<AreaComp>>();
+    });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,5 @@
+export type Expect<T extends true> = T;
+export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
+    T,
+>() => T extends Y ? 1 : 2 ? true
+    : false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
   "include": [
     "src/**/*",
     "scripts/**/*",
-    "tests/auto/color.spec.ts"
+    "tests/**/*"
   ]
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- Read the Contributing Guide: https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md (necessary)
- Create small PRs. In most cases this will be possible.
-->

## Description

MORE TESTING!

This PR is aligned to my PR fixing #645, we need tests for types in `add()` and `make()` and different returns from them. Any advice or new tests suggestions please comment here.