### PR TITLE
feat: Text formatting API exposed and fix line height of stretching characters

### DIFF
--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -2,7 +2,10 @@ import type { BitmapFontData } from "../../../assets/bitmapFont";
 import { DEF_TEXT_SIZE } from "../../../constants";
 import { onLoad } from "../../../events/globalEvents";
 import { getRenderProps } from "../../../game/utils";
-import { drawFormattedText, type FormattedText } from "../../../gfx/draw/drawFormattedText";
+import {
+    drawFormattedText,
+    type FormattedText,
+} from "../../../gfx/draw/drawFormattedText";
 import type {
     CharTransform,
     CharTransformFunc,
@@ -136,7 +139,7 @@ export interface TextCompOpt {
 }
 
 export function text(t: string, opt: TextCompOpt = {}): TextComp {
-    let theFormattedText: FormattedText
+    let theFormattedText: FormattedText;
     function update(obj: GameObj<TextComp | any>) {
         theFormattedText = formatText(Object.assign(getRenderProps(obj), {
             text: obj.text + "",
@@ -157,7 +160,6 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
 
         obj.height = theFormattedText.height / (obj.scale?.y || 1);
     }
-
 
     const obj = {
         id: "text",

--- a/src/gfx/draw/drawFormattedText.ts
+++ b/src/gfx/draw/drawFormattedText.ts
@@ -34,7 +34,6 @@ export interface FormattedChar {
     quad: Quad;
     pos: Vec2;
     scale: Vec2;
-    oscale: Vec2;
     angle: number;
     color: Color;
     opacity: number;

--- a/src/gfx/draw/drawText.ts
+++ b/src/gfx/draw/drawText.ts
@@ -135,7 +135,7 @@ export interface CharTransform {
      * If true, characters that have a X scale that is not 1 won't have the bounding box stretched to fit the character,
      * and may end up overlapping with adjacent characters.
      *
-     * @default false
+     * @default true
      */
     stretchInPlace?: boolean;
 }

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -133,14 +133,14 @@ function getFontAtlasForFont(font: FontData | string): FontAtlas {
             outline: Outline | null;
             filter: TexFilter;
         } = font instanceof FontData
-                ? {
-                    outline: font.outline,
-                    filter: font.filter,
-                }
-                : {
-                    outline: null,
-                    filter: DEF_FONT_FILTER,
-                };
+            ? {
+                outline: font.outline,
+                filter: font.filter,
+            }
+            : {
+                outline: null,
+                filter: DEF_FONT_FILTER,
+            };
 
         // TODO: customizable font tex filter
         atlas = {
@@ -300,7 +300,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
 
         // always new line on '\n'
         if (ch === "\n") {
-
             lines.push({
                 width: curX - letterSpacing,
                 chars: curLine,
@@ -431,9 +430,11 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                     lastSpace = curLine.length;
                     lastSpaceWidth = curX;
                 }
-                if (opt.indentAll
+                if (
+                    opt.indentAll
                     && paraIndentX === undefined
-                    && /\S/.test(ch)) {
+                    && /\S/.test(ch)
+                ) {
                     paraIndentX = curX;
                 }
 
@@ -451,7 +452,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         chars: curLine,
     });
 
-
     if (opt.width) {
         tw = opt.width;
     }
@@ -467,8 +467,10 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         for (const { ch } of lines[i].chars) {
             ch.pos = ch.pos.add(ox, th);
             formattedChars.push(ch);
-            thisLineHeight = Math.max(thisLineHeight,
-                size * (ch.stretchInPlace ? scale : ch.scale).y / scale.y)
+            thisLineHeight = Math.max(
+                thisLineHeight,
+                size * (ch.stretchInPlace ? scale : ch.scale).y / scale.y,
+            );
         }
         th += thisLineHeight;
     }

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -170,7 +170,7 @@ import { drawSubtracted } from "./gfx/draw/drawSubstracted";
 import { drawText } from "./gfx/draw/drawText";
 import { drawTriangle } from "./gfx/draw/drawTriangle";
 import { drawUVQuad } from "./gfx/draw/drawUVQuad";
-import { formatText } from "./gfx/formatText";
+import { compileStyledText, formatText } from "./gfx/formatText";
 import {
     center,
     flush,
@@ -927,6 +927,7 @@ const kaplay = <
         drawSprite,
         drawText,
         formatText,
+        compileStyledText,
         drawRect,
         drawLine,
         drawLines,

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ import type { DrawRectOpt } from "./gfx/draw/drawRect";
 import type { DrawSpriteOpt } from "./gfx/draw/drawSprite";
 import type { DrawTextOpt } from "./gfx/draw/drawText";
 import type { DrawTriangleOpt } from "./gfx/draw/drawTriangle";
+import type { StyledTextInfo } from "./gfx/formatText";
 import type { Texture } from "./gfx/gfx";
 import type { Color, CSSColor, RGBAValue, RGBValue } from "./math/color";
 import type { GjkCollisionResult } from "./math/gjk";
@@ -5469,6 +5470,15 @@ export interface KAPLAYCtx<
      * @group Draw
      */
     formatText(options: DrawTextOpt): FormattedText;
+    /**
+     * Parses the text that has formatting tags, and returns the unstyled text
+     * (the actual characters that will be displayed) as well as which styles are
+     * active on each character.
+     *
+     * @since v4000
+     * @group Draw
+     */
+    compileStyledText(text: any): StyledTextInfo;
     /**
      * Create a canvas to draw stuff offscreen.
      *

--- a/tests/playtests/bigText.js
+++ b/tests/playtests/bigText.js
@@ -1,17 +1,20 @@
 kaplay();
 
 add([
-    text("text text text text text text text text text text text text text text text\ntext [big]big[/big] text\ntext text text", {
-        styles: {
-            big() {
-                return {
-                    scale: vec2(wave(3, 5, time())),
-                    stretchInPlace: false
-                };
-            }
+    text(
+        "text text text text text text text text text text text text text text text\ntext [big]big[/big] text\ntext text text",
+        {
+            styles: {
+                big() {
+                    return {
+                        scale: vec2(wave(3, 5, time())),
+                        stretchInPlace: false,
+                    };
+                },
+            },
+            width: width() / 2,
         },
-        width: width() / 2,
-    }),
+    ),
     pos(100, 100),
     area(),
 ]);

--- a/tests/playtests/bigText.js
+++ b/tests/playtests/bigText.js
@@ -1,0 +1,18 @@
+kaplay();
+
+add([
+    text("text text text text text text text text text text text text text text text\ntext [big]big[/big] text\ntext text text", {
+        styles: {
+            big() {
+                return {
+                    scale: vec2(wave(3, 5, time())),
+                    stretchInPlace: false
+                };
+            }
+        },
+        width: width() / 2,
+    }),
+    pos(100, 100),
+    area(),
+]);
+debug.inspect = true;

--- a/tests/playtests/pausedText.js
+++ b/tests/playtests/pausedText.js
@@ -1,0 +1,10 @@
+kaplay();
+
+add([
+    text("this text should not be moving", {
+        transform(i) {
+            return { pos: vec2(0, wave(-10, 10, time() + i)) };
+        }
+    }),
+    pos(100, 100),
+]).paused = true;

--- a/tests/playtests/pausedText.js
+++ b/tests/playtests/pausedText.js
@@ -4,7 +4,7 @@ add([
     text("this text should not be moving", {
         transform(i) {
             return { pos: vec2(0, wave(-10, 10, time() + i)) };
-        }
+        },
     }),
     pos(100, 100),
 ]).paused = true;

--- a/tests/playtests/textUnparse.js
+++ b/tests/playtests/textUnparse.js
@@ -1,0 +1,39 @@
+kaplay();
+
+const text = "hello [foo]styled[/foo] world \\[weird tag] with \\] [barbaz]some more [nested]text[/nested][/barbaz] bloop";
+// const text = "hello [a][b]a[/b][/a] goodbye";
+const formatted = compileStyledText(text);
+console.log(formatted);
+
+function tagDiff(l1, l2) {
+    var min = 0;
+    var out = "";
+    while (l1[min] === l2[min] && min < l1.length && min < l2.length)
+        min++;
+    for (var i = l1.length - 1; i >= min; i--)
+        out += `[/${l1[i]}]`;
+    for (var j = min; j < l2.length; j++)
+        out += `[${l2[j]}]`;
+    return out;
+}
+
+function sliceUnparse(formatted, start, end) {
+    if (!end) end = formatted.text.length;
+    var out = "";
+    var lastTags = [];
+    for (var i = start; i < end; i++) {
+        const curTags = formatted.charStyleMap[i] ?? [];
+        out += tagDiff(lastTags, curTags);
+        out += formatted.text[i].replace(/([\[\\])/g, "\\$1");
+        lastTags = curTags;
+    }
+    out += tagDiff(lastTags, []);
+    return out;
+}
+
+for (var start = 0; start < formatted.text.length; start++) {
+    for (var end = start + 1; end <= formatted.text.length; end++) {
+        const t = sliceUnparse(formatted, start, end);
+        console.log(t);
+    }
+}

--- a/tests/playtests/textUnparse.js
+++ b/tests/playtests/textUnparse.js
@@ -1,6 +1,7 @@
 kaplay();
 
-const text = "hello [foo]styled[/foo] world \\[weird tag] with \\] [barbaz]some more [nested]text[/nested][/barbaz] bloop";
+const text =
+    "hello [foo]styled[/foo] world \\[weird tag] with \\] [barbaz]some more [nested]text[/nested][/barbaz] bloop";
 // const text = "hello [a][b]a[/b][/a] goodbye";
 const formatted = compileStyledText(text);
 console.log(formatted);
@@ -8,12 +9,15 @@ console.log(formatted);
 function tagDiff(l1, l2) {
     var min = 0;
     var out = "";
-    while (l1[min] === l2[min] && min < l1.length && min < l2.length)
+    while (l1[min] === l2[min] && min < l1.length && min < l2.length) {
         min++;
-    for (var i = l1.length - 1; i >= min; i--)
+    }
+    for (var i = l1.length - 1; i >= min; i--) {
         out += `[/${l1[i]}]`;
-    for (var j = min; j < l2.length; j++)
+    }
+    for (var j = min; j < l2.length; j++) {
         out += `[${l2[j]}]`;
+    }
     return out;
 }
 


### PR DESCRIPTION
closes #509
closes #672

* compileStyledText is exposed, as well as a getter method formattedText() on the text component
* since the formattedText() object contains a renderedText property, the renderedText getter on the text comp is removed.
* fixes some state issues in the text component (text comp will stop recalculating the formatting if it is paused but not hidden -- this was intended but not implemented per a comment that I deleted)
* when I added the stretchy text characters in #676, I only made them stretch by x direction, now if stretchInPlace is false they will also stretch in the y-direction, and the line will get taller as a result.
* also, the doc comment listed the default for stretchInPlace to be false, but it was actually true.