### PR TITLE
doc: typo in sprite play opt

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6288,7 +6288,7 @@ export interface SpriteAnimPlayOpt {
     /**
      * If the animation should not restart from frame 1 and t=0 if it is already playing.
      *
-     * @default true
+     * @default false
      */
     preventRestart?: boolean;
     /**


### PR DESCRIPTION
default is false but I put true for some unknown reason