### PR TITLE
feat: tuple component list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`GJK`) distance algorithm.
 - Changed default behaviour of `kaplay({ tagsAsComponents: false })` to `false`.
 - Now if you pass a nullish value to `.use()` it throws an error
+- Improved TypeScript in game objects
 
 ## [3001.0.10] "Happy Colors" - TBD
 
@@ -75,7 +76,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   spritesheet - @chqs-git
   ```js
   loadSprite("player", "sprites/player.png", {
-    singular: true,
+      singular: true,
   });
   ```
 
@@ -115,7 +116,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ```js
 kaplay({
-  spriteAtlasPadding: 10, // 10 pixels of space between each sprite
+    spriteAtlasPadding: 10, // 10 pixels of space between each sprite
 });
 ```
 
@@ -139,8 +140,8 @@ kaplay({
   trigger("shoot", "target", 140);
 
   on("shoot", "target", (obj, score) => {
-    obj.destroy();
-    debug.log(140); // every bomb was 140 score points!
+      obj.destroy();
+      debug.log(140); // every bomb was 140 score points!
   });
   ```
 
@@ -149,18 +150,18 @@ kaplay({
 
   ```js
   add([
-    pos(100, 150),
-    text("With override: Hello [foo]styled[/foo] text", {
-      transform: {
-        color: BLACK, // Default text color for every character
-      },
-      styles: {
-        foo: {
-          color: RED, // [foo] will be red
-          override: true, // will override the black def color
-        },
-      },
-    }),
+      pos(100, 150),
+      text("With override: Hello [foo]styled[/foo] text", {
+          transform: {
+              color: BLACK, // Default text color for every character
+          },
+          styles: {
+              foo: {
+                  color: RED, // [foo] will be red
+                  override: true, // will override the black def color
+              },
+          },
+      }),
   ]);
   ```
 
@@ -190,9 +191,9 @@ kaplay({
 - Added `k.cancel()` to cancel the current event (**experimental**)
 - ```js
   onKeyPress("space", () => {
-    // do something
-    // cancel the event
-    return cancel();
+      // do something
+      // cancel the event
+      return cancel();
   });
   ```
 - Added `getDefaultLayer()` to get the default layer (**experimental**)
@@ -229,18 +230,18 @@ kaplay({
 
   ```js
   kaplay({
-    // bind your buttons
-    buttons: {
-      jump: {
-        keyboard: ["space", "up"],
-        keyboardCode: "Space", // you can also use key codes
-        gamepad: ["south"],
+      // bind your buttons
+      buttons: {
+          jump: {
+              keyboard: ["space", "up"],
+              keyboardCode: "Space", // you can also use key codes
+              gamepad: ["south"],
+          },
       },
-    },
   });
 
   onButtonPress("jump", () => {
-    player.jump();
+      player.jump();
   });
   ```
 
@@ -252,8 +253,8 @@ kaplay({
 
   // change the jump button in keyboard to "w"
   setButton("jump", {
-    keyboard: ["w"],
-    // gamepad binding is not changed
+      keyboard: ["w"],
+      // gamepad binding is not changed
   });
   ```
 
@@ -261,8 +262,8 @@ kaplay({
 
   ```js
   onButtonPress(() => {
-    const lastInputDevice = getLastInputDeviceType(); // keyboard, mouse or gamepad
-    // change icons, etc
+      const lastInputDevice = getLastInputDeviceType(); // keyboard, mouse or gamepad
+      // change icons, etc
   });
   ```
 
@@ -278,7 +279,7 @@ kaplay({
 
   ```js
   onKeyPress(["w", "up"], () => {
-    player.jump();
+      player.jump();
   });
   ```
 
@@ -286,7 +287,7 @@ kaplay({
 
   ```js
   onGamepadButtonPress("south", (btn, gp) => {
-    console.log(gp.index); // gamepad number on navigator's gamepad list
+      console.log(gp.index); // gamepad number on navigator's gamepad list
   });
   ```
 
@@ -344,8 +345,8 @@ kaplay({
   ```js
   // prop to animate, frames, options
   rotatingBean.animate("angle", [0, 360], {
-    duration: 2,
-    direction: "forward",
+      duration: 2,
+      direction: "forward",
   });
   ```
 
@@ -360,13 +361,13 @@ kaplay({
   ```js
   // define the layers
   layers(
-    [
-      "bg",
+      [
+          "bg",
+          "game",
+          "ui",
+          // the default layer
+      ],
       "game",
-      "ui",
-      // the default layer
-    ],
-    "game"
   );
 
   // use the layer component
@@ -386,14 +387,14 @@ kaplay({
 
   ```js
   loadSprite("bean", "bean.png", {
-    sliceX: 4,
-    sliceY: 1,
-    anims: {
-      walk: {
-        from: 0,
-        to: 3,
+      sliceX: 4,
+      sliceY: 1,
+      anims: {
+          walk: {
+              from: 0,
+              to: 3,
+          },
       },
-    },
   });
 
   const obj = add([sprite("bean")]);
@@ -421,9 +422,9 @@ kaplay({
 
   ```js
   add([
-    rect(100, 100, {
-      radius: [10, 20, 30, 40],
-    }),
+      rect(100, 100, {
+          radius: [10, 20, 30, 40],
+      }),
   ]);
   ```
 
@@ -483,7 +484,7 @@ kaplay({
 
   ```js
   kaplay({
-    debugKey: "l",
+      debugKey: "l",
   });
   ```
 
@@ -491,14 +492,14 @@ kaplay({
 
   ```js
   const obj = add([
-    sprite("bean"),
-    {
-      health: 100, // on debug.inspect
-      damage: 10, // on debug.inspect
-      hp() {
-        this.health -= this.damage;
-      }, // not on debug.inspect
-    },
+      sprite("bean"),
+      {
+          health: 100, // on debug.inspect
+          damage: 10, // on debug.inspect
+          hp() {
+              this.health -= this.damage;
+          }, // not on debug.inspect
+      },
   ]);
 
   // see the custom properties in debug mode
@@ -610,10 +611,10 @@ kaplay({
 
 ```js
 loadFont("apl386", "/examples/fonts/apl386.ttf", {
-  outline: {
-    width: 8,
-    color: rgb(0, 0, 255),
-  },
+    outline: {
+        width: 8,
+        color: rgb(0, 0, 255),
+    },
 });
 ```
 
@@ -664,7 +665,7 @@ music.stop();
 ```js
 // get sprite size
 getSprite("bean").then((spr) => {
-  console.log(spr.width, spr.height);
+    console.log(spr.width, spr.height);
 });
 ```
 
@@ -691,11 +692,11 @@ const scene = add([]);
 const bean = scene.add([sprite("bean"), pos(100, 200), area(), body()]);
 
 scene.onKeyPress("space", () => {
-  bean.jump();
+    bean.jump();
 });
 
 scene.onMousePress(() => {
-  bean.jump();
+    bean.jump();
 });
 
 // setting scene.paused will pause all the input events
@@ -710,19 +711,19 @@ ui.add(makeButton());
 
 // these will only work if ui game object is active
 ui.onMousePress(() => {
-  // ...
+    // ...
 });
 
 // before you'll have to manually clean up events on obj.onDestroy()
 const scene = add([]);
 const evs = [];
 scene.onDestroy(() => {
-  evs.forEach((ev) => ev.cancel());
+    evs.forEach((ev) => ev.cancel());
 });
 evs.push(
-  k.onKeyPress("space", () => {
-    doSomeSceneSpecificStuff();
-  })
+    k.onKeyPress("space", () => {
+        doSomeSceneSpecificStuff();
+    }),
 );
 ```
 
@@ -741,9 +742,9 @@ add(obj);
 const ui = add([fixed()]);
 
 ui.add([
-  rect(),
-  // have to also give all children game objects fixed()
-  fixed(),
+    rect(),
+    // have to also give all children game objects fixed()
+    fixed(),
 ]);
 
 // now
@@ -775,16 +776,16 @@ ui.add([rect(100, 100)]);
 const bean = add([sprite("bean"), pos(160, 120)]);
 
 const sword = bean.add([
-  sprite("sword"),
-  // transforms will be relative to parent bean object
-  pos(20, 20),
-  rotate(20),
+    sprite("sword"),
+    // transforms will be relative to parent bean object
+    pos(20, 20),
+    rotate(20),
 ]);
 
 const hat = bean.add([
-  sprite("hat"),
-  // transforms will be relative to parent bean object
-  pos(0, -10),
+    sprite("hat"),
+    // transforms will be relative to parent bean object
+    pos(0, -10),
 ]);
 
 // children will be moved alongside the parent
@@ -798,10 +799,10 @@ bean.destroy();
 
 ```js
 const enemies = get("enemy", {
-  // get from all children and descendants, instead of only direct children
-  recursive: true,
-  // live update the returned list to listen to onAdd and onDestroy events
-  liveUpdate: true,
+    // get from all children and descendants, instead of only direct children
+    recursive: true,
+    // live update the returned list to listen to onAdd and onDestroy events
+    liveUpdate: true,
 });
 
 console.log(enemies.length); // 3
@@ -832,11 +833,11 @@ console.log(enemies.length); // 4
 
 ```js
 const bean = add([
-  sprite("bean"),
-  pos(100, 80),
-  area({
-    collisionIgnore: ["cloud", "particle"],
-  }),
+    sprite("bean"),
+    pos(100, 80),
+    area({
+        collisionIgnore: ["cloud", "particle"],
+    }),
 ]);
 ```
 
@@ -844,10 +845,10 @@ const bean = add([
 
 ```js
 for (const col of player.getCollisions()) {
-  const c = col.target;
-  if (c.is("chest")) {
-    c.open();
-  }
+    const c = col.target;
+    if (c.is("chest")) {
+        c.open();
+    }
 }
 ```
 
@@ -872,9 +873,9 @@ for (const col of player.getCollisions()) {
 ```js
 // make semi-solid platforms that doesn't block player when player is jumping over it
 player.onBeforePhysicsResolve((collision) => {
-  if (collision.target.is(["platform", "soft"]) && player.isJumping()) {
-    collision.preventResolution();
-  }
+    if (collision.target.is(["platform", "soft"]) && player.isJumping()) {
+        collision.preventResolution();
+    }
 });
 ```
 
@@ -916,14 +917,14 @@ player.onBeforePhysicsResolve((collision) => {
 ```js
 // before
 obj.onAnimEnd("walk", () => {
-  // do something
+    // do something
 });
 
 // v3000
 obj.onAnimEnd((anim) => {
-  if (anim === "walk") {
-    // do something
-  }
+    if (anim === "walk") {
+        // do something
+    }
 });
 ```
 
@@ -933,11 +934,11 @@ obj.onAnimEnd((anim) => {
 
 ```js
 const player = add([
-  sprite("bean"),
-  // will calculate and send u_time every frame
-  shader("flashy", () => ({
-    u_time: time(),
-  })),
+    sprite("bean"),
+    // will calculate and send u_time every frame
+    shader("flashy", () => ({
+        u_time: time(),
+    })),
 ]);
 ```
 
@@ -953,11 +954,11 @@ const player = add([
 ```js
 // custom loading screen
 onLoadUpdate((progress) => {
-  drawCircle({
-    pos: center(),
-    radius: 32,
-    end: map(progress, 0, 1, 0, 360),
-  });
+    drawCircle({
+        pos: center(),
+        radius: 32,
+        end: map(progress, 0, 1, 0, 360),
+    });
 });
 ```
 
@@ -965,9 +966,9 @@ onLoadUpdate((progress) => {
 
 ```js
 loadSprite("player", [
-  "sprites/player_idle.png",
-  "sprites/player_run.png",
-  "sprites/player_jump.png",
+    "sprites/player_idle.png",
+    "sprites/player_run.png",
+    "sprites/player_jump.png",
 ]);
 ```
 
@@ -985,8 +986,8 @@ loadFont("FlowerSketches", "/examples/fonts/FlowerSketches.ttf");
 
 // Load a custom font with options
 loadFont("apl386", "/examples/fonts/apl386.ttf", {
-  outline: 4,
-  filter: "linear",
+    outline: 4,
+    filter: "linear",
 });
 ```
 
@@ -1018,14 +1019,14 @@ loadFont("apl386", "/examples/fonts/apl386.ttf", {
 
 ```js
 loadShader(
-  "invert",
-  null,
-  `
+    "invert",
+    null,
+    `
 vec4 frag(vec2 pos, vec2 uv, vec4 color, sampler2D tex) {
     vec4 c = def_frag();
     return vec4(1.0 - c.r, 1.0 - c.g, 1.0 - c.b, c.a);
 }
-`
+`,
 );
 
 usePostEffect("invert");
@@ -1037,21 +1038,21 @@ usePostEffect("invert");
 
 ```js
 loadSprite("grass", "/sprites/grass.png", {
-  slice9: {
-    left: 8,
-    right: 8,
-    top: 8,
-    bottom: 8,
-  },
+    slice9: {
+        left: 8,
+        right: 8,
+        top: 8,
+        bottom: 8,
+    },
 });
 
 const g = add([sprite("grass")]);
 
 onMouseMove(() => {
-  const mpos = mousePos();
-  // updating width / height will scale the image but not the sliced frame
-  g.width = mpos.x;
-  g.height = mpos.y;
+    const mpos = mousePos();
+    // updating width / height will scale the image but not the sliced frame
+    g.width = mpos.x;
+    g.height = mpos.y;
 });
 ```
 
@@ -1103,34 +1104,34 @@ music.loop = true;
 ```js
 // before
 addLevel(["@  ^ $$", "======="], {
-  width: 32,
-  height: 32,
-  "=": () => [sprite("grass"), area(), body({ isStatic: true })],
-  $: () => [sprite("coin"), area(), "coin"],
-  any: (symbol) => {
-    if (symbol === "@") {
-      return [
-        /* ... */
-      ];
-    }
-  },
+    width: 32,
+    height: 32,
+    "=": () => [sprite("grass"), area(), body({ isStatic: true })],
+    $: () => [sprite("coin"), area(), "coin"],
+    any: (symbol) => {
+        if (symbol === "@") {
+            return [
+                /* ... */
+            ];
+        }
+    },
 });
 
 // v3000
 addLevel(["@  ^ $$", "======="], {
-  tileWidth: 32,
-  tileHeight: 32,
-  tiles: {
-    "=": () => [sprite("grass"), area(), body({ isStatic: true })],
-    $: () => [sprite("coin"), area(), "coin"],
-  },
-  wildcardTile: (symbol) => {
-    if (symbol === "@") {
-      return [
-        /* ... */
-      ];
-    }
-  },
+    tileWidth: 32,
+    tileHeight: 32,
+    tiles: {
+        "=": () => [sprite("grass"), area(), body({ isStatic: true })],
+        $: () => [sprite("coin"), area(), "coin"],
+    },
+    wildcardTile: (symbol) => {
+        if (symbol === "@") {
+            return [
+                /* ... */
+            ];
+        }
+    },
 });
 ```
 
@@ -1170,20 +1171,20 @@ add();
 
 ```js
 onMousePress(() => {
-  tween(
-    bean.pos.x,
-    mousePos().x,
-    1,
-    (val) => (bean.pos.x = val),
-    easings.easeOutBounce
-  );
-  tween(
-    bean.pos.y,
-    mousePos().y,
-    1,
-    (val) => (bean.pos.y = val),
-    easings.easeOutBounce
-  );
+    tween(
+        bean.pos.x,
+        mousePos().x,
+        1,
+        (val) => (bean.pos.x = val),
+        easings.easeOutBounce,
+    );
+    tween(
+        bean.pos.y,
+        mousePos().y,
+        1,
+        (val) => (bean.pos.y = val),
+        easings.easeOutBounce,
+    );
 });
 ```
 
@@ -1193,13 +1194,13 @@ onMousePress(() => {
 ```js
 // before
 const cancel = onUpdate(() => {
-  /* ... */
+    /* ... */
 });
 cancel();
 
 // v3000
 const ev = onUpdate(() => {
-  /* ... */
+    /* ... */
 });
 ev.paused = true;
 ev.cancel();
@@ -1209,13 +1210,13 @@ ev.cancel();
 
 ```js
 const timer = wait(4, () => {
-  /* ... */
+    /* ... */
 });
 timer.paused = true;
 timer.resume();
 
 const timer = loop(1, () => {
-  /* ... */
+    /* ... */
 });
 timer.paused = true;
 timer.resume();
@@ -1409,11 +1410,11 @@ add([sprite("player"), area()]);
 add([sprite("rock"), solid()]);
 
 keyDown("left", () => {
-  player.move(-120, 0);
+    player.move(-120, 0);
 });
 
 player.action(() => {
-  player.resolve(); // or pushOutAll() in beta versions
+    player.resolve(); // or pushOutAll() in beta versions
 });
 
 // after
@@ -1423,8 +1424,8 @@ const player = add([sprite("player"), area(), solid()]);
 add([sprite("rock"), area(), solid()]);
 
 keyDown("left", () => {
-  // this will handle collision resolution for you, if the other obj is also "solid"
-  player.move(-120, 0);
+    // this will handle collision resolution for you, if the other obj is also "solid"
+    player.move(-120, 0);
 });
 ```
 
@@ -1485,10 +1486,10 @@ keyPress(...);
 
 ```js
 add([
-  sprite("bean"),
-  area(), // empty area will derive from sprite size
-  area({ scale: 0.5 }), // 0.5x the sprite size
-  area({ offset: vec2(0, 12), width: 4, height: 12 }), // more control over the collider region
+    sprite("bean"),
+    area(), // empty area will derive from sprite size
+    area({ scale: 0.5 }), // 0.5x the sprite size
+    area({ offset: vec2(0, 12), width: 4, height: 12 }), // more control over the collider region
 ]);
 ```
 
@@ -1513,16 +1514,16 @@ add([
 
 ```js
 function alwaysRight() {
-  return {
-    // the id of this component
-    id: "alwaysRight",
-    // list of component ids that this requires
-    require: ["pos"],
-    update() {
-      // so you can use `move()` from pos() component with no worry
-      this.move(100, 0);
-    },
-  };
+    return {
+        // the id of this component
+        id: "alwaysRight",
+        // list of component ids that this requires
+        require: ["pos"],
+        update() {
+            // so you can use `move()` from pos() component with no worry
+            this.move(100, 0);
+        },
+    };
 }
 ```
 
@@ -1570,12 +1571,12 @@ obj.c("sprite").play("anim");
 
 ```js
 loadSprite("hero", "hero.png", {
-  sliceX: 9,
-  anims: {
-    idle: { from: 0, to: 3, speed: 3, loop: true },
-    run: { from: 4, to: 7, speed: 10, loop: true },
-    hit: 8,
-  },
+    sliceX: 9,
+    anims: {
+        idle: { from: 0, to: 3, speed: 3, loop: true },
+        run: { from: 4, to: 7, speed: 10, loop: true },
+        hit: 8,
+    },
 });
 ```
 
@@ -1586,8 +1587,8 @@ loadSprite("hero", "hero.png", {
 
 ```js
 addLevel(["*    *", "*    *", "======"], {
-  "*": () => [sprite("wall"), area(), solid()],
-  "=": () => [sprite("floor"), area(), solid()],
+    "*": () => [sprite("wall"), area(), solid()],
+    "=": () => [sprite("floor"), area(), solid()],
 });
 ```
 
@@ -1604,8 +1605,8 @@ addLevel(["*    *", "*    *", "======"], {
 ```js
 const area = player.worldArea();
 if (area.shape === "rect") {
-  const width = area.p2.x - area.p1.x;
-  const height = area.p2.y - area.p1.y;
+    const width = area.p2.x - area.p1.x;
+    const height = area.p2.y - area.p1.y;
 }
 ```
 
@@ -1664,9 +1665,9 @@ if (area.shape === "rect") {
 ```js
 // replaces init(), and added a 'global' flag for previous kaboom.global()
 kaboom({
-  global: true,
-  width: 480,
-  height: 480,
+    global: true,
+    width: 480,
+    height: 480,
 });
 ```
 

--- a/tests/types/GameObj.test-d.ts
+++ b/tests/types/GameObj.test-d.ts
@@ -96,7 +96,6 @@ describe("Type Inference from add()", () => {
         const componentB = () => {
             return {
                 id: "componentB",
-                // Un-comment to fix type error:
                 // propertyB: true,
                 add() {
                     console.log("add B");
@@ -112,7 +111,7 @@ describe("Type Inference from add()", () => {
             ],
         );
 
-        //        expectTypeOf(obj.propertyA).toBeBoolean();
+        expectTypeOf(obj.propertyA).toBeBoolean();
     });
 });
 
@@ -159,5 +158,37 @@ describe("Type Inference from make()", () => {
         ]);
 
         expectTypeOf(obj).toEqualTypeOf<GameObj<CircleComp>>();
+    });
+
+    test("make() should tuple components", () => {
+        const componentA = () => {
+            return {
+                id: "componentA",
+                propertyA: true,
+                add() {
+                    console.log("add A");
+                },
+            };
+        };
+
+        const componentB = () => {
+            return {
+                id: "componentB",
+                // propertyB: true,
+                add() {
+                    console.log("add B");
+                },
+            };
+        };
+
+        const obj = k.make(
+            [
+                k.circle(4),
+                componentA(),
+                componentB(),
+            ],
+        );
+
+        expectTypeOf(obj.propertyA).toBeBoolean();
     });
 });


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- Read the Contributing Guide: https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md (necessary)
- Create small PRs. In most cases this will be possible.
-->

## Description

This makes `add()` and `make()` convert their arrays to tuples so types like { a: string, b: string } | { a: string } are not converted to { a: string } but mantained as an Union. Also it add comments to some of the weirdest KAPLAY TypeScript methods.

I know I added much `as` in the make code but I don't think really worth making it correctly, only will slow types. This is only for user end

### Issues or related

<!--
For pull requests that relate or close an issue, please include them
below.

The text `closes #1234` will connect the current PR to that issue, it also closes
the issue when the PR is merged.
-->

- Closes #645 
