### PR TITLE
feat: Send `make()` to the doom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - drawCanvas - @mflerackers
 - Added `video()` component - @mflerackers
 
+### Removed
+
+- `make()` was sent to doom
+
 ### Changed
 
 - Replaced the Separating Axis Theorem (SAT) with the "Gilbert–Johnson–Keerthi"

--- a/src/game/make.ts
+++ b/src/game/make.ts
@@ -119,11 +119,11 @@ export function make<const T extends CompList<unknown>>(
             return Array.from(tags);
         },
 
-        add<const T2 extends CompList<unknown> | GameObj<unknown>>(
+        add<const T2 extends CompList<unknown>>(
             this: GameObj,
             a: T2,
-        ): T2 extends CompList<unknown> ? GameObj<T2[number]> : T2 {
-            const obj = a instanceof Array ? make(a) : a as GameObj<unknown>;
+        ): GameObj<T2[number]> {
+            const obj = make(a);
 
             if (obj.parent) {
                 throw new Error(
@@ -142,8 +142,7 @@ export function make<const T extends CompList<unknown>>(
 
             _k.game.events.trigger("add", obj);
 
-            return obj as T2 extends CompList<unknown> ? GameObj<T2[number]>
-                : T2;
+            return obj;
         },
 
         readd(obj: GameObj): GameObj {

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -4,8 +4,11 @@ const VERSION = "4000.0.0";
 import { type ButtonsDef, initApp } from "./app";
 
 import {
+    appendToPicture,
+    beginPicture,
     center,
     drawBezier,
+    drawCanvas,
     drawCircle,
     drawCurve,
     drawDebug,
@@ -16,6 +19,7 @@ import {
     drawLines,
     drawLoadScreen,
     drawMasked,
+    drawPicture,
     drawPolygon,
     drawRect,
     drawSprite,
@@ -25,10 +29,7 @@ import {
     drawTriangle,
     drawUnscaled,
     drawUVQuad,
-    beginPicture,
-    appendToPicture,
     endPicture,
-    drawPicture,
     flush,
     formatText,
     FrameBuffer,
@@ -37,6 +38,7 @@ import {
     initAppGfx,
     initGfx,
     mousePos,
+    Picture,
     popTransform,
     pushMatrix,
     pushRotate,
@@ -46,8 +48,6 @@ import {
     setBackground,
     updateViewport,
     width,
-    Picture,
-    drawCanvas,
 } from "./gfx";
 
 import {
@@ -267,7 +267,6 @@ import {
     initGame,
     KeepFlags,
     layers,
-    make,
     on,
     onAdd,
     onClick,
@@ -382,7 +381,8 @@ const kaplay = <
 >(
     gopt: KAPLAYOpt<TPlugins, TButtons> = {},
 ): TPlugins extends [undefined] ? KAPLAYCtx<TButtons, TButtonsName>
-    : KAPLAYCtx<TButtons, TButtonsName> & MergePlugins<TPlugins> => {
+    : KAPLAYCtx<TButtons, TButtonsName> & MergePlugins<TPlugins> =>
+{
     if (_k.k) {
         console.warn(
             "KAPLAY already initialized, you are calling kaplay() multiple times, it may lead bugs!",
@@ -1025,7 +1025,7 @@ const kaplay = <
         let errorScreen = false;
 
         app.run(
-            () => { },
+            () => {},
             () => {
                 if (errorScreen) return;
                 errorScreen = true;
@@ -1093,7 +1093,7 @@ const kaplay = <
             // clear canvas
             gl.clear(
                 gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT
-                | gl.STENCIL_BUFFER_BIT,
+                    | gl.STENCIL_BUFFER_BIT,
             );
 
             // unbind everything
@@ -1304,7 +1304,6 @@ const kaplay = <
         // obj
         getTreeRoot,
         add,
-        make,
         destroy,
         destroyAll,
         get,
@@ -1600,7 +1599,7 @@ const kaplay = <
     // export everything to window if global is set
     if (gopt.global !== false) {
         for (const key in ctx) {
-            (<any>window[<any>key]) = ctx[key as keyof KAPLAYCtx];
+            (<any> window[<any> key]) = ctx[key as keyof KAPLAYCtx];
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,39 +230,11 @@ export interface KAPLAYCtx<
      * });
      * ```
     *
-    * @param comps - List of components to add to the game object, or a game object made with {@link make `make()`}.
+    * @param comps - List of components to add to the game object.
     * @returns The added game object that contains all properties and methods each component offers.
     * @group Game Obj
     */
-    add<const T extends CompList<unknown> | GameObj<unknown>>(
-        comps?: T,
-    ): T extends CompList<unknown> ? GameObj<T[number]> : T;
-    /**
-     * Create a game object like add(), but not adding to the scene.
-     *
-     * @param comps - List of components to add to the game object.
-     *
-     * @example
-     * ```js
-     * const label = make([
-     *     rect(100, 20),
-     * ]);
-     *
-     * // Add a new text to the label
-     * label.add([
-     *     text("Hello, world!"),
-     * ]);
-     *
-     * // Add game object to the scene
-     * // Now it will render
-     * add(label);
-     * ```
-     *
-     * @returns The created game object that contains all properties and methods each component offers.
-     * @since v3000.1
-     * @group Game Obj
-     */
-    make<const T extends CompList<unknown>>(comps?: T): GameObj<T[number]>;
+    add<const T extends CompList<unknown>>(comps?: T): GameObj<T[number]>;
     /**
      * Remove and re-add the game obj, without triggering add / destroy events.
      *
@@ -6171,9 +6143,7 @@ export interface GameObjRaw {
      * @returns The added game object.
      * @since v3000.0
      */
-    add<const T extends CompList<unknown> | GameObj<unknown>>(
-        comps?: T,
-    ): T extends CompList<unknown> ? GameObj<T[number]> : T;
+    add<const T extends CompList<unknown>>(comps?: T): GameObj<T[number]>;
     /**
      * Remove and re-add the game obj, without triggering add / destroy events.
      *

--- a/tests/playtests/largeTexture.js
+++ b/tests/playtests/largeTexture.js
@@ -13,16 +13,16 @@ add([
 ]);
 
 // Adds a label
-const label = make([
+const label = add([
     text("Click and drag the mouse, scroll the wheel"),
+    z(1),
 ]);
 
 add([
     rect(label.width, label.height),
     color(0, 0, 0),
+    z(0),
 ]);
-
-add(label);
 
 // Mouse handling
 onUpdate(() => {

--- a/tests/types/GameObj.test-d.ts
+++ b/tests/types/GameObj.test-d.ts
@@ -51,16 +51,6 @@ describe("Type Inference from add()", () => {
         expectTypeOf(obj).toEqualTypeOf<GameObj<CircleComp>>();
     });
 
-    test("add([make(circle())]) should return GameObj<CircleComp>", () => {
-        const base = k.make([
-            k.circle(4),
-        ]);
-
-        const obj = k.add(base);
-
-        expectTypeOf(obj).toEqualTypeOf<GameObj<CircleComp>>();
-    });
-
     test("add([circle(), circle()]) should return GameObj<CircleComp>", () => {
         const obj = k.add([
             k.circle(4),
@@ -104,84 +94,6 @@ describe("Type Inference from add()", () => {
         };
 
         const obj = k.add(
-            [
-                k.circle(4),
-                componentA(),
-                componentB(),
-            ],
-        );
-
-        expectTypeOf(obj.propertyA).toBeBoolean();
-    });
-});
-
-describe("Type Inference from make()", () => {
-    const k = kaplay();
-
-    test("make() should return GameObj<unknown>", () => {
-        const obj = k.make();
-        //     ^?
-
-        // Actually this test can give falsy true because unknown is acceptable for never
-        expectTypeOf(obj).toEqualTypeOf<GameObj<unknown>>();
-    });
-
-    test("make([]) should return GameObj<never>", () => {
-        const obj = k.make([]);
-        //     ^?
-
-        // Actually this test can give falsy true because unknown is acceptable for never
-        expectTypeOf(obj).toEqualTypeOf<GameObj<never>>();
-    });
-
-    test("make([circle()] should return GameObj<CircleComp>", () => {
-        const obj = k.make([
-            k.circle(4),
-        ]);
-
-        expectTypeOf(obj).toEqualTypeOf<GameObj<CircleComp>>();
-    });
-
-    test("make([circle(), scale()]) should return GameObj<CircleComp | ScaleComp>", () => {
-        const obj = k.make([
-            k.circle(4),
-            k.scale(),
-        ]);
-
-        expectTypeOf(obj).toEqualTypeOf<GameObj<CircleComp | ScaleComp>>();
-    });
-
-    test("make([circle(), \"cat\"]) should return GameObj<CircleComp>", () => {
-        const obj = k.make([
-            k.circle(4),
-            "cat",
-        ]);
-
-        expectTypeOf(obj).toEqualTypeOf<GameObj<CircleComp>>();
-    });
-
-    test("make() should tuple components", () => {
-        const componentA = () => {
-            return {
-                id: "componentA",
-                propertyA: true,
-                add() {
-                    console.log("add A");
-                },
-            };
-        };
-
-        const componentB = () => {
-            return {
-                id: "componentB",
-                // propertyB: true,
-                add() {
-                    console.log("add B");
-                },
-            };
-        };
-
-        const obj = k.make(
             [
                 k.circle(4),
                 componentA(),


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- Read the Contributing Guide: https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md (necessary)
- Create small PRs. In most cases this will be possible.
-->

## Description

This removes `make()`, a function that no one liked (except me).

This isn't the end, but a farewell. I love you, make; thanks for giving so much, sorry for not giving anything.

## Related issues

- Closes #664 

