### PR TITLE
fix: use an object event instead of an app event in AreaComp.onClick

### DIFF
--- a/src/components/physics/area.ts
+++ b/src/components/physics/area.ts
@@ -381,7 +381,7 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
             f: () => void,
             btn: MouseButton = "left",
         ): KEventController {
-            const e = _k.app.onMousePress(btn, () => {
+            const e = this.onMousePress(btn, () => {
                 if (this.isHovering()) {
                     f();
                 }


### PR DESCRIPTION
Reproduction of #779 