### PR TITLE
feat: improve text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `end` - @dragoncoder047
 - `wave()` can now go back and forth between any value that is able to be used
   with `lerp()` - @dragoncoder047, @mflerackers
+- The `textInput` component has more events: `focus`, `blur`, `input`, and `change`, to better interact with the text input state - @dragoncoder047
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Now if you pass a nullish value to `.use()` it throws an error
 - Improved TypeScript in game objects - @amyspark-ng, @lajbel, @KeSuave
   - Added/updated JSDoc comments to some members - @ErikGXDev, @dragoncoder047
+- The `textInput` component's `isFocused` property is now a one-hot lockout, setting it to true (focused) will clear focus from all the other text inputs - @dragoncoder047
 
 ## [3001.0.10] "Happy Colors" - TBD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `end` - @dragoncoder047
 - `wave()` can now go back and forth between any value that is able to be used
   with `lerp()` - @dragoncoder047, @mflerackers
-- The `textInput` component has more events: `focus`, `blur`, `input`, and `change`, to better interact with the text input state - @dragoncoder047
+- The `textInput` component has more events: `focus`, `blur`, `input`, and
+  `change`, to better interact with the text input state - @dragoncoder047
 
 ### Fixed
 
@@ -100,7 +101,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Now if you pass a nullish value to `.use()` it throws an error
 - Improved TypeScript in game objects - @amyspark-ng, @lajbel, @KeSuave
   - Added/updated JSDoc comments to some members - @ErikGXDev, @dragoncoder047
-- The `textInput` component's `isFocused` property is now a one-hot lockout, setting it to true (focused) will clear focus from all the other text inputs - @dragoncoder047
+- The `textInput` component's `isFocused` property is now a one-hot lockout,
+  setting it to true (focused) will clear focus from all the other text inputs -
+  @dragoncoder047
 
 ## [3001.0.10] "Happy Colors" - TBD
 

--- a/src/ecs/components/misc/textInput.ts
+++ b/src/ecs/components/misc/textInput.ts
@@ -36,7 +36,7 @@ export interface TextInputComp extends Comp {
     /**
      * Event that runs when the user types any character in the text input
      * and causes its value to change.
-     * 
+     *
      * This runs *after* the display text is updated with the escaped version
      * of the typed text, so in the event handler you can override the
      * displayed text with another version (like if you want to add syntax


### PR DESCRIPTION
closes #716

* adds four events to detect when the input is focused, loses focus, receives input, and is updated with changes
* makes the focus property a one hot lockout among all text inputs