### PR TITLE
fix: use an object event instead of an app event in AreaComp.onClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   @dragoncoder047
 - Changed the API of `HealthComp` - @amyspark-ng
 
+## [4000.0.0-alpha.20] - TBD
+
+### Fixed
+
+- Fixed `AreaComp#onClick()` attaching events to app, instead of object, so
+  event wasn't being paused with `obj.paused` - @lajbel
+
 ## [3001.0.18] - 2025-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed `AreaComp#onClick()` attaching events to app, instead of object, so
   event wasn't being paused with `obj.paused` - @lajbel
 
+## [3001.0.19] - TBD
+
+- Fixed `AreaComp#onClick()` attaching events to app, instead of object, so
+  event wasn't being paused with `obj.paused` - @lajbel
+
 ## [3001.0.18] - 2025-05-16
 
 ### Fixed

--- a/src/ecs/components/physics/area.ts
+++ b/src/ecs/components/physics/area.ts
@@ -417,11 +417,12 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
                 });
             }
 
-            const e = _k.app.onMousePress(btn, () => {
+            const e = this.onMousePress(btn, () => {
                 if (this.isHovering()) {
                     action();
                 }
             });
+
             events.push(e);
 
             return e;


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

Fixed `AreaComp#onClick()` attaching events to app, instead of object, so
  event wasn't being paused with `obj.paused`

## Summary

- [x] Changeloged
