### PR TITLE
style: add hypens before param in jsDoc

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ export default tseslint.config(
             jsdoc,
         },
         rules: {
-            "jsdoc/require-jsdoc": "warn",
+            "jsdoc/require-hyphen-before-param-description": "error",
         },
         files: ["./src/**/*.ts"],
     },

--- a/src/ecs/components/level/patrol.ts
+++ b/src/ecs/components/level/patrol.ts
@@ -18,7 +18,7 @@ export interface PatrolComp extends Comp {
     nextLocation: Vec2 | undefined;
     /**
      * Attaches an event handler which is called when using "stop" and the end of the path is reached.
-     * @param cb The event handler called when the patrol finishes.
+     * @param cb - The event handler called when the patrol finishes.
      */
     onPatrolFinished(cb: (objects: GameObj[]) => void): KEventController;
 }

--- a/src/ecs/components/level/sentry.ts
+++ b/src/ecs/components/level/sentry.ts
@@ -29,14 +29,14 @@ export interface SentryComp extends Comp {
     spotted: GameObj<any>[];
     /**
      * Attaches an event handler which is called when objects of interest are spotted.
-     * @param cb The event handler called when objects are spotted.
+     * @param cb - The event handler called when objects are spotted.
      */
     onObjectsSpotted(cb: (objects: GameObj[]) => void): KEventController;
     /**
      * Returns true if the object is within the field of view.
-     * @param obj The object to test.
-     * @param direction The direction to look at.
-     * @param fieldOfView The field of view in degrees.
+     * @param obj - The object to test.
+     * @param direction - The direction to look at.
+     * @param fieldOfView - The field of view in degrees.
      */
     isWithinFieldOfView(
         obj: GameObj<PosComp>,
@@ -45,7 +45,7 @@ export interface SentryComp extends Comp {
     ): boolean;
     /**
      * Returns true if there is a line of sight to the object.
-     * @param obj The object to test.
+     * @param obj - The object to test.
      */
     hasLineOfSight(obj: GameObj<PosComp>): boolean;
 }

--- a/src/ecs/components/misc/animate.ts
+++ b/src/ecs/components/misc/animate.ts
@@ -79,9 +79,9 @@ export interface BaseValues {
 export interface AnimateComp extends Comp {
     /**
      * Animates a property on this object.
-     * @param name Name of the property to animate.
-     * @param keys Keys determining the value at a certain point in time.
-     * @param opts Options.
+     * @param name - Name of the property to animate.
+     * @param keys - Keys determining the value at a certain point in time.
+     * @param opts - Options.
      */
     animate<T extends LerpValue>(
         name: string,
@@ -90,7 +90,7 @@ export interface AnimateComp extends Comp {
     ): void;
     /**
      * Removes the animation from the given property.
-     * @param name Name of the property to remove the animation from.
+     * @param name - Name of the property to remove the animation from.
      */
     unanimate(name: string): void;
     /**
@@ -99,12 +99,12 @@ export interface AnimateComp extends Comp {
     unanimateAll(): void;
     /**
      * Attaches an event handler which is called when all the animation channels have finished.
-     * @param cb The event handler called when the animation finishes.
+     * @param cb - The event handler called when the animation finishes.
      */
     onAnimateFinished(cb: () => void): KEventController;
     /**
      * Attaches an event handler which is called when an animation channels has finished.
-     * @param cb The event handler called when an animation channel finishes.
+     * @param cb - The event handler called when an animation channel finishes.
      */
     onAnimateChannelFinished(cb: (name: string) => void): KEventController;
     /**
@@ -168,8 +168,8 @@ class AnimateChannel {
 
     /**
      * Returns the first key index for the given time, as well as the relative time towards the second key.
-     * @param t The time in seconds.
-     * @param timing The optional timestamps in percent.
+     * @param t - The time in seconds.
+     * @param timing - The optional timestamps in percent.
      * @returns The first key index for the given time, as well as the relative time towards the second key.
      */
     getLowerKeyIndexAndRelativeTime(
@@ -267,8 +267,8 @@ class AnimateChannel {
 
 /**
  * Reflects a point around another point
- * @param a Point to reflect
- * @param b Point to reflect around
+ * @param a - Point to reflect
+ * @param b - Point to reflect around
  * @returns Reflected point
  */
 function reflect(a: Vec2, b: Vec2) {
@@ -645,8 +645,8 @@ export function animate(gopts: AnimateCompOpt = {}): AnimateComp {
 
 /**
  * Serializes an animation to javascript objects for serialization to JSON.
- * @param obj The root object to serialize from.
- * @param name Optional name of the root object.
+ * @param obj - The root object to serialize from.
+ * @param name - Optional name of the root object.
  * @returns A javascript object serialization of the animation.
  */
 export function serializeAnimation(obj: GameObj<any>, name: string): any {
@@ -694,8 +694,8 @@ function deserializeOptions(options: AnimationOptions) {
 
 /**
  * Applies the animation to this object and its named children
- * @param obj The root object to deserialize to.
- * @param animation A javascript object serialization of the animation.
+ * @param obj - The root object to deserialize to.
+ * @param animation - A javascript object serialization of the animation.
  */
 export function applyAnimation(obj: GameObj<any>, animation: Animation) {
     // TODO: test this

--- a/src/ecs/components/physics/body.ts
+++ b/src/ecs/components/physics/body.ts
@@ -77,12 +77,12 @@ export interface BodyComp extends Comp {
     isJumping(): boolean;
     /**
      * Applies an impulse
-     * @param impulse The impulse vector, applied directly
+     * @param impulse - The impulse vector, applied directly
      */
     applyImpulse(impulse: Vec2): void;
     /**
      * Applies a force
-     * @param force The force vector, applied after scaled by the inverse mass
+     * @param force - The force vector, applied after scaled by the inverse mass
      */
     addForce(force: Vec2): void;
     /**

--- a/src/gfx/draw/drawPicture.ts
+++ b/src/gfx/draw/drawPicture.ts
@@ -30,7 +30,7 @@ export class Picture {
 
     /**
      * Creates an empty picture if no data is given, otherwise deserializes the data
-     * @param data Optional archived picture data
+     * @param data - Optional archived picture data
      */
     constructor(data?: string) {
         this.vertices = [];
@@ -77,8 +77,8 @@ export type DrawPictureOpt = RenderProps & {};
 
 /**
  * Draws a picture to the screen. This function can not be used to draw recursively to a picture.
- * @param picture The picture to draw
- * @param opt Drawing options
+ * @param picture - The picture to draw
+ * @param opt - Drawing options
  */
 export function drawPicture(
     picture: Picture,
@@ -173,7 +173,7 @@ export function drawPicture(
 
 /**
  * Selects the picture for drawing, erases existing data.
- * @param picture The picture to write drawing data to.
+ * @param picture - The picture to write drawing data to.
  */
 export function beginPicture(picture?: Picture) {
     picture ??= new Picture();
@@ -185,7 +185,7 @@ export function beginPicture(picture?: Picture) {
 
 /**
  * Selects the picture for drawing, keeps existing data.
- * @param picture The picture to write drawing data to.
+ * @param picture - The picture to write drawing data to.
  */
 export function appendToPicture(picture?: Picture) {
     picture ??= new Picture();

--- a/src/math/Vec2.ts
+++ b/src/math/Vec2.ts
@@ -85,10 +85,10 @@ export class Vec2 {
 
     /**
      * Calculates the sum of the vectors
-     * @param v The first term
-     * @param x The x of the second term
-     * @param y The y of the second term
-     * @param out The vector sum
+     * @param v - The first term
+     * @param x - The x of the second term
+     * @param y - The y of the second term
+     * @param out - The vector sum
      * @returns The sum of the vectors
      */
     static addc(v: Vec2, x: number, y: number, out: Vec2): Vec2 {
@@ -99,9 +99,9 @@ export class Vec2 {
 
     /**
      * Calculates the sum of the vectors
-     * @param v The first term
-     * @param other The second term
-     * @param out The vector sum
+     * @param v - The first term
+     * @param other - The second term
+     * @param out - The vector sum
      * @returns The sum of the vectors
      */
     static add(v: Vec2, other: Vec2, out: Vec2): Vec2 {
@@ -118,10 +118,10 @@ export class Vec2 {
 
     /**
      * Calculates the difference of the vectors
-     * @param v The first term
-     * @param x The x of the second term
-     * @param y The y of the second term
-     * @param out The vector difference
+     * @param v - The first term
+     * @param x - The x of the second term
+     * @param y - The y of the second term
+     * @param out - The vector difference
      * @returns The difference of the vectors
      */
     static subc(v: Vec2, x: number, y: number, out: Vec2): Vec2 {
@@ -132,9 +132,9 @@ export class Vec2 {
 
     /**
      * Calculates the difference of the vectors
-     * @param v The first term
-     * @param other The second term
-     * @param out The vector difference
+     * @param v - The first term
+     * @param other - The second term
+     * @param out - The vector difference
      * @returns The difference of the vectors
      */
     static sub(v: Vec2, other: Vec2, out: Vec2): Vec2 {
@@ -151,10 +151,10 @@ export class Vec2 {
 
     /**
      * Calculates the scale of the vector
-     * @param v The vector
-     * @param x The x scale
-     * @param y The y scale
-     * @param out The scaled vector
+     * @param v - The vector
+     * @param x - The x scale
+     * @param y - The y scale
+     * @param out - The scaled vector
      * @returns The scale of the vector
      */
     static scale(v: Vec2, s: number, out: Vec2): Vec2 {
@@ -165,10 +165,10 @@ export class Vec2 {
 
     /**
      * Calculates the scale of the vector
-     * @param v The vector
-     * @param x The x scale
-     * @param y The y scale
-     * @param out The scaled vector
+     * @param v - The vector
+     * @param x - The x scale
+     * @param y - The y scale
+     * @param out - The scaled vector
      * @returns The scale of the vector
      */
     static scalec(v: Vec2, x: number, y: number, out: Vec2): Vec2 {
@@ -179,9 +179,9 @@ export class Vec2 {
 
     /**
      * Calculates the scale of the vector
-     * @param v The vector
-     * @param other The scale
-     * @param out The scaled vector
+     * @param v - The vector
+     * @param other - The scale
+     * @param out - The scaled vector
      * @returns The scale of the vector
      */
     static scalev(v: Vec2, other: Vec2, out: Vec2): Vec2 {
@@ -204,8 +204,8 @@ export class Vec2 {
 
     /**
      * Calculates the distance between the vectors
-     * @param v The vector
-     * @param other The other vector
+     * @param v - The vector
+     * @param other - The other vector
      * @returns The between the vectors
      */
     static dist(v: Vec2, other: Vec2): number {
@@ -222,8 +222,8 @@ export class Vec2 {
 
     /**
      * Calculates the squared distance between the vectors
-     * @param v The vector
-     * @param other The other vector
+     * @param v - The vector
+     * @param other - The other vector
      * @returns The distance between the vectors
      */
     static sdist(v: Vec2, other: Vec2): number {
@@ -243,7 +243,7 @@ export class Vec2 {
 
     /**
      * Calculates the length of the vector
-     * @param v The vector
+     * @param v - The vector
      * @returns The length of the vector
      */
     static len(v: Vec2) {
@@ -261,7 +261,7 @@ export class Vec2 {
 
     /**
      * Calculates the squared length of the vector
-     * @param v The vector
+     * @param v - The vector
      * @returns The squared length of the vector
      */
     static slen(v: Vec2) {
@@ -343,9 +343,9 @@ export class Vec2 {
 
     /**
      * Calculates the rotated vector
-     * @param v The vector
-     * @param dir The rotation vector
-     * @param out The rotated vector
+     * @param v - The vector
+     * @param dir - The rotation vector
+     * @param out - The rotated vector
      * @returns The rotated vector
      */
     static rotate(v: Vec2, dir: Vec2, out: Vec2): Vec2 {
@@ -357,9 +357,9 @@ export class Vec2 {
 
     /**
      * Calculates the rotated vector
-     * @param v The vector
-     * @param angle The angle in radians
-     * @param out The rotated vector
+     * @param v - The vector
+     * @param angle - The angle in radians
+     * @param out - The rotated vector
      * @returns The rotated vector
      */
     static rotateByAngle(v: Vec2, angle: number, out: Vec2): Vec2 {
@@ -382,9 +382,9 @@ export class Vec2 {
 
     /**
      * Calculates the inverse rotated vector
-     * @param v The vector
-     * @param dir The rotation vector
-     * @param out The rotated vector
+     * @param v - The vector
+     * @param dir - The rotation vector
+     * @param out - The rotated vector
      * @returns The rotated vector
      */
     static inverseRotate(v: Vec2, dir: Vec2, out: Vec2): Vec2 {
@@ -438,7 +438,7 @@ export class Vec2 {
 
     /**
      * Calculates the angle represented by the vector in radians
-     * @param v The vector
+     * @param v - The vector
      * @returns Angle represented by the vector in radians
      */
     static toAngle(v: Vec2) {
@@ -457,8 +457,8 @@ export class Vec2 {
 
     /**
      * Calculates the angle between the vectors in radians
-     * @param v First vector
-     * @param other Second vector
+     * @param v - First vector
+     * @param other - Second vector
      * @returns Angle between the vectors in radians
      */
     static angleBetween(v: Vec2, other: Vec2) {
@@ -477,10 +477,10 @@ export class Vec2 {
 
     /**
      * Linear interpolate src and dst by t
-     * @param src First vector
-     * @param dst Second vector
-     * @param t Percentage
-     * @param out The linear interpolation between src and dst by t
+     * @param src - First vector
+     * @param dst - Second vector
+     * @param t - Percentage
+     * @param out - The linear interpolation between src and dst by t
      * @returns The linear interpolation between src and dst by t
      */
     static lerp(src: Vec2, dst: Vec2, t: number, out: Vec2): Vec2 {
@@ -506,10 +506,10 @@ export class Vec2 {
 
     /**
      * Spherical interpolate src and dst by t
-     * @param src First vector
-     * @param dst Second vector
-     * @param t Percentage
-     * @param out The spherical interpolation between src and dst by t
+     * @param src - First vector
+     * @param dst - Second vector
+     * @param t - Percentage
+     * @param out - The spherical interpolation between src and dst by t
      * @returns The spherical interpolation between src and dst by t
      */
     static slerp(src: Vec2, dst: Vec2, t: number, out: Vec2): Vec2 {

--- a/src/math/gjk.ts
+++ b/src/math/gjk.ts
@@ -7,7 +7,7 @@ interface Collider {
     center: Vec2;
     /**
      * This function needs to return the furthest point of the collider in the given direction.
-     * @param direction The direction to search in.
+     * @param direction - The direction to search in.
      */
     support(direction: Vec2): Vec2;
 }
@@ -219,8 +219,8 @@ function evolveSimplex(
 
 /**
  * Returns true if the colliders intersect.
- * @param colliderA The first collider to test
- * @param colliderB The second collider to test
+ * @param colliderA - The first collider to test
+ * @param colliderB - The second collider to test
  * @returns True if the colliders intersect
  */
 function gjkIntersects(colliderA: Collider, colliderB: Collider): boolean {
@@ -247,8 +247,8 @@ type Edge = {
 
 /**
  * Returns the edge closest to the origin.
- * @param simplex The simplex whose edges we will check to find the closest edge to the origin
- * @param winding The winding order of the simplex
+ * @param simplex - The simplex whose edges we will check to find the closest edge to the origin
+ * @param winding - The winding order of the simplex
  * @returns The edge closest to the origin.
  */
 function findClosestEdge(simplex: Vec2[], winding: PolygonWinding): Edge {
@@ -301,8 +301,8 @@ export type GjkCollisionResult = {
 
 /**
  * Returns true if the shapes collide
- * @param colliderA The first collider to test
- * @param colliderB The second collider to test
+ * @param colliderA - The first collider to test
+ * @param colliderB - The second collider to test
  * @returns True if the shapes collide
  */
 function getIntersection(
@@ -362,8 +362,8 @@ function getIntersection(
 
 /**
  * Returns a collision result if there was a collision
- * @param colliderA The first collider to test
- * @param colliderB The second collider to test
+ * @param colliderA - The first collider to test
+ * @param colliderB - The second collider to test
  * @returns A collision result or null
  */
 function gjkIntersection(
@@ -388,7 +388,7 @@ function gjkIntersection(
 
 /**
  * Returns a collider for the given shape.
- * @param shape The shape to get a collider for.
+ * @param shape - The shape to get a collider for.
  * @returns
  */
 function shapeToCollider(shape: Shape): Collider {
@@ -419,8 +419,8 @@ function shapeToCollider(shape: Shape): Collider {
 
 /**
  * Returns true if the shapes collide
- * @param shapeA The first shape to test
- * @param shapeB The second shape to test
+ * @param shapeA - The first shape to test
+ * @param shapeB - The second shape to test
  * @returns True if the shapes collide
  */
 export function gjkShapeIntersects(shapeA: Shape, shapeB: Shape): boolean {
@@ -431,8 +431,8 @@ export function gjkShapeIntersects(shapeA: Shape, shapeB: Shape): boolean {
 
 /**
  * Returns a collision result if there was a collision
- * @param shapeA The first shape to test
- * @param shapeB The second shape to test
+ * @param shapeA - The first shape to test
+ * @param shapeB - The second shape to test
  * @returns A collision result or null
  */
 export function gjkShapeIntersection(

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -2400,10 +2400,10 @@ export function curveLengthApproximation(
 
 /**
  * A second order function returning an evaluator for the given 1D Hermite curve
- * @param pt1 First point
- * @param m1 First control point (tangent)
- * @param m2 Second control point (tangent)
- * @param pt2 Second point
+ * @param pt1 - First point
+ * @param m1 - First control point (tangent)
+ * @param m2 - Second control point (tangent)
+ * @param pt2 - Second point
  * @returns A function which gives the value on the 1D Hermite curve at t
  */
 export function hermite(pt1: number, m1: number, m2: number, pt2: number) {
@@ -2421,12 +2421,12 @@ export function hermite(pt1: number, m1: number, m2: number, pt2: number) {
 
 /**
  * A second order function returning an evaluator for the given 2D Cardinal curve
- * @param pt1 Previous point
- * @param pt2 First point
- * @param pt3 Second point
- * @param pt4 Next point
- * @param tension The tension of the curve, [0..1] from round to tight.
- * @param h The hermite function or one of its derivatives.
+ * @param pt1 - Previous point
+ * @param pt2 - First point
+ * @param pt3 - Second point
+ * @param pt4 - Next point
+ * @param tension - The tension of the curve, [0..1] from round to tight.
+ * @param h - The hermite function or one of its derivatives.
  * @returns A function which gives the value on the 2D Cardinal curve at t
  */
 export function cardinal(
@@ -2456,10 +2456,10 @@ export function cardinal(
 
 /**
  * A second order function returning an evaluator for the given 2D Catmull-Rom curve
- * @param pt1 Previous point
- * @param pt2 First point
- * @param pt3 Second point
- * @param pt4 Next point
+ * @param pt1 - Previous point
+ * @param pt2 - First point
+ * @param pt3 - Second point
+ * @param pt4 - Next point
  * @returns A function which gives the value on the 2D Catmull-Rom curve at t
  */
 export function catmullRom(
@@ -2475,10 +2475,10 @@ export function catmullRom(
 
 /**
  * A second order function returning an evaluator for the given 2D quadratic Bezier curve
- * @param pt1 First point
- * @param pt2 First control point
- * @param pt3 Second control point
- * @param pt4 Second point
+ * @param pt1 - First point
+ * @param pt2 - First control point
+ * @param pt3 - Second control point
+ * @param pt4 - Second point
  * @returns A function which gives the value on the 2D quadratic Bezier curve at t
  */
 export function bezier(
@@ -2500,13 +2500,13 @@ export function bezier(
 
 /**
  * A second order function returning an evaluator for the given 2D Kochanek–Bartels curve
- * @param pt1 Previous point
- * @param pt2 First point
- * @param pt3 Second point
- * @param pt4 Next point
- * @param tension The tension of the curve, [-1..1] from round to tight.
- * @param continuity The continuity of the curve, [-1..1] from box corners to inverted corners.
- * @param bias The bias of the curve, [-1..1] from pre-shoot to post-shoot.
+ * @param pt1 - Previous point
+ * @param pt2 - First point
+ * @param pt3 - Second point
+ * @param pt4 - Next point
+ * @param tension - The tension of the curve, [-1..1] from round to tight.
+ * @param continuity - The continuity of the curve, [-1..1] from box corners to inverted corners.
+ * @param bias - The bias of the curve, [-1..1] from pre-shoot to post-shoot.
  * @returns A function which gives the value on the 2D Kochanek–Bartels curve at t
  */
 export function kochanekBartels(
@@ -2546,10 +2546,10 @@ export function kochanekBartels(
 
 /**
  * A second order function returning an evaluator for the derivative of the given 1D Hermite curve
- * @param pt1 First point
- * @param m1 First control point (tangent)
- * @param m2 Second control point (tangent)
- * @param pt2 Second point
+ * @param pt1 - First point
+ * @param m1 - First control point (tangent)
+ * @param m2 - Second control point (tangent)
+ * @param pt2 - Second point
  * @returns A function which gives the first derivative on the 1D Hermite curve at t
  */
 export function hermiteFirstDerivative(

--- a/src/math/navigationgrid.ts
+++ b/src/math/navigationgrid.ts
@@ -17,8 +17,8 @@ export class Grid implements Graph {
     private _connMap: number[];
 
     /**
-     * @param data Grid data
-     * @param options Navigation options
+     * @param data - Grid data
+     * @param options - Navigation options
      */
     constructor(
         width: number,

--- a/src/math/spatial/sweepandprune.ts
+++ b/src/math/spatial/sweepandprune.ts
@@ -31,7 +31,7 @@ export class SweepAndPrune {
 
     /**
      * Add the object and its edges to the list
-     * @param obj The object to add
+     * @param obj - The object to add
      */
     add(obj: GameObj<AreaComp>) {
         const left = new Edge(obj, true);
@@ -43,7 +43,7 @@ export class SweepAndPrune {
 
     /**
      * Remove the object and its edges from the list
-     * @param obj The object to remove
+     * @param obj - The object to remove
      */
     remove(obj: GameObj<AreaComp>) {
         const pair = this.objects.get(obj);

--- a/src/types.ts
+++ b/src/types.ts
@@ -682,8 +682,8 @@ export interface KAPLAYCtx<
     /**
      * Draws a video.
      *
-     * @param url The video to play. Needs to be on the same webserver due to CORS.
-     * @param opt The video component options
+     * @param url - The video to play. Needs to be on the same webserver due to CORS.
+     * @param opt - The video component options
      *
      * @returns The video comp.
      * @since v4000.0
@@ -693,7 +693,7 @@ export interface KAPLAYCtx<
     /**
      * Draws a picture.
      *
-     * @param picture The picture to draw.
+     * @param picture - The picture to draw.
      *
      * @returns The picture comp.
      * @since v4000.0
@@ -1865,7 +1865,7 @@ export interface KAPLAYCtx<
      * Register an event that runs once for each asset that failed to load,
      * after all others have completed.
      *
-     * @param action The function to run when the event is triggered.
+     * @param action - The function to run when the event is triggered.
      *
      * @example
      * ```js
@@ -2281,7 +2281,7 @@ export interface KAPLAYCtx<
     /**
      * Register an event that runs when user release certain keys.
      *
-     * @param k = The key(s) to listen for. See {@link Key `Key`}.
+     * @param k - = The key(s) to listen for. See {@link Key `Key`}.
      * @param action - The function that runs when a user releases certain keys
      *
      * @example
@@ -4464,11 +4464,11 @@ export interface KAPLAYCtx<
      *
      * For clamping check {@link mapc}
      *
-     * @param v The value the function will depend on.
-     * @param l1 The minimum value of the source range.
-     * @param h1 The minimum result value.
-     * @param l2 The maximum value of the source range.
-     * @param h2 The maximum result value.
+     * @param v - The value the function will depend on.
+     * @param l1 - The minimum value of the source range.
+     * @param h1 - The minimum result value.
+     * @param l2 - The maximum value of the source range.
+     * @param h2 - The maximum result value.
      *
      * @example
      * ```js
@@ -4487,11 +4487,11 @@ export interface KAPLAYCtx<
     /**
      * Map a value from one range to another range, and clamp to the dest range.
      *
-     * @param v The value the function will depend on.
-     * @param l1 The minimum value of the source range.
-     * @param h1 The minimum result value.
-     * @param l2 The maximum value of the source range.
-     * @param h2 The maximum result value.
+     * @param v - The value the function will depend on.
+     * @param l1 - The minimum value of the source range.
+     * @param h1 - The minimum result value.
+     * @param l2 - The maximum value of the source range.
+     * @param h2 - The maximum result value.
      *
      * @example
      * ```js
@@ -4679,7 +4679,7 @@ export interface KAPLAYCtx<
      * @param pt2 - First point
      * @param pt3 - Second point
      * @param pt4 - Next point
-     * @param tension The tension of the curve, [0..1] from round to tight.
+     * @param tension - The tension of the curve, [0..1] from round to tight.
      * @returns A function which gives the value on the 2D Cardinal curve at t
      */
     cardinal(
@@ -5390,12 +5390,12 @@ export interface KAPLAYCtx<
     Picture: typeof Picture;
     /**
      * Selects the picture for drawing, erases existing data.
-     * @param picture The picture to write drawing data to.
+     * @param picture - The picture to write drawing data to.
      */
     beginPicture(picture?: Picture): void;
     /**
      * Selects the picture for drawing, keeps existing data.
-     * @param picture The picture to write drawing data to.
+     * @param picture - The picture to write drawing data to.
      */
     appendToPicture(picture?: Picture): void;
     /**
@@ -5405,8 +5405,8 @@ export interface KAPLAYCtx<
     endPicture(): Picture;
     /**
      * Draws a picture to the screen. This function can not be used to draw recursively to a picture.
-     * @param picture The picture to draw
-     * @param opt Drawing options
+     * @param picture - The picture to draw
+     * @param opt - Drawing options
      */
     drawPicture(picture: Picture, opt: DrawPictureOpt): void;
     /**
@@ -5539,7 +5539,7 @@ export interface KAPLAYCtx<
     /**
      * Draw a canvas.
      *
-     * @param opt The canvas object.
+     * @param opt - The canvas object.
      *
      * @since v4000.0
      * @group Draw
@@ -5575,9 +5575,9 @@ export interface KAPLAYCtx<
     /**
      * Runs a system at the specified events in the pipeline
      *
-     * @param name The name of the system. Overwrites an existing system if the name has been used before.
-     * @param cb The function to run.
-     * @param when When to run the function.
+     * @param name - The name of the system. Overwrites an existing system if the name has been used before.
+     * @param cb - The function to run.
+     * @param when - When to run the function.
      *
      * @since v4000.0
      * @group Plugins


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

This PR adds an ESLint rule to ensure all `@param` tags are using a hyphen before the description, for proper styled docs

