### PR TITLE
fix: hp vs. hp() after #765

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Blocky imperative syntax for describing behaviors
 ```js
 // .onCollide() comes from "area" component
 player.onCollide("enemy", () => {
-    // .hurt() comes from "health" component
-    player.hurt(1);
+    // .health comes from "health" component
+    player.health--;
 });
 
 // check fall death

--- a/examples/ghosthunting.js
+++ b/examples/ghosthunting.js
@@ -206,7 +206,7 @@ function addEnemy(p) {
         {
             add() {
                 this.onHurt(() => {
-                    this.opacity = this.hp() / 100;
+                    this.opacity = this.hp / 100;
                 });
                 this.onDeath(() => {
                     const rect = this.localArea();
@@ -372,7 +372,7 @@ onMousePress(() => {
         });
         if (hit.object && hit.object.is("enemy")) {
             hit.object.moveBy(dir.unit().scale(10));
-            hit.object.hurt(20);
+            hit.object.hp -= 20;
         }
     }
 });

--- a/examples/shooter.js
+++ b/examples/shooter.js
@@ -48,7 +48,7 @@ scene("battle", () => {
 
     const music = play("OtherworldlyFoe");
 
-    volume(0.5);
+    setVolume(0.5);
 
     function grow(rate) {
         return {
@@ -293,7 +293,7 @@ scene("battle", () => {
 
     onCollide("bullet", "enemy", (b, e) => {
         destroy(b);
-        e.hurt(insaneMode ? 10 : 1);
+        e.hp -= insaneMode ? 10 : 1;
         addExplode(b.pos, 1, 24, 1);
     });
 
@@ -315,7 +315,7 @@ scene("battle", () => {
     });
 
     boss.onHurt(() => {
-        healthbar.set(boss.hp());
+        healthbar.set(boss.hp);
     });
 
     boss.onDeath(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1187,12 +1187,12 @@ export interface KAPLAYCtx<
      * ])
      *
      * player.onCollide("bad", (bad) => {
-     *     player.hurt(1)
-     *     bad.hurt(1)
+     *     player.health--;
+     *     bad.health--;
      * })
      *
      * player.onCollide("apple", () => {
-     *     player.heal(1)
+     *     player.health++;
      * })
      *
      * player.on("hurt", () => {

--- a/tests/playtests/areaLag.js
+++ b/tests/playtests/areaLag.js
@@ -1,0 +1,28 @@
+kaplay({
+    tagsAsComponents: true,
+});
+
+loadBean();
+
+function recur(obj, level) {
+    if (level < 0) return;
+    const obj2 = obj.add([
+        pos(rand(vec2(0), vec2(100))),
+        scale(rand(vec2(2))),
+        rotate(rand(0, 360)),
+    ]);
+    if (level === 0) {
+        obj2.use(sprite("bean"));
+        obj2.use(area());
+        // obj2.collisionIgnore.push("*");
+    }
+    recur(obj2, level - 1);
+}
+
+for (var i = 0; i < 500; i++)
+    recur(getTreeRoot(), 2);
+var frames = 0;
+onUpdate(() => {
+    frames++;
+    debug.log((frames / time()).toFixed());
+});


### PR DESCRIPTION
the hp was changed to a getter and not a function but the examples weren't updated so examples were crashing. 