### PR TITLE
refactor: Part 2

### DIFF
--- a/src/core/debug.ts
+++ b/src/core/debug.ts
@@ -1,0 +1,64 @@
+import type { App } from "../app";
+import type { AudioCtx } from "../audio";
+import { LOG_MAX } from "../constants";
+import type { Game } from "../game";
+import type { AppGfxCtx } from "../gfx";
+import type { Debug, KAPLAYOpt } from "../types";
+import type { FrameRenderer } from "./frameRendering";
+
+export const initDebug = (
+    gopt: KAPLAYOpt,
+    app: App,
+    appGfx: AppGfxCtx,
+    audio: AudioCtx,
+    game: Game,
+    fr: FrameRenderer,
+): Debug => {
+    let debugPaused = false;
+
+    const debug = {
+        inspect: false,
+        set timeScale(timeScale: number) {
+            app.state.timeScale = timeScale;
+        },
+        get timeScale() {
+            return app.state.timeScale;
+        },
+        showLog: true,
+        fps: () => app.fps(),
+        numFrames: () => app.numFrames(),
+        stepFrame: fr.updateFrame,
+        drawCalls: () => appGfx.lastDrawCalls,
+        clearLog: () => game.logs = [],
+        log: (...msgs) => {
+            const max = gopt.logMax ?? LOG_MAX;
+            const msg = msgs.length > 1 ? msgs.concat(" ").join(" ") : msgs[0];
+
+            game.logs.unshift({
+                msg: msg,
+                time: app.time(),
+            });
+            if (game.logs.length > max) {
+                game.logs = game.logs.slice(0, max);
+            }
+        },
+        error: (msg) =>
+            debug.log(new Error(msg.toString ? msg.toString() : msg as string)),
+        curRecording: null,
+        numObjects: () => game.root.get("*", { recursive: true }).length,
+        get paused() {
+            return debugPaused;
+        },
+        set paused(v) {
+            debugPaused = v;
+            if (v) {
+                audio.ctx.suspend();
+            }
+            else {
+                audio.ctx.resume();
+            }
+        },
+    } satisfies Debug;
+
+    return debug;
+};

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -7,10 +7,13 @@ import { initAssets } from "../assets";
 import { initAudio } from "../audio";
 import { initGame } from "../game";
 import { initAppGfx, initGfx } from "../gfx";
-import type { KAPLAYOpt } from "../types";
+import type { KAPLAYCtx, KAPLAYOpt } from "../types";
 import { createCanvas } from "./canvas";
+import { initDebug } from "./debug";
 import { createFontCache } from "./fontCache";
 import { createFrameRenderer } from "./frameRendering";
