### PR TITLE
fix: brackets in error msg no longer cause an error when drawing error screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   @dragoncoder047
 - More errors raised during object creation are caught and cause the blue crash
   screen - @lajbel
-- The blue crash screen will no longer fail to draw if the error message contains brackets - @dragoncoder047
+- The blue crash screen will no longer fail to draw if the error message
+  contains brackets - @dragoncoder047
 - Now you can use the global option `inspectOnlyActive: false` to prevent paused
   objects from showing in the debug inspect view, this is useful if you are
   swapping out objects for different views - @dragoncoder047

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   @dragoncoder047
 - More errors raised during object creation are caught and cause the blue crash
   screen - @lajbel
+- The blue crash screen will no longer fail to draw if the error message contains brackets - @dragoncoder047
 - Now you can use the global option `inspectOnlyActive: false` to prevent paused
   objects from showing in the debug inspect view, this is useful if you are
   swapping out objects for different views - @dragoncoder047

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -23,7 +23,7 @@ export const handleErr = (err: unknown) => {
     }
 
     if (!error.message) {
-        error.message = "Uknown error, check console for more info";
+        error.message = "Unknown error, check console for more info";
     }
 
     _k.app.runOnce(
@@ -64,7 +64,7 @@ export const handleErr = (err: unknown) => {
 
                 drawText({
                     ...textStyle,
-                    text: error.message,
+                    text: esc(error.message),
                     pos: vec2(pad, pad + title.height + gap),
                     fixed: true,
                 });
@@ -88,3 +88,7 @@ export const handleErr = (err: unknown) => {
         console.error(error);
     }
 };
+
+function esc(t: string) {
+    return t.replaceAll(/(?<!\\)\[/g, "\\[");
+}

--- a/tests/playtests/errorWithBrackets.js
+++ b/tests/playtests/errorWithBrackets.js
@@ -1,0 +1,4 @@
+kaplay();
+onUpdate(() => {
+    throw new Error("[blooey]");
+});


### PR DESCRIPTION
> I often get Uncaught Error: Styled text error: unclosed tags corner instead of the actual error

- [X] Changeloged
