### PR TITLE
fix: correct shader error message so it displays the right line as well as the contents of said line

### DIFF
--- a/src/assets/shader.ts
+++ b/src/assets/shader.ts
@@ -177,14 +177,15 @@ export function makeShader(
             VERTEX_FORMAT.map((vert) => vert.name),
         );
     } catch (e) {
-        const lineOffset = 14;
         const fmt = /(?<type>^\w+) SHADER ERROR: 0:(?<line>\d+): (?<msg>.+)/;
         const match = getErrorMessage(e).match(fmt);
         if (!match?.groups) throw e;
-        const line = Number(match.groups.line) - lineOffset;
+        const line = Number(match.groups.line);
         const msg = match.groups.msg.trim();
         const ty = match.groups.type.toLowerCase();
-        throw new Error(`${ty} shader line ${line}: ${msg}`);
+        const lines = (ty == "vertex" ? vcode : fcode).split("\n");
+        const lineContents = lines[line - 1];
+        throw new Error(`${ty} shader line ${line}: ${msg}\n${lineContents}`);
     }
 }
 


### PR DESCRIPTION
The shader error message code previously hard-coded the error offset, but that was before the shaders were manually minified into one line, so the offset is 0 now. Also I added a bit to point directly to the offending line so you see where the error is more clearly.