### PR TITLE
fix: tiles in level have their add hooks run twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   event wasn't being paused with `obj.paused` - @lajbel
 - Fixed all touch events having a bad transform - @lajbel
 - Fixed sprite scaling not working properly when letterbox - @mflerackers
-- Fixed "add" event running twice in `addLeve()` tiles - @lajbel
+- Fixed "add" event running twice in `addLevel()` tiles - @lajbel
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   event wasn't being paused with `obj.paused` - @lajbel
 - Fixed all touch events having a bad transform - @lajbel
 - Fixed sprite scaling not working properly when letterbox - @mflerackers
+- Fixed "add" event running twice in `addLeve()` tiles - @lajbel
 
 ### Removed
 

--- a/src/ecs/entity/GameObjRaw.ts
+++ b/src/ecs/entity/GameObjRaw.ts
@@ -605,7 +605,6 @@ export const GameObjRawPrototype: Omit<InternalGameObjRaw, AppEvents> = {
 
         try {
             obj.trigger("add", obj);
-            obj.children.forEach(c => c.trigger("add", c));
         } catch (e) {
             handleErr(e);
         }
@@ -738,7 +737,7 @@ export const GameObjRawPrototype: Omit<InternalGameObjRaw, AppEvents> = {
                     }
                 }));
             }
-            // If tags are are components, we don't need to use these callbacks
+            // If tags are components, we don't need to use these callbacks
             // If tags are not components, we only need to use these callbacks if this query looks at tags
             if (!compIdAreTags && opts.only !== "comps") {
                 events.push(onTag((obj, tag) => {


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

The error was happening because we haven't removed the functionality of `children.forEach...`. It was used for registering "add" events of obj's' children added using `make()`

close #805

## Summary

- [ ] Changeloged
