### PR TITLE
feat: allow sprites to be used as a font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `stretchInPlace: false` - @dragoncoder047
 - Expose the formatted text parsing functions to allow manipulation of formatted
   text - @dragoncoder047
+- Now you can use the frames of a sprite in an atlas also as a font - @dragoncoder047
 - More errors raised during object creation are caught and cause the blue crash
   screen - @lajbel
 - Now you can use the global option `inspectOnlyActive: false` to prevent paused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `stretchInPlace: false` - @dragoncoder047
 - Expose the formatted text parsing functions to allow manipulation of formatted
   text - @dragoncoder047
-- Now you can use the frames of a sprite in an atlas also as a font - @dragoncoder047
+- Now you can use the frames of a sprite in an atlas also as a font -
+  @dragoncoder047
 - More errors raised during object creation are caught and cause the blue crash
   screen - @lajbel
 - Now you can use the global option `inspectOnlyActive: false` to prevent paused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed all touch events having a bad transform - @lajbel
 - Fixed sprite scaling not working properly when letterbox - @mflerackers
 
+### Added
+
+- Now you can use the frames of a sprite in an atlas also as a font -
+  @dragoncoder047
+
 ### Removed
 
 - `loadPedit` was removed - @lajbel

--- a/src/assets/bitmapFont.ts
+++ b/src/assets/bitmapFont.ts
@@ -68,7 +68,10 @@ export function loadBitmapFontFromSprite(
                     `Duplicate characters given when defining sprite font "${spriteID}": ${chars}`,
                 );
             }
