### PR TITLE
feat: assets aliases

### DIFF
--- a/src/.env.d.ts
+++ b/src/.env.d.ts
@@ -7,3 +7,7 @@ declare module "*.mp3" {
     const value: Uint8Array;
     export default value;
 }
+
+interface Window {
+    kaplayjs_assetsAliases: Record<string, string>;
+}

--- a/src/assets/utils.ts
+++ b/src/assets/utils.ts
@@ -2,6 +2,10 @@ import { _k } from "../shared";
 import { isDataURL } from "../utils/dataURL";
 
 export function fixURL<D>(url: D): D {
+    if (typeof url == "string" && window.kaplayjs_assetsAliases[url]) {
+        url = (window.kaplayjs_assetsAliases[url] as unknown) as D;
+    }
+
     if (typeof url !== "string" || isDataURL(url)) return url;
     return _k.assets.urlPrefix + url as D;
 }

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -15,6 +15,9 @@ import { createFrameRenderer } from "./frameRendering";
 
 export type Engine = ReturnType<typeof createEngine>;
 
+// Create global variables
+window.kaplayjs_assetsAliases = {};
+
 export const createEngine = (gopt: KAPLAYOpt) => {
     // Default options
     const opt = Object.assign({


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

This feature is interesting for building tools (like KAPLAYGROUND) setting aliases to paths in assets url, with this feature we could do:

```js
window.kaplayjs_assetsAliases["beansrc"] = "Base64URLHere";

loadSprite("bean", "beansrc"); // now beansrc will be replaced with the alias
```

## Summary

- [ ] Changeloged
