### PR TITLE
doc: Add default doc in BitmapFont Opt, remove unused outline option and remove another BinaryData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4000.0.0-alpha.20] - TBD
 
+### Added
+
+- Improved various doc entries.
+
 ### Fixed
 
 - Fixed `AreaComp#onClick()` attaching events to app, instead of object, so

--- a/src/assets/bitmapFont.ts
+++ b/src/assets/bitmapFont.ts
@@ -20,12 +20,15 @@ export function getBitmapFont(name: string): Asset<BitmapFontData> | null {
 }
 
 export interface LoadBitmapFontOpt {
+    /**
+     * A string of characters to map to every sprite in the characters grid
+     *
+     * @default " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+     */
     chars?: string;
     filter?: TexFilter;
-    outline?: number;
 }
 
-// TODO: support outline
 // TODO: support LoadSpriteSrc
 export function loadBitmapFont(
     name: string | null,

--- a/src/assets/font.ts
+++ b/src/assets/font.ts
@@ -94,7 +94,7 @@ export function getFont(name: string): Asset<FontData> | null {
 // TODO: pass in null src to store opt for default fonts like "monospace"
 export function loadFont(
     name: string,
-    src: string | BinaryData,
+    src: string | ArrayBuffer | ArrayBufferView,
     opt: LoadFontOpt = {},
 ): Asset<FontData> {
     const font = new FontFace(


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

Basically, what title says. Little PR :p

## Summary

- [x] Changeloged
