### PR TITLE
fix: make wave() able to lerp any lerpable value

### DIFF
--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1460,13 +1460,13 @@ export class Mat4 {
     }
 }
 
-export function wave(
-    lo: number,
-    hi: number,
+export function wave<V extends LerpValue>(
+    lo: V,
+    hi: V,
     t: number,
     f = (t: number) => -Math.cos(t),
-): number {
-    return lo + (f(t) + 1) / 2 * (hi - lo);
+): V {
+    return lerp(lo, hi, (f(t) + 1) / 2);
 }
 
 // basic ANSI C LCG

--- a/src/types.ts
+++ b/src/types.ts
@@ -4370,7 +4370,7 @@ export interface KAPLAYCtx<
      */
     chance(p: number): boolean;
     /**
-     * Linear interpolation.
+     * Linear interpolation. Can take a number, vector, or color.
      *
      * @group Math
      */
@@ -4474,7 +4474,9 @@ export interface KAPLAYCtx<
      */
     mapc(v: number, l1: number, h1: number, l2: number, h2: number): number;
     /**
-     * Interpolate between 2 values (Optionally takes a custom periodic function, which default to Math.sin).
+     * Interpolate back and forth between 2 values.
+     * 
+     * (Optionally takes a custom periodic function, which default to a sine wave.).
      *
      * @example
      * ```js
@@ -4488,12 +4490,12 @@ export interface KAPLAYCtx<
      *
      * @group Math
      */
-    wave(
-        lo: number,
-        hi: number,
+    wave<V extends LerpValue>(
+        lo: V,
+        hi: V,
         t: number,
         func?: (x: number) => number,
-    ): number;
+    ): V;
     /**
      * Convert degrees to radians.
      *


### PR DESCRIPTION
closes #685

I made the function go from -1 to 1 as it was for backwards compatibility, but yeah the function going from 0 to 1 instead makes more sense, like the glsl mix() function.