+
+export type Engine = ReturnType<typeof createEngine>;
 
 export const createEngine = (gopt: KAPLAYOpt) => {
     const canvas = createCanvas(gopt);
@@ -39,22 +42,29 @@ export const createEngine = (gopt: KAPLAYOpt) => {
     const game = initGame();
 
     // Frame rendering
-    const { frameStart, frameEnd } = createFrameRenderer(
+    const frameRenderer = createFrameRenderer(
         appGfx,
+        game,
         gopt.pixelDensity ?? 1,
     );
 
+    // Debug mode
+    const debug = initDebug(gopt, app, appGfx, audio, game, frameRenderer);
+
     return {
+        globalOpt: gopt,
         canvas,
         app,
-        gfx,
-        appGfx,
+        ggl: gfx,
+        gfx: appGfx,
         audio,
         assets,
-        frameStart,
-        frameEnd,
+        frameRenderer,
         fontCacheC2d,
         fontCacheCanvas,
         game,
+        debug,
+        // Patch, k it's only avaible after running kaplay()
+        k: null as unknown as KAPLAYCtx,
     };
 };

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,80 @@
+import { DBG_FONT } from "../constants";
+import {
+    drawFormattedText,
+    drawRect,
+    drawText,
+    drawUnscaled,
+    formatText,
+    height,
+    popTransform,
+    width,
+} from "../gfx";
+import { _k } from "../kaplay";
+import { rgb, vec2 } from "../math";
+
+let crashed = false;
+
+export const handleErr = (err: Error | any) => {
+    if (crashed) return;
+    crashed = true;
+    console.error(err);
+    _k.audio.ctx.suspend();
+    const errorMessage = err.message ?? String(err)
+        ?? "Unknown error, check console for more info";
+    let errorScreen = false;
+
+    _k.app.run(
+        () => {},
+        () => {
+            if (errorScreen) return;
+            errorScreen = true;
+
+            _k.frameRenderer.frameStart();
+
+            drawUnscaled(() => {
+                const pad = 32;
+                const gap = 16;
+                const gw = width();
+                const gh = height();
+
+                const textStyle = {
+                    size: 36,
+                    width: gw - pad * 2,
+                    letterSpacing: 4,
+                    lineSpacing: 4,
+                    font: DBG_FONT,
+                    fixed: true,
+                };
+
+                drawRect({
+                    width: gw,
+                    height: gh,
+                    color: rgb(0, 0, 255),
+                    fixed: true,
+                });
+
+                const title = formatText({
+                    ...textStyle,
+                    text: "Error",
+                    pos: vec2(pad),
+                    color: rgb(255, 128, 0),
+                    fixed: true,
+                });
+
+                drawFormattedText(title);
+
+                drawText({
+                    ...textStyle,
+                    text: errorMessage,
+                    pos: vec2(pad, pad + title.height + gap),
+                    fixed: true,
+                });
+
+                popTransform();
+                _k.game.events.trigger("error", err);
+            });
+
+            _k.frameRenderer.frameEnd();
+        },
+    );
+};

--- a/src/core/frameRendering.ts
+++ b/src/core/frameRendering.ts
@@ -1,4 +1,5 @@
 import { BG_GRID_SIZE } from "../constants";
+import type { Game } from "../game";
 import {
     type AppGfxCtx,
     drawTexture,
@@ -10,7 +11,13 @@ import {
 } from "../gfx";
 import { Quad, Vec2 } from "../math";
 
-export const createFrameRenderer = (gfx: AppGfxCtx, pixelDensity: number) => {
+export type FrameRenderer = ReturnType<typeof createFrameRenderer>;
+
+export const createFrameRenderer = (
+    gfx: AppGfxCtx,
+    game: Game,
+    pixelDensity: number,
+) => {
     // start a rendering frame, reset some states
     function frameStart() {
         // clear backbuffer
@@ -79,5 +86,14 @@ export const createFrameRenderer = (gfx: AppGfxCtx, pixelDensity: number) => {
         gfx.height = oh;
     }
 
-    return { frameStart, frameEnd };
+    function fixedUpdateFrame() {
+        // update every obj
+        game.root.fixedUpdate();
+    }
+
+    function updateFrame() {
+        game.root.update();
+    }
+
+    return { frameStart, frameEnd, fixedUpdateFrame, updateFrame };
 };

--- a/src/ecs/make.ts
+++ b/src/ecs/make.ts
@@ -1,3 +1,5 @@
+// The E of KAPLAY
+
 import type { App } from "../app";
 import type {
     FixedComp,
@@ -7,6 +9,7 @@ import type {
     ScaleComp,
 } from "../components";
 import { COMP_DESC, COMP_EVENTS } from "../constants";
+import { handleErr } from "../core/errors";
 import {
     flush,
     popTransform,
@@ -43,6 +46,7 @@ export type SetParentOpt = {
 export function make<const T extends CompList<unknown>>(
     comps: T = [] as unknown as T,
 ): GameObj<T[number]> {
+    const id = uid();
     const compStates = new Map<string, Comp>();
     const anonymousCompStates: Comp[] = [];
     const cleanups = {} as Record<string, (() => unknown)[]>;
@@ -52,14 +56,16 @@ export function make<const T extends CompList<unknown>>(
     const drawEvents = new KEvent<[]>();
     const inputEvents: KEventController[] = [];
     const tags = new Set<Tag>("*");
-    const treatTagsAsComponents = _k.globalOpt.tagsAsComponents;
+    const treatTagsAsComponents = id == 0
+        ? false
+        : _k.globalOpt.tagsAsComponents;
     let onCurCompCleanup: Function | null = null;
     let paused = false;
     let _parent: GameObj;
 
     // the game object without the event methods, added later
     const obj: Omit<GameObj, keyof typeof appEvs> = {
-        id: uid(),
+        id: id,
         // TODO: a nice way to hide / pause when add()-ing
         hidden: false,
         transform: new Mat23(),
@@ -137,7 +143,7 @@ export function make<const T extends CompList<unknown>>(
                 obj.trigger("add", obj);
                 obj.children.forEach(c => c.trigger("add", c));
             } catch (e) {
-                _k.handleErr(e);
+                handleErr(e);
             }
 
             _k.game.events.trigger("add", obj);
@@ -297,7 +303,7 @@ export function make<const T extends CompList<unknown>>(
                         }
                     }
                 } catch (e) {
-                    _k.handleErr(e);
+                    handleErr(e);
                 }
             };
 

--- a/src/events/eventMap.ts
+++ b/src/events/eventMap.ts
@@ -1,3 +1,4 @@
+import type { Asset } from "../assets";
 import {
     type agent,
     type animate,
@@ -30,181 +31,181 @@ import type {
  */
 export type GameObjEventMap = {
     /** Triggered every frame */
-    "update": [GameObj];
+    update: [GameObj];
     /** Triggered every frame at a fixed 50fps rate */
-    "fixedUpdate": [GameObj];
+    fixedUpdate: [GameObj];
     /** Triggered every frame before update */
-    "draw": [GameObj];
+    draw: [GameObj];
     /** Triggered when object is added */
-    "add": [GameObj];
+    add: [GameObj];
     /** Triggered when object is destroyed */
-    "destroy": [GameObj];
+    destroy: [GameObj];
     /** Triggered when component is used */
-    "use": [GameObj, string];
+    use: [GameObj, string];
     /** Triggered when component is unused */
-    "unuse": [GameObj, string];
+    unuse: [GameObj, string];
     /** Triggered when tag is added */
-    "tag": [GameObj, string];
+    tag: [GameObj, string];
     /** Triggered when tag is removed */
-    "untag": [GameObj, string];
+    untag: [GameObj, string];
     /**
      * Triggered when object collides with another object
      *
      * From {@link area `area()`} component
      */
-    "collide": [GameObj, GameObj, Collision];
+    collide: [GameObj, GameObj, Collision];
     /**
      * Triggered every frame when object collides with another object
      *
      * From {@link area `area()`} component
      */
-    "collideUpdate": [GameObj, GameObj, Collision];
+    collideUpdate: [GameObj, GameObj, Collision];
     /**
      * Triggered when object stops colliding with another object
      *
      * From {@link area `area()`} component
      */
-    "collideEnd": [GameObj, GameObj, Collision];
+    collideEnd: [GameObj, GameObj, Collision];
     /**
      * Triggered when object is hurted
      *
      * From {@link health `health()`} component
      */
-    "hurt": [GameObj, hurt: number];
+    hurt: [GameObj, hurt: number];
     /**
      * Triggered when object is healed
      *
      * From {@link health `health()`} component
      */
-    "heal": [GameObj, heal: number];
+    heal: [GameObj, heal: number];
     /**
      * Triggered when object dies
      *
      * From {@link health `health()`} component
      */
-    "death": [GameObj];
+    death: [GameObj];
     /**
      * Triggered before physics resolves
      *
      * From {@link body `body()`} component
      */
-    "beforePhysicsResolve": [GameObj, col: Collision];
+    beforePhysicsResolve: [GameObj, col: Collision];
     /**
      * Triggered after physics resolves
      *
      * From {@link body `body()`} component
      */
-    "physicsResolve": [GameObj, col: Collision];
+    physicsResolve: [GameObj, col: Collision];
     /**
      * Triggered when object is on the ground
      *
      * From {@link body `body()`} component
      */
-    "ground": [GameObj];
+    ground: [GameObj];
     /**
      * Triggered when object is falling
      *
      * From {@link body `body()`} component
      */
-    "fall": [GameObj];
+    fall: [GameObj];
     /**
      * Triggered when object stops falling
      *
      * From {@link body `body()`} component
      */
-    "fallOff": [GameObj];
+    fallOff: [GameObj];
     /**
      * Triggered when object head butt something (like Mario with brick)
      *
      * From {@link body `body()`} component
      */
-    "headbutt": [GameObj];
+    headbutt: [GameObj];
     /**
      * Triggered when an object lands on this object
      *
      * From {@link body `body()`} component
      */
-    "land": [GameObj];
+    land: [GameObj];
     /**
      * Triggered when object is headbutted by another object
      *
      * From {@link body `body()`} component
      */
-    "headbutted": [GameObj];
+    headbutted: [GameObj];
     /**
      * Triggered when object double jumps
      *
      * From {@link doubleJump `doubleJump()`} component
      */
-    "doubleJump": [GameObj];
+    doubleJump: [GameObj];
     /**
      * Triggered when object goes out of view
      *
      * From {@link offscreen `offscreen()`} component
      */
-    "exitView": [GameObj];
+    exitView: [GameObj];
     /**
      * Triggered when object enters view
      *
      * From {@link offscreen `offscreen()`} component
      */
-    "enterView": [GameObj];
+    enterView: [GameObj];
     /**
      * Triggered when a sprite animation starts
      *
      * From {@link sprite `sprite()`} component
      */
-    "animStart": [GameObj, anim: string];
+    animStart: [GameObj, anim: string];
     /**
      * Triggered when a sprite animation ends
      *
      * From {@link sprite `sprite()`} component
      */
-    "animEnd": [GameObj, anim: string];
+    animEnd: [GameObj, anim: string];
     /**
      * From {@link agent `agent()`} component
      */
-    "navigationNext": [GameObj, GameObj, Vec2];
+    navigationNext: [GameObj, GameObj, Vec2];
     /**
      * From {@link agent `agent()`} component
      */
-    "navigationEnded": [GameObj, GameObj];
+    navigationEnded: [GameObj, GameObj];
     /**
      * From {@link agent `agent()`} component
      */
-    "navigationStarted": [GameObj, GameObj];
+    navigationStarted: [GameObj, GameObj];
     /**
      * From {@link agent `agent()`} component
      */
-    "targetReached": [GameObj, GameObj];
+    targetReached: [GameObj, GameObj];
     /**
      * From {@link patrol `patrol()`} component
      */
-    "patrolFinished": [GameObj];
+    patrolFinished: [GameObj];
     /**
      * From {@link sentry `sentry()`} component
      */
-    "objectSpotted": [GameObj, GameObj[]];
+    objectSpotted: [GameObj, GameObj[]];
     /**
      * From {@link animate `animate()`} component
      */
-    "animateChannelFinished": [GameObj, channel: string];
+    animateChannelFinished: [GameObj, channel: string];
     /**
      * From {@link animate `animate()`} component
      */
-    "animateFinished": [GameObj];
+    animateFinished: [GameObj];
     /**
      * From level of {@link addLevel `addLevel()`} function
      */
-    "spatialMapChanged": [GameObj];
+    spatialMapChanged: [GameObj];
     /**
      * From level of {@link addLevel `addLevel()`} function
      */
-    "navigationMapInvalid": [GameObj];
+    navigationMapInvalid: [GameObj];
     /**
      * From level of {@link addLevel `addLevel()`} function
      */
-    "navigationMapChanged": [GameObj];
+    navigationMapChanged: [GameObj];
 };
 
 export type GameObjEvents = GameObjEventMap & {
@@ -243,4 +244,19 @@ export type AppEventMap = {
     show: [];
     resize: [];
     input: [];
+};
+
+/**
+ * All Game State events with their arguments
+ */
+export type GameEventMap = {
+    load: [];
+    loadError: [string, Asset<any>];
+    loading: [number];
+    error: [Error];
+    input: [];
+    frameEnd: [];
+    resize: [];
+    sceneLeave: [string];
+    sceneEnter: [string];
 };

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -1,53 +1,49 @@
-import type { Asset } from "../assets";
+import { type Asset, loadSprite, type SpriteData } from "../assets";
 import { timer, type TimerComp } from "../components";
+import { make } from "../ecs/make";
+import type { GameEventMap, GameObjEventMap } from "../events";
 import { Mat23, Vec2 } from "../math/math";
-import { type GameObj, type Key, type MouseButton } from "../types";
+import { type GameObj } from "../types";
 import { KEventHandler } from "../utils";
-import { make } from "./make";
 import type { SceneDef, SceneName } from "./scenes";
+import type { System } from "./systems";
 
-export type Game = ReturnType<typeof initGame>;
+/**
+ * The "Game" it's all the state related to the game running
+ */
+export type Game = {
+    /**
+     * Where game object global events are stored.
+     */
+    events: KEventHandler<GameEventMap & GameObjEventMap>;
+    /**
+     * The root game object, parent of all game objects.
+     */
+    root: GameObj<TimerComp>;
+    gravity: Vec2 | null;
+    scenes: Record<SceneName, SceneDef>;
+    currentScene: string | null;
+    layers: string[] | null;
+    defaultLayerIndex: number;
+    systems: System[];
+    systemsByEvent: [
+        System[],
+        System[],
+        System[],
+        System[],
+        System[],
+        System[],
+    ];
+    kaSprite: Asset<SpriteData> | null;
+    boomSprite: Asset<SpriteData> | null;
+    logs: Log[];
+    cam: CamData;
+};
 
-export const initGame = () => {
+export const initGame = (): Game => {
     const game = {
         // general events
-        events: new KEventHandler<{
-            mouseMove: [];
-            mouseDown: [MouseButton];
-            mousePress: [MouseButton];
-            mouseRelease: [MouseButton];
-            charInput: [string];
-            keyPress: [Key];
-            keyDown: [Key];
-            keyPressRepeat: [Key];
-            keyRelease: [Key];
-            touchStart: [Vec2, Touch];
-            touchMove: [Vec2, Touch];
-            touchEnd: [Vec2, Touch];
-            gamepadButtonDown: [string];
-            gamepadButtonPress: [string];
-            gamepadButtonRelease: [string];
-            gamepadStick: [string, Vec2];
-            gamepadConnect: [Gamepad];
-            gamepadDisconnect: [Gamepad];
-            scroll: [Vec2];
-            add: [GameObj];
-            destroy: [GameObj];
-            use: [GameObj, string];
-            unuse: [GameObj, string];
-            tag: [GameObj, string];
-            untag: [GameObj, string];
-            load: [];
-            loadError: [string, Asset<any>];
-            loading: [number];
-            error: [Error];
-            input: [];
-            frameEnd: [];
-            resize: [];
-            sceneLeave: [string];
-            sceneEnter: [string];
-        }>(),
-
+        events: new KEventHandler<GameEventMap & GameObjEventMap>(),
         // root game object
         root: make([]) as GameObj<TimerComp>,
 
@@ -57,6 +53,20 @@ export const initGame = () => {
         currentScene: null as SceneName | null,
         layers: null as string[] | null,
         defaultLayerIndex: 0,
+        systems: [], // all systems added
+        // we allocate systems
+        systemsByEvent: [
+            [], // afterDraw
+            [], // afterFixedUpdate
+            [], // afterUpdate
+            [], // beforeDraw
+            [], // beforeFixedUpdate
+            [], // beforeUpdate
+        ],
+
+        // default assets
+        kaSprite: null as unknown as Asset<SpriteData>,
+        boomSprite: null as unknown as Asset<SpriteData>,
 
         // on screen log
         logs: [] as { msg: string | { toString(): string }; time: number }[],
@@ -69,9 +79,20 @@ export const initGame = () => {
             shake: 0,
             transform: new Mat23(),
         },
-    };
+    } satisfies Game;
 
     game.root.use(timer());
 
     return game;
+};
+
+// TODO: Move
+type Log = { msg: string | { toString(): string }; time: number };
+
+type CamData = {
+    pos: Vec2 | null;
+    scale: Vec2;
+    angle: number;
+    shake: number;
+    transform: Mat23;
 };

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,3 +1,4 @@
+export * from "../ecs/make";
 export * from "../events";
 export * from "./camera";
 export * from "./game";
@@ -6,7 +7,6 @@ export * from "./initEvents";
 export * from "./kaboom";
 export * from "./layers";
 export * from "./level";
-export * from "./make";
 export * from "./object";
 export * from "./scenes";
 export * from "./utils";

--- a/src/game/initEvents.ts
+++ b/src/game/initEvents.ts
@@ -24,8 +24,8 @@ export function initEvents() {
             return;
         }
 
-        _k.canvas.width = _k.canvas.offsetWidth * _k.pixelDensity;
-        _k.canvas.height = _k.canvas.offsetHeight * _k.pixelDensity;
+        _k.canvas.width = _k.canvas.offsetWidth * _k.gfx.pixelDensity;
+        _k.canvas.height = _k.canvas.offsetHeight * _k.gfx.pixelDensity;
 
         updateViewport();
 
@@ -36,10 +36,12 @@ export function initEvents() {
                 _k.gfx.ggl.gl.drawingBufferWidth,
                 _k.gfx.ggl.gl.drawingBufferHeight,
             );
-            _k.gfx.width = _k.gfx.ggl.gl.drawingBufferWidth / _k.pixelDensity
-                / _k.gscale;
-            _k.gfx.height = _k.gfx.ggl.gl.drawingBufferHeight / _k.pixelDensity
-                / _k.gscale;
+            _k.gfx.width = _k.gfx.ggl.gl.drawingBufferWidth
+                / _k.gfx.pixelDensity
+                / _k.gfx.gscale;
+            _k.gfx.height = _k.gfx.ggl.gl.drawingBufferHeight
+                / _k.gfx.pixelDensity
+                / _k.gfx.gscale;
         }
     });
 

--- a/src/game/kaboom.ts
+++ b/src/game/kaboom.ts
@@ -24,6 +24,10 @@ export interface BoomOpt {
 }
 
 export function addKaboom(p: Vec2, opt: BoomOpt = {}): GameObj {
+    if (!_k.game.boomSprite || !_k.game.kaSprite) {
+        throw new Error("You can't use addKaboom without the sprites loaded");
+    }
+
     const kaboom = _k.game.root.add([
         pos(p),
         stay(),
@@ -33,7 +37,7 @@ export function addKaboom(p: Vec2, opt: BoomOpt = {}): GameObj {
     const s = opt.scale || 1;
 
     kaboom.add([
-        sprite(_k.boomSprite),
+        sprite(_k.game.boomSprite),
         scale(0),
         anchor("center"),
         boom(speed, s),
@@ -41,7 +45,7 @@ export function addKaboom(p: Vec2, opt: BoomOpt = {}): GameObj {
     ]);
 
     const ka = kaboom.add([
-        sprite(_k.kaSprite),
+        sprite(_k.game.kaSprite),
         scale(0),
         anchor("center"),
         timer(),

--- a/src/game/systems.ts
+++ b/src/game/systems.ts
@@ -17,7 +17,7 @@ export enum LCEvents {
 }
 
 export const system = (name: string, action: () => void, when: LCEvents[]) => {
-    const systems = _k.systems;
+    const systems = _k.game.systems;
     const replacingSystemIdx = systems.findIndex((s) => s.name === name);
 
     // if existent system, remove it
@@ -26,10 +26,10 @@ export const system = (name: string, action: () => void, when: LCEvents[]) => {
         const when = replacingSystem.when;
 
         for (const loc of when) {
-            const idx = _k.systemsByEvent[loc].findIndex(
+            const idx = _k.game.systemsByEvent[loc].findIndex(
                 (s) => s.name === name,
             );
-            _k.systemsByEvent[loc].splice(idx, 1);
+            _k.game.systemsByEvent[loc].splice(idx, 1);
         }
     }
 
@@ -40,7 +40,7 @@ export const system = (name: string, action: () => void, when: LCEvents[]) => {
     };
 
     for (const loc of when) {
-        _k.systemsByEvent[loc].push(system);
+        _k.game.systemsByEvent[loc].push(system);
     }
 
     systems.push({ name, run: action, when });

--- a/src/gfx/draw/drawText.ts
+++ b/src/gfx/draw/drawText.ts
@@ -133,7 +133,7 @@ export interface CharTransform {
     /**
      * If true, characters that have a X scale that is not 1 won't have the bounding box stretched to fit the character,
      * and may end up overlapping with adjacent characters.
-     * 
+     *
      * @default false
      */
     stretchInPlace?: boolean;

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -1,4 +1,10 @@
-import { Asset, type BitmapFontData, FontData, type GfxFont, resolveFont } from "../assets";
+import {
+    Asset,
+    type BitmapFontData,
+    FontData,
+    type GfxFont,
+    resolveFont,
+} from "../assets";
 import {
     DEF_FONT_FILTER,
     DEF_TEXT_CACHE_SIZE,
@@ -15,7 +21,7 @@ import {
     type CharTransform,
     type DrawTextOpt,
     type FormattedChar,
-    type FormattedText
+    type FormattedText,
 } from "./draw";
 import { Texture } from "./gfx";
 
@@ -30,7 +36,9 @@ const fontAtlases: Record<string, FontAtlas> = {};
 
 function applyCharTransform(fchar: FormattedChar, tr: CharTransform) {
     if (tr.font) fchar.font = tr.font;
-    if (tr.stretchInPlace !== undefined) fchar.stretchInPlace = tr.stretchInPlace;
+    if (tr.stretchInPlace !== undefined) {
+        fchar.stretchInPlace = tr.stretchInPlace;
+    }
     if (tr.override) {
         Object.assign(fchar, tr);
         return;
@@ -85,7 +93,7 @@ export function compileStyledText(txt: string): {
                     if (x !== undefined) {
                         throw new Error(
                             "Styled text error: mismatched tags. "
-                            + `Expected [/${x}], got [/${gn}]`,
+                                + `Expected [/${x}], got [/${gn}]`,
                         );
                     }
                     else {
@@ -132,14 +140,14 @@ function getFontAtlasForFont(font: FontData | string): FontAtlas {
             outline: Outline | null;
             filter: TexFilter;
         } = font instanceof FontData
-                ? {
-                    outline: font.outline,
-                    filter: font.filter,
-                }
-                : {
-                    outline: null,
-                    filter: DEF_FONT_FILTER,
-                };
+            ? {
+                outline: font.outline,
+                filter: font.filter,
+            }
+            : {
+                outline: null,
+                filter: DEF_FONT_FILTER,
+            };
 
         // TODO: customizable font tex filter
         atlas = {
@@ -273,7 +281,9 @@ export function formatText(opt: DrawTextOpt): FormattedText {
     const { charStyleMap, text } = compileStyledText(opt.text + "");
     const chars = runes(text);
 
-    let defGfxFont = (font instanceof FontData || typeof font === "string") ? getFontAtlasForFont(font).font : font;
+    let defGfxFont = (font instanceof FontData || typeof font === "string")
+        ? getFontAtlasForFont(font).font
+        : font;
 
     const size = opt.size || defGfxFont.size;
     const scale = vec2(opt.scale ?? 1).scale(size / defGfxFont.size);
@@ -284,7 +294,7 @@ export function formatText(opt: DrawTextOpt): FormattedText {
     let th = 0;
     const lines: Array<{
         width: number;
-        chars: {ch: FormattedChar, font: GfxFont}[];
+        chars: { ch: FormattedChar; font: GfxFont }[];
     }> = [];
     let curLine: typeof lines[number]["chars"] = [];
     let cursor = 0;
@@ -312,10 +322,17 @@ export function formatText(opt: DrawTextOpt): FormattedText {
             paraIndentX = undefined;
         }
         else {
-
-            const defaultFontValue = (font instanceof FontData || typeof font === "string") ? font : undefined;
-            type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
-            const theFChar: PartialBy<FormattedChar, "width" | "height" | "quad"> = {
+            const defaultFontValue =
+                (font instanceof FontData || typeof font === "string")
+                    ? font
+                    : undefined;
+            type PartialBy<T, K extends keyof T> =
+                & Omit<T, K>
+                & Partial<Pick<T, K>>;
+            const theFChar: PartialBy<
+                FormattedChar,
+                "width" | "height" | "quad"
+            > = {
                 tex: defGfxFont.tex,
                 ch: ch,
                 pos: new Vec2(curX, th),
@@ -374,7 +391,10 @@ export function formatText(opt: DrawTextOpt): FormattedText {
 
             // TODO: leave space if character not found?
             if (q) {
-                let gw = q.w * (theFChar.stretchInPlace ? theFChar.oscale : theFChar.scale).x;
+                let gw = q.w
+                    * (theFChar.stretchInPlace
+                        ? theFChar.oscale
+                        : theFChar.scale).x;
                 let move = vec2(0);
 
                 if (opt.width && curX + gw > opt.width) {

--- a/src/gfx/gfxApp.ts
+++ b/src/gfx/gfxApp.ts
@@ -118,6 +118,8 @@ export const initAppGfx = (gfx: GfxCtx, gopt: KAPLAYOpt) => {
         postShader: null as string | null,
         postShaderUniform: null as Uniform | (() => Uniform) | null,
         renderer: renderer,
+        pixelDensity: pixelDensity,
+        gscale,
 
         transform: new Mat23(),
         transformStack: transformStack,

--- a/src/gfx/viewport.ts
+++ b/src/gfx/viewport.ts
@@ -7,7 +7,7 @@ export function updateViewport() {
     // window size (will be the same as view size except letterbox mode)
 
     // canvas size
-    const pd = _k.pixelDensity;
+    const pd = _k.gfx.pixelDensity;
     const canvasWidth = _k.gfx.ggl.gl.drawingBufferWidth / pd;
     const canvasHeight = _k.gfx.ggl.gl.drawingBufferHeight / pd;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ import type {
     ParticlesOpt,
 } from "./components/draw/particles";
 import type { PictureComp } from "./components/draw/picture";
+import type { Engine } from "./core/engine";
 import type {
     BoomOpt,
     Game,
@@ -150,30 +151,6 @@ import type { NavMesh } from "./math/navigationmesh";
 import type { KEvent, KEventController, KEventHandler } from "./utils/";
 
 /**
- * Sensitive KAPLAY data
- */
-export type KAPLAYInternal = {
-    k: KAPLAYCtx;
-    globalOpt: KAPLAYOpt;
-    gfx: AppGfxCtx;
-    game: Game;
-    app: App;
-    assets: ReturnType<typeof initAssets>;
-    fontCacheCanvas: HTMLCanvasElement | null;
-    fontCacheC2d: CanvasRenderingContext2D | null;
-    debug: Debug;
-    audio: AudioCtx;
-    pixelDensity: number;
-    canvas: HTMLCanvasElement;
-    gscale: number;
-    kaSprite: Asset<SpriteData>;
-    boomSprite: Asset<SpriteData>;
-    systems: System[];
-    systemsByEvent: System[][];
-    handleErr: (e: any) => void;
-};
-
-/**
  * Context handle that contains every KAPLAY function.
  *
  * @template TButtonDef - The button map
@@ -191,7 +168,7 @@ export interface KAPLAYCtx<
      * @readonly
      * @group Misc
      */
-    _k: KAPLAYInternal;
+    _k: Engine & { k: KAPLAYCtx };
     /**
      * Assemble a game object from a list of components, and add it to the game,
      *

--- a/tests/playtests/styleChangeFont.js
+++ b/tests/playtests/styleChangeFont.js
@@ -2,26 +2,29 @@ kaplay({ background: "#000000", crisp: true });
 loadFont("Romantique", "/examples/fonts/Romantique.ttf", { filter: "nearest" });
 
 const x = add([
-    text("everything here is arial except the e's are romantique and red and stretched".replaceAll("e", "[e]e[/e]"), {
-        transform: {
-            font: "Arial",
-            stretchInPlace: false,
-        },
-        styles: {
-            e: (i, ch) => {
-                const w = wave(0.5, 2, time() * 3 + i);
-                return {
-                    font: "Romantique",
-                    color: RED,
-                    scale: vec2(w, 1),
-                    stretchInPlace: w > 1,
-                };
+    text(
+        "everything here is arial except the e's are romantique and red and stretched"
+            .replaceAll("e", "[e]e[/e]"),
+        {
+            transform: {
+                font: "Arial",
+                stretchInPlace: false,
             },
+            styles: {
+                e: (i, ch) => {
+                    const w = wave(0.5, 2, time() * 3 + i);
+                    return {
+                        font: "Romantique",
+                        color: RED,
+                        scale: vec2(w, 1),
+                        stretchInPlace: w > 1,
+                    };
+                },
+            },
+            width: width(),
+            size: 75,
         },
-        width: width(),
-        size: 75,
-
-    }),
+    ),
 ]);
 
 onUpdate(() => x.width = width());


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:
- Read the Contributing Guide: https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md (necessary)
- Create small PRs. In most cases this will be possible.
-->

## Description

> "yup, that's me, you're probably wondering how i ended up in this situation"

Will summarize changes

- Moved `make.ts` to `ecs/make.ts`
- Moved debug stuff to `src/core/debug.ts` and now it's part of `createEngine`
- Moved `frameUpdate` and `fixedFrameUpdate` to `frameRendering` (ik is not rendering, but well, names are a draft, maybe it can be frameProcessor or frameRunner)
- Moved `handleErr` to `src/core/error.ts`
- Strictly typed `game.events` and `initGame` return type (`Game` type is now explicit, not inferred)
- Removed `KAPLAYInternal` type replaced by `Engine`

Then most changes are variable updates, I tried to mantain names that's why I backed `gfx` to `ggl` and `appGfx` to `gfx`. The idea is change it later. This PR makes code more cleaner, organization better. As I said previously I try to make the less number of changes possible that's why still not moving files crazyly. The idea of `ecs` folder is contain systems, entity and components related stuff.

Now is more clear what different `init` depends of, I think that makes our code less spaguethi


### Issues or related

<!--
For pull requests that relate or close an issue, please include them
below.

The text `closes #1234` will connect the current PR to that issue, it also closes
the issue when the PR is merged.
-->

- Related Issue #
- Closes #
