### PR TITLE
fix: textInput Component backspace v3001

### DIFF
--- a/src/components/misc/textInput.ts
+++ b/src/components/misc/textInput.ts
@@ -55,8 +55,9 @@ export function textInput(
             backEv = _k.k.onKeyPressRepeat("backspace", () => {
                 if (this.hasFocus) {
                     this.typedText = this.typedText.slice(0, -1);
+
+                    flip();
                 }
-                flip();
             });
         },
         destroy() {


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

## Summary

Objects with textInput with non-focused get cleared when hitting backspace. Only those with focus should be cleared.
