### PR TITLE
fix: some examples were bugged

### DIFF
--- a/examples/fastLoop.js
+++ b/examples/fastLoop.js
@@ -7,20 +7,14 @@ loadBean();
 const interval = 0.001;
 const delay = 1;
 
-loop(
-    interval,
-    () => {
-        const bean = add([
-            sprite("bean"),
-            pos(rand(vec2(0), vec2(width(), height()))),
-        ]);
-        wait(delay, () => {
-            destroy(bean);
-        });
-    },
-    -1,
-    true,
-);
+loop(interval, () => {
+    add([
+        sprite("bean"),
+        pos(rand(vec2(0), vec2(width(), height()))),
+        lifespan(delay),
+        opacity(1),
+    ]);
+});
 
 const counter = add([
     pos(10, 10),

--- a/examples/raycastObject.js
+++ b/examples/raycastObject.js
@@ -49,7 +49,7 @@ onUpdate(() => {
     shapes.forEach(s1 => {
         if (
             shapes.some(s2 =>
-                s1 !== s2 && s1.getShape().collides(s2.getShape())
+                s1 !== s2 && s1.worldArea().collides(s2.worldArea())
             )
         ) {
             s1.color = RED;
@@ -80,8 +80,8 @@ onMousePress(() => {
     const pickList = shapes.filter((shape) => shape.hasPoint(pos));
     const selection = pickList[pickList.length - 1];
     if (selection) {
-        get("selected").forEach(s => s.unuse("selected"));
-        selection.use("selected");
+        get("selected").forEach(s => s.untag("selected"));
+        selection.tag("selected");
     }
 });
 
@@ -97,8 +97,8 @@ onMouseMove((pos, delta) => {
 });
 
 onMouseRelease(() => {
-    get("selected").forEach(s => s.unuse("selected"));
-    get("turn").forEach(s => s.unuse("turn"));
+    get("selected").forEach(s => s.untag("selected"));
+    get("turn").forEach(s => s.untag("turn"));
 });
 
 function laser() {
@@ -180,7 +180,7 @@ const ray = add([
     anchor("center"),
     rect(64, 64),
     area(),
-    laser(0),
+    laser(),
     color(RED),
     opacity(0.0),
     "laser",
@@ -194,12 +194,12 @@ get("laser").forEach(laser => {
         laser.showRing = false;
     });
     laser.onClick(() => {
-        get("selected").forEach(s => s.unuse("selected"));
+        get("selected").forEach(s => s.untag("selected"));
         if (laser.pos.sub(mousePos()).slen() > 28 * 28) {
-            laser.use("turn");
+            laser.tag("turn");
         }
         else {
-            laser.use("selected");
+            laser.tag("selected");
         }
     });
 });

--- a/examples/raycastShape.js
+++ b/examples/raycastShape.js
@@ -196,8 +196,8 @@ onMousePress(() => {
     const pickList = shapes.filter((shape) => shape.getShape().contains(pos));
     const selection = pickList[pickList.length - 1];
     if (selection) {
-        get("selected").forEach(s => s.unuse("selected"));
-        selection.use("selected");
+        get("selected").forEach(s => s.untag("selected"));
+        selection.tag("selected");
     }
 });
 
@@ -213,8 +213,8 @@ onMouseMove((pos, delta) => {
 });
 
 onMouseRelease(() => {
-    get("selected").forEach(s => s.unuse("selected"));
-    get("turn").forEach(s => s.unuse("turn"));
+    get("selected").forEach(s => s.untag("selected"));
+    get("turn").forEach(s => s.untag("turn"));
 });
 
 function laser() {
@@ -296,7 +296,7 @@ const ray = add([
     anchor("center"),
     rect(64, 64),
     area(),
-    laser(0),
+    laser(),
     color(RED),
     opacity(0.0),
     "laser",
@@ -310,12 +310,12 @@ get("laser").forEach(laser => {
         laser.showRing = false;
     });
     laser.onClick(() => {
-        get("selected").forEach(s => s.unuse("selected"));
+        get("selected").forEach(s => s.untag("selected"));
         if (laser.pos.sub(mousePos()).slen() > 28 * 28) {
-            laser.use("turn");
+            laser.tag("turn");
         }
         else {
-            laser.use("selected");
+            laser.tag("selected");
         }
     });
 });


### PR DESCRIPTION
* the loop example explicitly passed in a loop count of -1, which is not supported anymore to mean "infinity".
* the raycast examples still used unuse when they meant untag, which resulted in the onMouseRelease handler not releasing the selected objects and they got stuck to the mouse.