-            const spr = await _k.assets.sprites.waitFor(spriteID);
+            const spr = await _k.assets.sprites.waitFor(
+                spriteID,
+                _k.globalOpt.loadTimeout ?? 3000,
+            );
             const frames = spr.frames;
             if (frames.length < splittedChars.length) {
                 throw new Error(

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,4 +1,3 @@
-import type { App } from "../app/app";
 import { getData, setData } from "../app/data";
 import { loadAseprite } from "../assets/aseprite";
 import {
@@ -9,18 +8,21 @@ import {
     loadProgress,
     loadRoot,
 } from "../assets/asset";
-import { getBitmapFont, loadBitmapFont, loadHappy } from "../assets/bitmapFont";
+import {
+    getBitmapFont,
+    loadBitmapFont,
+    loadBitmapFontFromSprite,
+    loadHappy,
+} from "../assets/bitmapFont";
 import { getFont, loadFont } from "../assets/font";
 import { getShader, loadShader, loadShaderURL } from "../assets/shader";
 import { getSound, loadMusic, loadSound, SoundData } from "../assets/sound";
 import { getSprite, loadBean, loadSprite, SpriteData } from "../assets/sprite";
 import { loadSpriteAtlas } from "../assets/spriteAtlas";
-import type { AudioCtx } from "../audio/audio";
 import { burp } from "../audio/burp";
 import { play } from "../audio/play";
 import { getVolume, setVolume, volume } from "../audio/volume";
 import { ASCII_CHARS, EVENT_CANCEL_SYMBOL } from "../constants/general";
-import type { Debug } from "../debug/debug";
 import { record } from "../debug/record";
 import { blend } from "../ecs/components/draw/blend";
 import { circle } from "../ecs/components/draw/circle";
@@ -126,7 +128,6 @@ import {
     toScreen,
     toWorld,
 } from "../game/camera";
-import type { Game } from "../game/game";
 import {
     getGravity,
     getGravityDirection,
@@ -277,6 +278,7 @@ export const createContext = (
         loadMusic,
         loadBitmapFont,
         loadFont,
+        loadBitmapFontFromSprite,
         loadShader,
         loadShaderURL,
         loadAseprite,

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -124,12 +124,10 @@ function getFontName(font: FontData | string): string {
 }
 
 function getFontAtlasForFont(font: FontData | string): FontAtlas {
-    let atlas = _k.gfx.fontAtlases[getFontName(font)];
+    const fontName = getFontName(font);
+    let atlas = _k.gfx.fontAtlases[fontName];
     if (!atlas) {
         // create a new atlas
-        const fontName = font instanceof FontData
-            ? font.fontface.family
-            : font;
         const opts: {
             outline: Outline | null;
             filter: TexFilter;
@@ -372,10 +370,20 @@ export function formatText(opt: DrawTextOpt): FormattedText {
             }
             var requestedFontData = defGfxFont;
             if (requestedFont && requestedFont !== defaultFontValue) {
-                requestedFontData = getFontAtlasForFont(requestedFont).font;
+                if (
+                    resolvedFont instanceof FontData
+                    || typeof resolvedFont === "string"
+                ) {
+                    requestedFontData = getFontAtlasForFont(requestedFont).font;
+                }
+                else requestedFontData = resolvedFont;
                 theFChar.tex = requestedFontData.tex;
             }
-            if (requestedFont) updateFontAtlas(requestedFont, ch);
+            if (
+                requestedFont
+                && (resolvedFont instanceof FontData
+                    || typeof resolvedFont === "string")
+            ) updateFontAtlas(requestedFont, ch);
 
             let q = requestedFontData.map[ch];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3107,6 +3107,29 @@ export interface KAPLAYCtx<
         opt?: LoadBitmapFontOpt,
     ): Asset<BitmapFontData>;
     /**
+     * Define the frames of an existing sprite as characters that can be used as a font.
+     *
+     * This waits for the sprite to load before defining the font.
+     * This is so async loaders like {@link loadSpriteAtlas} can be used and still work.
+     *
+     * WARNING - if you don't define the sprite or it fails to load, your game will get stuck
+     * on the loading screen. Take care to actually make sure your sprite will load reliably
+     * before adding this function.
+     *
+     * @param sprite - The ID of the sprite to use as a font. Must already have frames defined
+     * @param chars - The characters that correspond to each of the frames in the sprite. You can't use
+     * space or newline here because those are hard-coded to special behaviors in the text layout code.
+     *
+     * @returns The generated font data.
+     * @group Assets
+     *
+     * @see {@link LoadSpriteOpt LoadSpriteOpt}
+     */
+    loadBitmapFontFromSprite(
+        sprite: string,
+        chars: string,
+    ): Asset<BitmapFontData>;
+    /**
      * Load a shader with vertex and fragment code.
      *
      * @param name - The asset name.

--- a/src/types.ts
+++ b/src/types.ts
@@ -3109,12 +3109,13 @@ export interface KAPLAYCtx<
     /**
      * Define the frames of an existing sprite as characters that can be used as a font.
      *
-     * This waits for the sprite to load before defining the font.
-     * This is so async loaders like {@link loadSpriteAtlas} can be used and still work.
+     * This was primarily intended for use with {@link loadSpriteAtlas} because the sprite in
+     * question usually isn't the whole image and so can't be also passed to {@link loadBitmapFont}
+     * as its own font.
      *
-     * WARNING - if you don't define the sprite or it fails to load, your game will get stuck
-     * on the loading screen. Take care to actually make sure your sprite will load reliably
-     * before adding this function.
+     * WARNING - since this waits for the sprite to load before doing anything, if you don't
+     * define the sprite or it fails to load, your game will get stuck on the loading screen.
+     * Take care to actually make sure your sprite will load reliably before adding this function.
      *
      * @param sprite - The ID of the sprite to use as a font. Must already have frames defined
      * @param chars - The characters that correspond to each of the frames in the sprite. You can't use

--- a/src/types.ts
+++ b/src/types.ts
@@ -3113,9 +3113,8 @@ export interface KAPLAYCtx<
      * question usually isn't the whole image and so can't be also passed to {@link loadBitmapFont}
      * as its own font.
      *
-     * WARNING - since this waits for the sprite to load before doing anything, if you don't
-     * define the sprite or it fails to load, your game will get stuck on the loading screen.
-     * Take care to actually make sure your sprite will load reliably before adding this function.
+     * This waits for the sprite to load before doing anything, but if the sprite doesn't load, the game
+     * will transition to the error screen after a timeout (which is set by {@link KAPLAYOpt.loadTimeout}).
      *
      * @param sprite - The ID of the sprite to use as a font. Must already have frames defined
      * @param chars - The characters that correspond to each of the frames in the sprite. You can't use
@@ -3124,7 +3123,7 @@ export interface KAPLAYCtx<
      * @returns The generated font data.
      * @group Assets
      *
-     * @see {@link LoadSpriteOpt LoadSpriteOpt}
+     * @see {@link LoadSpriteOpt}
      */
     loadBitmapFontFromSprite(
         sprite: string,
@@ -6197,6 +6196,15 @@ export interface KAPLAYOpt<
      * @default "gjk"
      */
     narrowPhaseCollisionAlgorithm?: string;
+    /**
+     * Timeout (in milliseconds) at which other loaders waiting on sprites will give
+     * up and throw an error.
+     *
+     * Currently this is only used by {@link KAPLAYCtx.loadBitmapFontFromSprite}.
+     *
+     * @default 3000
+     */
+    loadTimeout?: number;
 }
 
 /**

--- a/tests/playtests/spriteAsFont.js
+++ b/tests/playtests/spriteAsFont.js
@@ -10,7 +10,7 @@ loadSpriteAtlas("/sprites/dungeon.png", {
     },
 });
 
-loadBitmapFontFromSprite("hero", "abc", 3);
+loadBitmapFontFromSprite("hero", "abc");
 
 add([
     pos(100, 100),

--- a/tests/playtests/spriteAsFont.js
+++ b/tests/playtests/spriteAsFont.js
@@ -1,0 +1,33 @@
+kaplay({ background: "black" });
+
+loadSpriteAtlas("/sprites/dungeon.png", {
+    "hero": {
+        "x": 128,
+        "y": 196,
+        "width": 144,
+        "height": 28,
+        "sliceX": 9,
+    },
+});
+
+loadBitmapFontFromSprite("hero", "abc", 3);
+
+add([
+    pos(100, 100),
+    text("hello, I am [herofont]abcabc[/herofont]", {
+        styles: {
+            herofont: {
+                font: "hero",
+                scale: vec2(2),
+            },
+        },
+        width: 300,
+        transform: {
+            scale: vec2(2),
+            stretchInPlace: false,
+        },
+    }),
+    area(),
+]);
+
+debug.inspect = true;


### PR DESCRIPTION
also fixed a bug in the formatText that prevented some bitmap fonts from getting the right texture assigned or having the texture obliterated or needlessly creating an atlas and texture which will not be used

closes #804 

- [x] Changeloged
