### PR TITLE
fix: don't use destructuring for swap

### DIFF
--- a/src/math/spatial/sweepandprune.ts
+++ b/src/math/spatial/sweepandprune.ts
@@ -76,7 +76,7 @@ export class SweepAndPrune {
                 if (this.edges[j].x < this.edges[j + 1].x) break;
                 const temp = this.edges[j];
                 this.edges[j] = this.edges[j + 1];
-                this.edges[j] = temp;
+                this.edges[j + 1] = temp;
             }
         }
     }


### PR DESCRIPTION
I noticed that the update for the sweepandprune started allocating ludicrous amounts of memory and hammering the garbage collector when objects crossed each other vertically. It turned out that the swap using destructuring was actually allocating a 2-element array only to destructure it and discard the array. This uses the old-style temp variable swap method that doesn't allocate any more memory.