### PR TITLE
refactor: Improve JSDoc

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -6,7 +6,8 @@
 			"/**",
 			" * The serialized {@link ${TM_FILENAME_BASE} `${TM_FILENAME_BASE}()`} component.",
 			" *",
-			" * @group Component Serialization",
+			" * @group Components
+ * @subgroup Component Serialization",
 			" */",
 			"export interface Serialized${TM_FILENAME_BASE/(.)(.*)/${1:/upcase}${2}/}Comp {",
 			"",

--- a/data/groups.json
+++ b/data/groups.json
@@ -107,6 +107,10 @@
         "name": "Buttons API",
         "description": "Work with the Buttons API, an api that let you convine various input methods."
       },
+      "Touch": {
+        "name": "Touch",
+        "description": "Work with touch devices"
+      },
       "Util": {
         "name": "Util",
         "description": "Util methods when working with input."

--- a/data/groups.json
+++ b/data/groups.json
@@ -79,10 +79,6 @@
         "name": "UI",
         "description": "TODO"
       },
-      "Other": {
-        "name": "Other",
-        "description": "TODO"
-      },
       "Component Types": {
         "name": "Component Types",
         "description": "TODO"

--- a/data/groups.json
+++ b/data/groups.json
@@ -146,40 +146,46 @@
     "description": "Work with timers."
   },
   "Math": {
-    "name": "MF's Place",
+    "name": "Math",
     "description": "Work with math.",
     "subgroups": {
-      "Vectors": {
-        "name": "Vectors",
-        "description": "Work with vectors."
-      },
-      "Colors": {
-        "name": "Colors",
-        "description": "Work with colors."
-      },
-      "Angle": {
-        "name": "Angles",
-        "description": "Work with angles."
-      },
       "Random": {
         "name": "Random",
         "description": "Work with random values."
       },
       "Tween": {
-        "name": "Tweenks",
+        "name": "Tweens",
         "description": "Work with tweens and interpolations."
+      },
+      "Vectors": {
+        "name": "Vectors",
+        "description": "Work with vectors.",
+        "closed": true
+      },
+      "Colors": {
+        "name": "Colors",
+        "description": "Work with colors.",
+        "closed": true
+      },
+      "Angle": {
+        "name": "Angles",
+        "description": "Work with angles.",
+        "closed": true
       },
       "Raycast": {
         "name": "Raycast",
-        "description": "Work with raycasts."
+        "description": "Work with raycasts.",
+        "closed": true
       },
       "Shapes": {
         "name": "Shapes",
-        "description": "F"
+        "description": "Work with shapes.",
+        "closed": true
       },
       "Advanced": {
         "name": "Advanced",
-        "description": "For pro players."
+        "description": "For pro players.",
+        "closed": true
       }
     }
   },
@@ -199,25 +205,26 @@
         "name": "Camera",
         "description": "Work with the camera."
       },
-
       "Canvas": {
         "name": "Canvas",
-        "description": "Work with Canvas API."
+        "description": "Work with Canvas API.",
+        "closed": true
+      },
+      "Stack": {
+        "name": "Stack",
+        "description": "Work with transformation stack."
       }
     }
   },
   "Draw": {
     "name": "Drawing",
-    "description": "f",
+    "description": "Draw in the KAPLAY Canvas",
     "subgroups": {
       "Picture": {
         "name": "Picture",
         "description": "Work with Picture API."
       },
-      "Stack": {
-        "name": "Stack",
-        "description": "Work with transformation stack."
-      },
+
       "Types": {
         "name": "Types",
         "description": "Various types related to Draw."

--- a/data/groups.json
+++ b/data/groups.json
@@ -6,42 +6,40 @@
   "Assets": {
     "name": "Assets",
     "description": "Work with game assets",
-    "subgroups": [
-      {
-        "Sprite": {
-          "name": "Sprites",
-          "description": "TODO"
-        },
-        "Audio": {
-          "name": "Audio",
-          "description": "TODO"
-        },
-        "Font": {
-          "name": "Fonts",
-          "description": "TODO"
-        },
-        "Shader": {
-          "name": "Shaders",
-          "description": "TODO"
-        },
-        "Prefabs": {
-          "name": "Prefabs",
-          "description": "Assets for storing prefabs."
-        },
-        "Data": {
-          "name": "Data",
-          "description": "Assets for storing various data."
-        },
-        "Default": {
-          "name": "Default",
-          "description": "Default assets for prototyping"
-        },
-        "Util": {
-          "name": "Util",
-          "description": "Util information when working with assets."
-        }
+    "subgroups": {
+      "Sprite": {
+        "name": "Sprites",
+        "description": "TODO"
+      },
+      "Audio": {
+        "name": "Audio",
+        "description": "TODO"
+      },
+      "Font": {
+        "name": "Fonts",
+        "description": "TODO"
+      },
+      "Shader": {
+        "name": "Shaders",
+        "description": "TODO"
+      },
+      "Prefabs": {
+        "name": "Prefabs",
+        "description": "Assets for storing prefabs."
+      },
+      "Data": {
+        "name": "Data",
+        "description": "Assets for storing various data."
+      },
+      "Default": {
+        "name": "Default",
+        "description": "Default assets for prototyping"
+      },
+      "Util": {
+        "name": "Util",
+        "description": "Util information when working with assets."
       }
-    ]
+    }
   },
   "Game Obj": {
     "name": "Game Object",

--- a/data/groups.json
+++ b/data/groups.json
@@ -1,0 +1,158 @@
+{
+  "Start": {
+    "name": "Start",
+    "description": "TODO"
+  },
+  "Assets": {
+    "name": "Assets",
+    "description": "Work with game assets",
+    "subgroups": [
+      {
+        "Sprite": {
+          "name": "Sprite",
+          "description": "TODO"
+        },
+        "Audio": {
+          "name": "Audio",
+          "description": "TODO"
+        },
+        "Font": {
+          "name": "Font",
+          "description": "TODO"
+        },
+        "Shader": {
+          "name": "Shader",
+          "description": "TODO"
+        },
+        "Data": {
+          "name": "Data",
+          "description": "Default assets for prototyping"
+        },
+        "Util": {
+          "name": "Util",
+          "description": "Util information when working with assets."
+        }
+      }
+    ]
+  },
+  "Game Obj": {
+    "name": "Game Object",
+    "description": "Work with game objects",
+    "subgroups": {
+      "Prefab": {
+        "name": "Prefab",
+        "description": "Use game object serialization"
+      }
+    }
+  },
+  "Components": {
+    "name": "Components",
+    "description": "All components",
+    "subgroups": {
+      "Transform": {
+        "name": "Transform",
+        "description": "TODO"
+      },
+      "Rendering": {
+        "name": "Rendering",
+        "description": "TODO"
+      },
+      "Behaviour": {
+        "name": "Behaviour",
+        "description": "Components that may change Game Object general behaviour in relation to the scene."
+      },
+      "Physics": {
+        "name": "Physics",
+        "description": "TODO"
+      },
+      "Level": {
+        "name": "Level",
+        "description": "TODO"
+      },
+      "UI": {
+        "name": "UI",
+        "description": "TODO"
+      },
+      "Other": {
+        "name": "Other",
+        "description": "TODO"
+      }
+    }
+  },
+  "Input": {
+    "name": "Input",
+    "description": "All input",
+    "subgroups": {
+      "Keyboard": {
+        "name": "Keyboard",
+        "description": "Work with the keyboard input."
+      },
+      "Mouse": {
+        "name": "Mouse",
+        "description": "Work with the mouse/touch input."
+      },
+      "Gamepad": {
+        "name": "Gamepad",
+        "description": "Work with the gamepad input."
+      },
+      "Buttons API": {
+        "name": "Buttons API",
+        "description": "Work with the Buttons API, an api that let you convine various input methods."
+      },
+      "Util": {
+        "name": "Util",
+        "description": "Util methods when working with input."
+      }
+    }
+  },
+  "Audio": {
+    "name": "Audio",
+    "description": "Work with sounds and music."
+  },
+  "Scenes": {
+    "name": "Scenes",
+    "description": "F"
+  },
+  "Events": {
+    "name": "Events",
+    "description": "TODO"
+  },
+  "Timer": {
+    "name": "Timer",
+    "description": "Work with timers."
+  },
+  "Math": {
+    "name": "Math",
+    "description": "Work with math."
+  },
+  "Physics": {
+    "name": "Physics",
+    "description": "Work with physics."
+  },
+  "Rendering": {
+    "name": "Rendering",
+    "description": "Canvas API and more.",
+    "subgroups": {
+      "Layers": {
+        "name": "Layers",
+        "description": "Layers let you define what is rendered first."
+      },
+      "Camera": {
+        "name": "Camera",
+        "description": "Work with the camera."
+      }
+    }
+  },
+  "Info": {
+    "name": "Info",
+    "description": "IDK"
+  },
+  "Constants": {
+    "name": "Constants",
+    "description": "IDK"
+  },
+  "Misc": {
+    "name": "Other",
+    "description": "Uncategorized keywords."
+  }
+}

--- a/data/groups.json
+++ b/data/groups.json
@@ -148,7 +148,7 @@
         "description": "Work with colors."
       },
       "Angle": {
-        "name": "Angle",
+        "name": "Angles",
         "description": "Work with angles."
       },
       "Random": {
@@ -203,6 +203,14 @@
       "Picture": {
         "name": "Picture",
         "description": "Work with Picture API."
+      },
+      "Stack": {
+        "name": "Stack",
+        "description": "Work with transformation stack."
+      },
+      "Types": {
+        "name": "Types",
+        "description": "Various types related to Draw."
       }
     }
   },

--- a/data/groups.json
+++ b/data/groups.json
@@ -7,7 +7,7 @@
     "name": "Assets",
     "description": "Work with game assets",
     "subgroups": {
-      "Sprite": {
+      "Sprites": {
         "name": "Sprites",
         "description": "TODO"
       },
@@ -15,11 +15,11 @@
         "name": "Audio",
         "description": "TODO"
       },
-      "Font": {
+      "Fonts": {
         "name": "Fonts",
         "description": "TODO"
       },
-      "Shader": {
+      "Shaders": {
         "name": "Shaders",
         "description": "TODO"
       },

--- a/data/groups.json
+++ b/data/groups.json
@@ -136,8 +136,38 @@
     "description": "Work with timers."
   },
   "Math": {
-    "name": "Math",
-    "description": "Work with math."
+    "name": "MF's Place",
+    "description": "Work with math.",
+    "subgroups": {
+      "Vectors": {
+        "name": "Vectors",
+        "description": "Work with vectors."
+      },
+      "Colors": {
+        "name": "Colors",
+        "description": "Work with colors."
+      },
+      "Angle": {
+        "name": "Angle",
+        "description": "Work with angles."
+      },
+      "Random": {
+        "name": "Random",
+        "description": "Work with random values."
+      },
+      "Tween": {
+        "name": "Tweenks",
+        "description": "Work with tweens and interpolations."
+      },
+      "Raycast": {
+        "name": "Raycast",
+        "description": "Work with raycasts."
+      },
+      "Advanced": {
+        "name": "Advanced",
+        "description": "For pro players."
+      }
+    }
   },
   "Physics": {
     "name": "Physics",
@@ -157,13 +187,29 @@
       }
     }
   },
+  "Draw": {
+    "name": "Drawing",
+    "description": "f"
+  },
   "Info": {
     "name": "Info",
     "description": "IDK"
   },
+  "Data": {
+    "name": "Data",
+    "description": "f"
+  },
+  "Debug": {
+    "name": "Debug",
+    "description": "Debug"
+  },
   "Constants": {
     "name": "Constants",
     "description": "IDK"
+  },
+  "Plugins": {
+    "name": "Plugin",
+    "description": "Idk"
   },
   "Misc": {
     "name": "Other",

--- a/data/groups.json
+++ b/data/groups.json
@@ -29,15 +29,18 @@
       },
       "Getters": {
         "name": "Getters",
-        "description": "Get related data information."
+        "description": "Get related data information.",
+        "closed": true
       },
       "Data": {
         "name": "Data",
-        "description": "The data classes used to create asset data."
+        "description": "The data classes used to create asset data.",
+        "closed": true
       },
       "Types": {
         "name": "Types",
-        "description": "The types used to create asset data."
+        "description": "The types used to create asset data.",
+        "closed": true
       }
     }
   },
@@ -81,11 +84,13 @@
       },
       "Component Types": {
         "name": "Types",
-        "description": "TODO"
+        "description": "TODO",
+        "closed": true
       },
       "Component Serialization": {
         "name": "Serialization",
-        "description": "TODO"
+        "description": "TODO",
+        "closed": true
       }
     }
   },

--- a/data/groups.json
+++ b/data/groups.json
@@ -45,7 +45,7 @@
     "name": "Game Object",
     "description": "Work with game objects",
     "subgroups": {
-      "Prefab": {
+      "Prefabs": {
         "name": "Prefab",
         "description": "Use game object serialization"
       }
@@ -81,6 +81,14 @@
       },
       "Other": {
         "name": "Other",
+        "description": "TODO"
+      },
+      "Component Types": {
+        "name": "Component Types",
+        "description": "TODO"
+      },
+      "Component Serialization": {
+        "name": "Component Serialization",
         "description": "TODO"
       }
     }

--- a/data/groups.json
+++ b/data/groups.json
@@ -123,7 +123,7 @@
     "name": "Audio",
     "description": "Work with sounds and music."
   },
-  "Scenes": {
+  "Scene": {
     "name": "Scenes",
     "description": "F"
   },

--- a/data/groups.json
+++ b/data/groups.json
@@ -188,12 +188,23 @@
       "Camera": {
         "name": "Camera",
         "description": "Work with the camera."
+      },
+
+      "Canvas": {
+        "name": "Canvas",
+        "description": "Work with Canvas API."
       }
     }
   },
   "Draw": {
     "name": "Drawing",
-    "description": "f"
+    "description": "f",
+    "subgroups": {
+      "Picture": {
+        "name": "Picture",
+        "description": "Work with Picture API."
+      }
+    }
   },
   "Info": {
     "name": "Info",

--- a/data/groups.json
+++ b/data/groups.json
@@ -48,10 +48,6 @@
     "name": "Game Object",
     "description": "Work with game objects.",
     "subgroups": {
-      "Prefabs": {
-        "name": "Prefab",
-        "description": "Use game object serialization."
-      },
       "Types": {
         "name": "Types",
         "description": "Game Obj related types.",

--- a/data/groups.json
+++ b/data/groups.json
@@ -163,6 +163,10 @@
         "name": "Raycast",
         "description": "Work with raycasts."
       },
+      "Shapes": {
+        "name": "Shapes",
+        "description": "F"
+      },
       "Advanced": {
         "name": "Advanced",
         "description": "For pro players."

--- a/data/groups.json
+++ b/data/groups.json
@@ -9,35 +9,31 @@
     "subgroups": {
       "Sprites": {
         "name": "Sprites",
-        "description": "TODO"
+        "description": "Load different kinds of sprites."
       },
       "Audio": {
         "name": "Audio",
-        "description": "TODO"
+        "description": "Load different kinds of audio."
       },
       "Fonts": {
         "name": "Fonts",
-        "description": "TODO"
+        "description": "Load different kinds of fonts."
       },
-      "Shaders": {
-        "name": "Shaders",
-        "description": "TODO"
+      "Util": {
+        "name": "Various",
+        "description": "Load various stuff."
       },
-      "Prefabs": {
-        "name": "Prefabs",
-        "description": "Assets for storing prefabs."
+      "Getters": {
+        "name": "Getters",
+        "description": "Get related data information."
       },
       "Data": {
         "name": "Data",
-        "description": "Assets for storing various data."
+        "description": "The data classes used to create asset data."
       },
-      "Default": {
-        "name": "Default",
-        "description": "Default assets for prototyping"
-      },
-      "Util": {
-        "name": "Util",
-        "description": "Util information when working with assets."
+      "Types": {
+        "name": "Types",
+        "description": "The types used to create asset data."
       }
     }
   },

--- a/data/groups.json
+++ b/data/groups.json
@@ -235,10 +235,10 @@
         "name": "Picture",
         "description": "Work with Picture API."
       },
-
       "Types": {
         "name": "Types",
-        "description": "Various types related to Draw."
+        "description": "Various types related to Draw.",
+        "closed": true
       }
     }
   },

--- a/data/groups.json
+++ b/data/groups.json
@@ -19,6 +19,10 @@
         "name": "Fonts",
         "description": "Load different kinds of fonts."
       },
+      "Shaders": {
+        "name": "Shaders",
+        "description": "Load different kinds of shaders."
+      },
       "Util": {
         "name": "Various",
         "description": "Load various stuff."

--- a/data/groups.json
+++ b/data/groups.json
@@ -135,7 +135,14 @@
   },
   "Scene": {
     "name": "Scenes",
-    "description": "F"
+    "description": "Work with game scenes.",
+    "subgroups": {
+      "Types": {
+        "name": "Types",
+        "description": "Types related to scenes.",
+        "closed": true
+      }
+    }
   },
   "Events": {
     "name": "Events",
@@ -204,6 +211,10 @@
       "Camera": {
         "name": "Camera",
         "description": "Work with the camera."
+      },
+      "Shaders": {
+        "name": "Shaders",
+        "description": "Work with shaders."
       },
       "Canvas": {
         "name": "Canvas",

--- a/data/groups.json
+++ b/data/groups.json
@@ -80,11 +80,11 @@
         "description": "TODO"
       },
       "Component Types": {
-        "name": "Component Types",
+        "name": "Types",
         "description": "TODO"
       },
       "Component Serialization": {
-        "name": "Component Serialization",
+        "name": "Serialization",
         "description": "TODO"
       }
     }

--- a/data/groups.json
+++ b/data/groups.json
@@ -133,7 +133,7 @@
     "name": "Audio",
     "description": "Work with sounds and music."
   },
-  "Scene": {
+  "Scenes": {
     "name": "Scenes",
     "description": "Work with game scenes.",
     "subgroups": {

--- a/data/groups.json
+++ b/data/groups.json
@@ -9,7 +9,7 @@
     "subgroups": [
       {
         "Sprite": {
-          "name": "Sprite",
+          "name": "Sprites",
           "description": "TODO"
         },
         "Audio": {
@@ -17,15 +17,23 @@
           "description": "TODO"
         },
         "Font": {
-          "name": "Font",
+          "name": "Fonts",
           "description": "TODO"
         },
         "Shader": {
-          "name": "Shader",
+          "name": "Shaders",
           "description": "TODO"
+        },
+        "Prefabs": {
+          "name": "Prefabs",
+          "description": "Assets for storing prefabs."
         },
         "Data": {
           "name": "Data",
+          "description": "Assets for storing various data."
+        },
+        "Default": {
+          "name": "Default",
           "description": "Default assets for prototyping"
         },
         "Util": {

--- a/data/groups.json
+++ b/data/groups.json
@@ -46,11 +46,16 @@
   },
   "Game Obj": {
     "name": "Game Object",
-    "description": "Work with game objects",
+    "description": "Work with game objects.",
     "subgroups": {
       "Prefabs": {
         "name": "Prefab",
-        "description": "Use game object serialization"
+        "description": "Use game object serialization."
+      },
+      "Types": {
+        "name": "Types",
+        "description": "Game Obj related types.",
+        "closed": true
       }
     }
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,12 +13,13 @@ export default tseslint.config(
             "jsdoc/require-hyphen-before-param-description": "error",
             "jsdoc/check-alignment": "warn",
             "jsdoc/check-tag-names": ["error", {
-                "definedTags": ["group", "experimental"],
+                "definedTags": ["group", "subgroup", "experimental"],
             }],
             "jsdoc/sort-tags": ["error", {
                 tagSequence: [{
                     tags: [
                         "deprecated",
+                        "ignore",
                     ],
                 }, {
                     tags: [
@@ -40,6 +41,7 @@ export default tseslint.config(
                         "returns",
                         "since",
                         "group",
+                        "subgroup",
                         "experimental",
                     ],
                 }],

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,11 +3,11 @@
 import type {
     Cursor,
     GamepadDef,
-    GamepadStick,
     KAPLAYOpt,
     Key,
     KGamepad,
     KGamepadButton,
+    KGamepadStick,
     MouseButton,
 } from "../types";
 
@@ -53,7 +53,7 @@ export class ButtonState<T = string> {
 
 class GamepadState {
     buttonState: ButtonState<KGamepadButton> = new ButtonState();
-    stickState: Map<GamepadStick, Vec2> = new Map();
+    stickState: Map<KGamepadStick, Vec2> = new Map();
 }
 
 class FPSCounter {
@@ -616,7 +616,7 @@ export const initApp = (
     );
 
     function onGamepadStick(
-        stick: GamepadStick,
+        stick: KGamepadStick,
         action: (value: Vec2, gp: KGamepad) => void,
     ): KEventController {
         return state.events.on(
@@ -633,7 +633,7 @@ export const initApp = (
         return state.events.on("gamepadDisconnect", action);
     }
 
-    function getGamepadStick(stick: GamepadStick): Vec2 {
+    function getGamepadStick(stick: KGamepadStick): Vec2 {
         return state.mergedGamepadState.stickState.get(stick) || new Vec2(0);
     }
 
@@ -729,7 +729,7 @@ export const initApp = (
                     ?.buttonState
                     .released.has(btn) || false;
             },
-            getStick: (stick: GamepadStick) => {
+            getStick: (stick: KGamepadStick) => {
                 return state.gamepadStates.get(browserGamepad.index)?.stickState
                     .get(stick) || vec2();
             },
@@ -839,15 +839,15 @@ export const initApp = (
             }
 
             for (const stickName in map.sticks) {
-                const stick = map.sticks[stickName as GamepadStick];
+                const stick = map.sticks[stickName as KGamepadStick];
                 if (!stick) continue;
                 const value = new Vec2(
                     browserGamepad.axes[stick.x],
                     browserGamepad.axes[stick.y],
                 );
-                gamepadState.stickState.set(stickName as GamepadStick, value);
+                gamepadState.stickState.set(stickName as KGamepadStick, value);
                 state.mergedGamepadState.stickState.set(
-                    stickName as GamepadStick,
+                    stickName as KGamepadStick,
                     value,
                 );
                 state.events.trigger("gamepadStick", stickName, value, gamepad);

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -83,6 +83,15 @@ export type AppEvents = keyof {
     [K in keyof App as K extends `on${any}` ? K : never]: [never];
 };
 
+/**
+ * Create the App state object.
+ *
+ * @ignore
+ *
+ * @param opt - Options.
+ *
+ * @returns The app state.
+ */
 export const initAppState = (opt: {
     canvas: HTMLCanvasElement;
     touchToMouse?: boolean;
@@ -131,6 +140,16 @@ export const initAppState = (opt: {
     };
 };
 
+/**
+ * Create the App, the context, and handler for all things related to the game
+ * canvas, input, and DOM interaction.
+ *
+ * @ignore
+ *
+ * @param opt - Options.
+ *
+ * @returns The app context.
+ */
 export const initApp = (
     opt: {
         canvas: HTMLCanvasElement;

--- a/src/app/inputBindings.ts
+++ b/src/app/inputBindings.ts
@@ -5,7 +5,8 @@ import type { AppState } from "./app";
 /**
  * A button binding.
  *
- * @group Button Bindings
+ * @group Input
+ * @subgroup Buttons API
  */
 export type ButtonBinding = {
     keyboard?: Key | Key[];
@@ -17,14 +18,16 @@ export type ButtonBinding = {
 /**
  * A buttons definition for an action (jump, walk-left, run).
  *
- * @group Button Bindings
+ * @group Input
+ * @subgroup Buttons API
  */
 export type ButtonsDef = Record<string, ButtonBinding>;
 
 /**
  * A button binding device
  *
- * @group Button Bindings
+ * @group Input
+ * @subgroup Buttons API
  */
 export type ButtonBindingDevice = "keyboard" | "gamepad" | "mouse";
 

--- a/src/assets/aseprite.ts
+++ b/src/assets/aseprite.ts
@@ -5,6 +5,10 @@ import { type Asset, fetchJSON } from "./asset";
 import { type LoadSpriteSrc, type SpriteAnim, SpriteData } from "./sprite";
 import { fixURL } from "./utils";
 
+/**
+ * @group Assets
+ * @subgroup Data
+ */
 export type AsepriteData = {
     frames: Array<{
         frame: {

--- a/src/assets/asset.ts
+++ b/src/assets/asset.ts
@@ -252,8 +252,10 @@ export function load<T>(prom: Promise<T>): Asset<T> {
 }
 
 // create assets
-export type AssetsCtx = ReturnType<typeof initAssets>;
+/** @ignore */
+export type InternalAssetsCtx = ReturnType<typeof initAssets>;
 
+/** @ignore */
 export const initAssets = (ggl: GfxCtx, spriteAtlasPadding: number) => {
     const assets = {
         urlPrefix: "",

--- a/src/assets/asset.ts
+++ b/src/assets/asset.ts
@@ -87,6 +87,10 @@ export class Asset<D> {
     }
 }
 
+/**
+ * @group Assets
+ * @subgroup Types
+ */
 export class AssetBucket<D> {
     assets: Map<string, Asset<D>> = new Map();
     waiters: KEventHandler<any> = new KEventHandler();

--- a/src/assets/bitmapFont.ts
+++ b/src/assets/bitmapFont.ts
@@ -7,12 +7,20 @@ import { type Asset, loadImg } from "./asset";
 import { makeFont } from "./font";
 import { fixURL } from "./utils";
 
+/**
+ * @group Assets
+ * @subgroup Fonts
+ */
 export interface GfxFont {
     tex: Texture;
     map: Record<string, Quad>;
     size: number;
 }
 
+/**
+ * @group Assets
+ * @subgroup Fonts
+ */
 export type BitmapFontData = GfxFont;
 
 export function getBitmapFont(name: string): Asset<BitmapFontData> | null {

--- a/src/assets/bitmapFont.ts
+++ b/src/assets/bitmapFont.ts
@@ -9,7 +9,7 @@ import { fixURL } from "./utils";
 
 /**
  * @group Assets
- * @subgroup Fonts
+ * @subgroup Types
  */
 export interface GfxFont {
     tex: Texture;
@@ -19,7 +19,7 @@ export interface GfxFont {
 
 /**
  * @group Assets
- * @subgroup Fonts
+ * @subgroup Data
  */
 export type BitmapFontData = GfxFont;
 
@@ -27,6 +27,10 @@ export function getBitmapFont(name: string): Asset<BitmapFontData> | null {
     return _k.assets.bitmapFonts.get(name) ?? null;
 }
 
+/**
+ * @group Assets
+ * @subgroup Types
+ */
 export interface LoadBitmapFontOpt {
     /**
      * A string of characters to map to every sprite in the characters grid

--- a/src/assets/font.ts
+++ b/src/assets/font.ts
@@ -13,6 +13,10 @@ import type { LoadFontOpt, Outline, TexFilter } from "../types";
 import { Asset, loadProgress } from "./asset";
 import { type BitmapFontData, getBitmapFont, type GfxFont } from "./bitmapFont";
 
+/**
+ * @group Assets
+ * @subgroup Fonts
+ */
 export class FontData {
     fontface: FontFace;
     filter: TexFilter = DEF_FONT_FILTER;

--- a/src/assets/font.ts
+++ b/src/assets/font.ts
@@ -15,7 +15,7 @@ import { type BitmapFontData, getBitmapFont, type GfxFont } from "./bitmapFont";
 
 /**
  * @group Assets
- * @subgroup Fonts
+ * @subgroup Data
  */
 export class FontData {
     fontface: FontFace;

--- a/src/assets/shader.ts
+++ b/src/assets/shader.ts
@@ -20,14 +20,14 @@ import { fixURL } from "./utils";
 
 /**
  * @group Assets
- * @subgroup Shaders
+ * @subgroup Data
  */
 export type ShaderData = Shader;
 
 /**
  * Possible values for a shader Uniform.
  *
- * @group Assets
+ * @group Rendering
  * @subgroup Shaders
  */
 export type UniformValue =
@@ -43,13 +43,13 @@ export type UniformValue =
 /**
  * Possible uniform value, basically any but "u_tex".
  *
- * @group Assets
+ * @group Rendering
  * @subgroup Shaders
  */
 export type UniformKey = string;
 
 /**
- * @group Assets
+ * @group Rendering
  * @subgroup Shaders
  */
 export type Uniform = Record<UniformKey, UniformValue>;
@@ -57,7 +57,7 @@ export type Uniform = Record<UniformKey, UniformValue>;
 /**
  * A shader, yeah.
  *
- * @group Assets
+ * @group Rendering
  * @subgroup Shaders
  */
 export class Shader {

--- a/src/assets/shader.ts
+++ b/src/assets/shader.ts
@@ -18,10 +18,17 @@ import { fetchText, loadProgress } from "./asset";
 import { Asset } from "./asset";
 import { fixURL } from "./utils";
 
+/**
+ * @group Assets
+ * @subgroup Shaders
+ */
 export type ShaderData = Shader;
 
 /**
- * @group Math
+ * Possible values for a shader Uniform.
+ *
+ * @group Assets
+ * @subgroup Shaders
  */
 export type UniformValue =
     | number
@@ -34,16 +41,24 @@ export type UniformValue =
     | Color[];
 
 /**
- * @group Math
+ * Possible uniform value, basically any but "u_tex".
+ *
+ * @group Assets
+ * @subgroup Shaders
  */
-export type UniformKey = Exclude<string, "u_tex">;
+export type UniformKey = string;
+
 /**
- * @group Math
+ * @group Assets
+ * @subgroup Shaders
  */
 export type Uniform = Record<UniformKey, UniformValue>;
 
 /**
- * @group GFX
+ * A shader, yeah.
+ *
+ * @group Assets
+ * @subgroup Shaders
  */
 export class Shader {
     ctx: GfxCtx;

--- a/src/assets/sprite.ts
+++ b/src/assets/sprite.ts
@@ -8,6 +8,9 @@ import { fixURL } from "./utils";
 
 /**
  * Frame-based animation configuration.
+ *
+ * @group Assets
+ * @subgroup Types
  */
 export type SpriteAnim = number | {
     /**
@@ -40,12 +43,18 @@ export type SpriteAnim = number | {
 
 /**
  * A dict of name <-> animation.
+ *
+ * @group Assets
+ * @subgroup Types
  */
 export type SpriteAnims = Record<string, SpriteAnim>;
 
 // TODO: support frameWidth and frameHeight as alternative to slice
 /**
- * Sprite loading configuration.
+ * Sprite loading options.
+ *
+ * @group Assets
+ * @subgroup Types
  */
 export interface LoadSpriteOpt {
     /**
@@ -78,6 +87,10 @@ export interface LoadSpriteOpt {
     singular?: boolean;
 }
 
+/**
+ * @group Assets
+ * @subgroup Types
+ */
 export type NineSlice = {
     /**
      * The width of the 9-slice's left column.
@@ -97,6 +110,12 @@ export type NineSlice = {
     bottom: number;
 };
 
+/**
+ * Possible values for loading an sprite using {@link loadSprite `loadSprite`}.
+ *
+ * @group Assets
+ * @subgroup Types
+ */
 export type LoadSpriteSrc = string | ImageSource;
 
 export class SpriteData {

--- a/src/assets/spriteAtlas.ts
+++ b/src/assets/spriteAtlas.ts
@@ -10,10 +10,17 @@ import {
 } from "./sprite";
 import { fixURL } from "./utils";
 
+/**
+ * @group Assets
+ * @subgroup Data
+ */
 export type SpriteAtlasData = Record<string, SpriteAtlasEntry>;
 
 /**
  * A sprite in a sprite atlas.
+ *
+ * @group Assets
+ * @subgroup Types
  */
 export type SpriteAtlasEntry = LoadSpriteOpt & {
     /**

--- a/src/audio/audio.ts
+++ b/src/audio/audio.ts
@@ -1,10 +1,16 @@
-export type AudioCtx = ReturnType<typeof initAudio>;
+/** @ignore */
+export interface InternalAudioCtx {
+    ctx: AudioContext;
+    masterNode: GainNode;
+}
 
+/** @ignore */
 export function createEmptyAudioBuffer(ctx: AudioContext) {
     return ctx.createBuffer(1, 1, 44100);
 }
 
-export const initAudio = () => {
+/** @ignore */
+export const initAudio = (): InternalAudioCtx => {
     const audio = (() => {
         const ctx = new (
             window.AudioContext || (window as any).webkitAudioContext

--- a/src/audio/play.ts
+++ b/src/audio/play.ts
@@ -8,6 +8,8 @@ import { playMusic } from "./playMusic";
 // TODO: enable setting on load, make part of SoundData
 /**
  * Audio play configurations.
+ *
+ * @group Audio
  */
 export interface AudioPlayOpt {
     /**
@@ -57,6 +59,9 @@ export interface AudioPlayOpt {
     connectTo?: AudioNode;
 }
 
+/**
+ * @group Audio
+ */
 export interface AudioPlay {
     /**
      * Start playing audio.

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -5332,6 +5332,7 @@ export interface KAPLAYCtx<
     Mat4: typeof Mat4;
     /**
      * @since v4000.0
+     * @group Math
      * @subgroup Advanced
      */
     Mat23: typeof Mat23;
@@ -5339,6 +5340,7 @@ export interface KAPLAYCtx<
      * A 2D quad.
      *
      * @since v3001.0
+     * @group Math
      * @subgroup Advanced
      */
     Quad: typeof Quad;
@@ -5859,23 +5861,42 @@ export interface KAPLAYCtx<
     Picture: typeof Picture;
     /**
      * Selects the picture for drawing, erases existing data.
+     *
      * @param picture - The picture to write drawing data to.
+     *
+     * @since v4000.0
+     * @group Draw
+     * @subgroup Picture
      */
     beginPicture(picture?: Picture): void;
     /**
      * Selects the picture for drawing, keeps existing data.
+     *
      * @param picture - The picture to write drawing data to.
+     *
+     * @since v4000.0
+     * @group Draw
+     * @subgroup Picture
      */
     appendToPicture(picture?: Picture): void;
     /**
      * Deselects the current picture for drawing, returning the picture.
+     *
      * @returns The picture which was previously selected.
+     * @since v4000.0
+     * @group Draw
+     * @subgroup Picture
      */
     endPicture(): Picture;
     /**
      * Draws a picture to the screen. This function can not be used to draw recursively to a picture.
+     *
      * @param picture - The picture to draw
-     * @param opt - Drawing options
+     * @param opt - Drawing
+     *
+     * @since v4000.0
+     * @group Draw
+     * @subgroup Picture
      */
     drawPicture(picture: Picture, opt: DrawPictureOpt): void;
     /**
@@ -6122,7 +6143,8 @@ export interface KAPLAYCtx<
      *
      * @returns The explosion object.
      * @since v2000.0
-     * @group Misc
+     * @group Game Obj
+     * @subgroup Util
      */
     addKaboom(pos: Vec2, opt?: BoomOpt): GameObj;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -892,7 +892,7 @@ export interface KAPLAYCtx<
      * @returns The z comp.
      * @since v2000.0
      * @group Components
-     * @subgroup Rendering
+     * @subgroup Transform
      */
     z(z: number): ZComp;
     /**
@@ -1215,7 +1215,7 @@ export interface KAPLAYCtx<
      * @returns The follow comp.
      * @since v2000.0
      * @group Components
-     * @subgroup Transform
+     * @subgroup Behaviour
      */
     follow(obj: GameObj | null, offset?: Vec2): FollowComp;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -263,6 +263,7 @@ export interface KAPLAYCtx<
      *
      * @returns The added game object that contains all properties and methods each component offers.
      * @group Game Obj
+     * @subgroup Prefabs
      */
     addPrefab<T extends CompList<unknown>>(
         nameOrObject: SerializedGameObj | string,
@@ -284,6 +285,8 @@ export interface KAPLAYCtx<
      *
      * @returns The serialized game object.
      * @since v4000.0
+     * @group Game Obj
+     * @subgroup Prefabs
      */
     createPrefab(name: string, obj: GameObj): SerializedGameObj;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -5920,6 +5920,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Draw
+     * @subgroup Stack
      */
     pushTransform(): void;
     /**
@@ -5927,6 +5928,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Draw
+     * @subgroup Stack
      */
     popTransform(): void;
     /**
@@ -5945,6 +5947,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Draw
+     * @subgroup Stack
      */
     pushTranslate(t?: Vec2): void;
     /**
@@ -5952,6 +5955,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Draw
+     * @subgroup Stack
      */
     pushScale(s?: Vec2): void;
     /**
@@ -5959,6 +5963,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Draw
+     * @subgroup Stack
      */
     pushRotate(angle?: number): void;
     /**
@@ -5966,6 +5971,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Draw
+     * @subgroup Stack
      */
     pushMatrix(mat?: Mat23): void;
     /**
@@ -5984,7 +5990,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3000.0
-     * @group Draw
+     * @group Rendering
+     * @subgroup Shaders
      */
     usePostEffect(name: string, uniform?: Uniform | (() => Uniform)): void;
     /**
@@ -6008,6 +6015,7 @@ export interface KAPLAYCtx<
      * @returns The formatted text object.
      * @since v2000.2
      * @group Draw
+     * @subgroup Text
      */
     formatText(options: DrawTextOpt): FormattedText;
     /**
@@ -6017,6 +6025,7 @@ export interface KAPLAYCtx<
      *
      * @since v4000
      * @group Draw
+     * @subgroup Text
      */
     compileStyledText(text: any): StyledTextInfo;
     /**
@@ -6025,6 +6034,7 @@ export interface KAPLAYCtx<
      * @returns The canvas object.
      * @since v3001.0
      * @group Draw
+     * @subgroup Canvas
      */
     makeCanvas(w: number, h: number): Canvas;
     /**
@@ -6034,6 +6044,7 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0
      * @group Draw
+     * @subgroup Canvas
      */
     drawCanvas(opt: DrawCanvasOpt): void;
     /**
@@ -6089,7 +6100,7 @@ export interface KAPLAYCtx<
      *
      * @returns The dataURL of the image.
      * @since v2000.0
-     * @group Data
+     * @group Debug
      */
     screenshot(): string;
     /**
@@ -6125,7 +6136,7 @@ export interface KAPLAYCtx<
      *
      * @returns A control handle.
      * @since v2000.1
-     * @group Data
+     * @group Debug
      */
     record(frameRate?: number): Recording;
     /**
@@ -6293,9 +6304,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @returns The cancel event symbol.
-     * @since v3001.0.5
+     * @since v4000.0
      * @group Events
-     * @experimental This feature is in experimental phase, it will be fully released in v3001.1.0
      */
     cancel: () => Symbol;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -21,7 +21,7 @@ import type { Recording } from "../debug/record";
 import type { BlendComp } from "../ecs/components/draw/blend";
 import type { CircleComp, CircleCompOpt } from "../ecs/components/draw/circle";
 import type { ColorComp } from "../ecs/components/draw/color";
-import type { DrawonComp, DrawonOpt } from "../ecs/components/draw/drawon";
+import type { DrawonComp, DrawonCompOpt } from "../ecs/components/draw/drawon";
 import type { EllipseComp } from "../ecs/components/draw/ellipse";
 import type { MaskComp } from "../ecs/components/draw/mask";
 import type { OpacityComp } from "../ecs/components/draw/opacity";
@@ -1520,7 +1520,7 @@ export interface KAPLAYCtx<
      * @group Components
      * @subgroup Rendering
      */
-    drawon(canvas: FrameBuffer | Picture, opt?: DrawonOpt): DrawonComp;
+    drawon(canvas: FrameBuffer | Picture, opt?: DrawonCompOpt): DrawonComp;
     /**
      * A tile on a tile map.
      *
@@ -5858,7 +5858,18 @@ export interface KAPLAYCtx<
      */
     drawSubtracted(content: () => void, mask: () => void): void;
     /**
-     * A picture holding drawing data
+     * The exported Picture class to KAPLAY Context.
+     *
+     * @example
+     * ```js
+     * const k = kaplay();
+     *
+     * // You can use Picture class
+     * new k.Picture()
+     * ```
+     *
+     * @group Draw
+     * @subgroup Picture
      */
     Picture: typeof Picture;
     /**
@@ -6084,6 +6095,7 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0
      * @group Plugins
+     * @subgroup Systems
      */
     system(name: string, cb: () => void, when: SystemPhase[]): void;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -4664,7 +4664,7 @@ export interface KAPLAYCtx<
      * @returns The color.
      * @since v2000.1
      * @group Math
-     * @subgroup Color
+     * @subgroup Colors
      */
     hsl2rgb(hue: number, saturation: number, lightness: number): Color;
     /**
@@ -5265,7 +5265,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
-     * @subgroup Advanced
+     * @subgroup Shapes
      */
     Point: typeof Point;
     /**
@@ -5273,14 +5273,14 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
-     * @subgroup Advanced
+     * @subgroup Shapes
      */
     Line: typeof Line;
     /**
      * A rectangle shape.
      *
      * @since v2000.0
-     * @group Physics
+     * @group Math
      * @subgroup Shapes
      */
     Rect: typeof Rect;

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -118,6 +118,7 @@ import type { DrawBezierOpt } from "../gfx/draw/drawBezier";
 import type { DrawCanvasOpt } from "../gfx/draw/drawCanvas";
 import type { DrawCircleOpt } from "../gfx/draw/drawCircle";
 import type { DrawCurveOpt } from "../gfx/draw/drawCurve";
+import type { DrawEllipseOpt } from "../gfx/draw/drawEllipse";
 import type { FormattedText } from "../gfx/draw/drawFormattedText";
 import type {
     DrawLineOpt,
@@ -126,10 +127,12 @@ import type {
     LineJoin,
 } from "../gfx/draw/drawLine";
 import type { DrawPictureOpt, Picture } from "../gfx/draw/drawPicture";
+import type { DrawPolygonOpt } from "../gfx/draw/drawPolygon";
 import type { DrawRectOpt } from "../gfx/draw/drawRect";
 import type { DrawSpriteOpt } from "../gfx/draw/drawSprite";
 import type { DrawTextOpt } from "../gfx/draw/drawText";
 import type { DrawTriangleOpt } from "../gfx/draw/drawTriangle";
+import type { DrawUVQuadOpt } from "../gfx/draw/drawUVQuad";
 import type { StyledTextInfo } from "../gfx/formatText";
 import type { FrameBuffer } from "../gfx/FrameBuffer";
 import type { Color, CSSColor } from "../math/color";
@@ -159,9 +162,6 @@ import type {
     Comp,
     CompList,
     Cursor,
-    DrawEllipseOpt,
-    DrawPolygonOpt,
-    DrawUVQuadOpt,
     EmptyComp,
     GameObj,
     GetOpt,

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -477,6 +477,7 @@ export interface KAPLAYCtx<
      * @returns The position comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Transform
      */
     pos(x: number, y: number): PosComp;
     pos(xy: number): PosComp;
@@ -510,6 +511,7 @@ export interface KAPLAYCtx<
      * @returns The scale comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Transform
      */
     scale(x: number, y: number): ScaleComp;
     scale(xy: number): ScaleComp;
@@ -534,6 +536,7 @@ export interface KAPLAYCtx<
      * @returns The rotate comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Transform
      */
     rotate(a?: number): RotateComp;
     // #endregion
@@ -556,6 +559,7 @@ export interface KAPLAYCtx<
      * @returns The color comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     color(r: number, g: number, b: number): ColorComp;
     color(c: Color): ColorComp;
@@ -577,6 +581,7 @@ export interface KAPLAYCtx<
      * @returns The blend comp.
      * @since v4000.0
      * @group Components
+     * @subgroup Rendering
      */
     blend(blend: BlendMode): BlendComp;
     /**
@@ -601,6 +606,7 @@ export interface KAPLAYCtx<
      * @returns The opacity comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     opacity(o?: number): OpacityComp;
     /**
@@ -635,6 +641,7 @@ export interface KAPLAYCtx<
      * @returns The sprite comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     sprite(
         spr: string | SpriteData | Asset<SpriteData>,
@@ -674,6 +681,7 @@ export interface KAPLAYCtx<
      * @returns The text comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     text(txt?: string, opt?: TextCompOpt): TextComp;
     /**
@@ -696,6 +704,7 @@ export interface KAPLAYCtx<
      * @returns The polygon comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Rendering
      */
     polygon(pts: Vec2[], opt?: PolygonCompOpt): PolygonComp;
     /**
@@ -717,6 +726,7 @@ export interface KAPLAYCtx<
      *
      * @returns The rectangle component.
      * @group Components
+     * @subgroup Rendering
      */
     rect(w: number, h: number, opt?: RectCompOpt): RectComp;
     /**
@@ -736,6 +746,7 @@ export interface KAPLAYCtx<
      * @returns The circle comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     circle(radius: number, opt?: CircleCompOpt): CircleComp;
     /**
@@ -755,6 +766,7 @@ export interface KAPLAYCtx<
      * @returns The ellipse comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     ellipse(radiusX: number, radiusY: number): EllipseComp;
     /**
@@ -774,6 +786,7 @@ export interface KAPLAYCtx<
      * @returns The UV quad comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     uvquad(w: number, h: number): UVQuadComp;
     /**
@@ -785,16 +798,18 @@ export interface KAPLAYCtx<
      * @returns The video comp.
      * @since v4000.0
      * @group Components
+     * @subgroup Rendering
      */
     video(url: string, opt?: VideoCompOpt): VideoComp;
     /**
-     * Draws a picture.
+     * Draws a picture, using the Picture API.
      *
      * @param picture - The picture to draw.
      *
      * @returns The picture comp.
      * @since v4000.0
      * @group Components
+     * @subgroup Rendering
      */
     picture(picture: Picture): PictureComp;
     /**
@@ -827,6 +842,7 @@ export interface KAPLAYCtx<
      * @returns The area comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Physics
      */
     area(opt?: AreaCompOpt): AreaComp;
     /**
@@ -847,6 +863,7 @@ export interface KAPLAYCtx<
      * @returns The anchor comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     anchor(o: Anchor | Vec2): AnchorComp;
     /**
@@ -875,6 +892,7 @@ export interface KAPLAYCtx<
      * @returns The z comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     z(z: number): ZComp;
     /**
@@ -906,6 +924,7 @@ export interface KAPLAYCtx<
      * @returns The layer comp.
      * @since v3001.0
      * @group Layer
+     * @subgroup Rendering
      */
     layer(name: string): LayerComp;
     /**
@@ -931,6 +950,7 @@ export interface KAPLAYCtx<
      * @returns The outline comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     outline(
         width?: number,
@@ -975,6 +995,7 @@ export interface KAPLAYCtx<
      * @returns The particles comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Rendering
      */
     particles(popt: ParticlesOpt, eopt: EmitterOpt): ParticlesComp;
     /**
@@ -1010,6 +1031,7 @@ export interface KAPLAYCtx<
      * @returns The body comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Physics
      */
     body(opt?: BodyCompOpt): BodyComp;
     /**
@@ -1038,6 +1060,7 @@ export interface KAPLAYCtx<
      * @returns The surface effector comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Physics
      */
     surfaceEffector(opt: SurfaceEffectorCompOpt): SurfaceEffectorComp;
     /**
@@ -1049,6 +1072,7 @@ export interface KAPLAYCtx<
      * @returns The area effector comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Physics
      */
     areaEffector(opt: AreaEffectorCompOpt): AreaEffectorComp;
     /**
@@ -1060,6 +1084,7 @@ export interface KAPLAYCtx<
      * @returns The point effector comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Physics
      */
     pointEffector(opt: PointEffectorCompOpt): PointEffectorComp;
     /**
@@ -1072,6 +1097,7 @@ export interface KAPLAYCtx<
      * @returns The platform effector comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Physics
      */
     platformEffector(opt?: PlatformEffectorCompOpt): PlatformEffectorComp;
     /**
@@ -1083,6 +1109,7 @@ export interface KAPLAYCtx<
      * @returns The buoyancy effector comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Physics
      */
     buoyancyEffector(opt: BuoyancyEffectorCompOpt): BuoyancyEffectorComp;
     /**
@@ -1094,6 +1121,7 @@ export interface KAPLAYCtx<
      * @returns The constant force comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Physics
      */
     constantForce(opt: ConstantForceCompOpt): ConstantForceComp;
     /**
@@ -1104,6 +1132,7 @@ export interface KAPLAYCtx<
      * @returns The double jump comp.
      * @since v3000.0
      * @group Components
+     * @subgroup Physics
      *
      * @requires {@link body `body()`}
      */
@@ -1129,6 +1158,7 @@ export interface KAPLAYCtx<
      * @returns The move comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Behaviour
      *
      * @requires {@link pos `pos()`}
      */
@@ -1151,6 +1181,7 @@ export interface KAPLAYCtx<
      * @returns The offscreen comp.
      * @since v2000.2
      * @group Components
+     * @subgroup Behaviour
      */
     offscreen(opt?: OffScreenCompOpt): OffScreenComp;
     /**
@@ -1184,6 +1215,7 @@ export interface KAPLAYCtx<
      * @returns The follow comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Transform
      */
     follow(obj: GameObj | null, offset?: Vec2): FollowComp;
     /**
@@ -1195,6 +1227,7 @@ export interface KAPLAYCtx<
      * @returns The shader comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     shader(id: string, uniform?: Uniform | (() => Uniform)): ShaderComp;
     /**
@@ -1217,6 +1250,7 @@ export interface KAPLAYCtx<
      * @returns The text input comp.
      * @since v3001.0
      * @group Components
+     * @subgroup UI
      */
     textInput(hasFocus?: boolean, maxInputLength?: number): TextInputComp;
     /**
@@ -1238,6 +1272,7 @@ export interface KAPLAYCtx<
      * @returns The timer comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Behaviour
      */
     timer(maxLoopsPerFrame?: number): TimerComp;
     /**
@@ -1259,6 +1294,7 @@ export interface KAPLAYCtx<
      * @returns The fixed comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Rendering
      */
     fixed(fixed?: boolean): FixedComp;
     /**
@@ -1282,6 +1318,7 @@ export interface KAPLAYCtx<
      * @returns The stay comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Behaviour
      */
     stay(scenesToStay?: string[]): StayComp;
     /**
@@ -1319,6 +1356,7 @@ export interface KAPLAYCtx<
      * @returns The health comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Behaviour
      */
     health(hp: number, maxHP?: number): HealthComp;
     /**
@@ -1341,6 +1379,7 @@ export interface KAPLAYCtx<
      * @returns The lifespan comp.
      * @since v2000.0
      * @group Components
+     * @subgroup Behaviour
      */
     lifespan(time: number, options?: LifespanCompOpt): EmptyComp;
     /**
@@ -1351,6 +1390,7 @@ export interface KAPLAYCtx<
      * @returns The named comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Behaviour
      */
     named(name: string): NamedComp;
     /**
@@ -1395,6 +1435,7 @@ export interface KAPLAYCtx<
      * @returns The state comp.
      * @since v2000.1
      * @group Components
+     * @subgroup Behaviour
      */
     state<T extends string>(initialState: T, stateList?: T[]): StateComp<T>;
     /**
@@ -1425,6 +1466,7 @@ export interface KAPLAYCtx<
      * @returns The state comp.
      * @since v2000.2
      * @group Components
+     * @subgroup Behaviour
      */
     state<T extends string>(
         initialState: T,
@@ -1434,15 +1476,16 @@ export interface KAPLAYCtx<
     /**
      * @deprecated since v3001.0
      *
-     * @returns An empty comp.
-     * @since v3000.0
-     * @group Components
-     *
-     * @requires {@link opacity `opacity()`}
-     *
      * Fade object in.
      *
      * Uses opacity for finding what to fade into and to set opacity during fade animation.
+     *
+     * @returns An empty comp.
+     * @since v3000.0
+     * @group Components
+     * @subgroup Behaviour
+     *
+     * @requires {@link opacity `opacity()`}
      */
     fadeIn(time: number): Comp;
     /**
@@ -1453,6 +1496,7 @@ export interface KAPLAYCtx<
      * @returns The mask comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Rendering
      */
     mask(maskType?: Mask): MaskComp;
     /**
@@ -1474,6 +1518,7 @@ export interface KAPLAYCtx<
      * @returns The drawon comp.
      * @since v3000.0
      * @group Components
+     * @subgroup Rendering
      */
     drawon(canvas: FrameBuffer | Picture, opt?: DrawonOpt): DrawonComp;
     /**
@@ -1484,6 +1529,7 @@ export interface KAPLAYCtx<
      * @returns The tile comp.
      * @since v3000.0
      * @group Components
+     * @subgroup Behaviour
      */
     tile(opt?: TileCompOpt): TileComp;
     /**
@@ -1494,6 +1540,7 @@ export interface KAPLAYCtx<
      * @returns The agent comp.
      * @since v3000.0
      * @group Components
+     * @subgroup Level
      */
     agent(opt?: AgentCompOpt): AgentComp;
     /**
@@ -1545,6 +1592,7 @@ export interface KAPLAYCtx<
      * @returns The animate comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Behaviour
      */
     animate(opt?: AnimateCompOpt): AnimateComp;
     /**
@@ -1557,6 +1605,7 @@ export interface KAPLAYCtx<
      * @returns The fake mouse comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Behaviour
      */
     fakeMouse(opt?: FakeMouseOpt): FakeMouseComp;
     /**
@@ -1567,6 +1616,7 @@ export interface KAPLAYCtx<
      * @returns The serialized animation.
      * @since v3001.0
      * @group Components
+     * @subgroup Component Serialization
      */
     serializeAnimation(obj: GameObj, name: string): Animation;
     /**
@@ -1575,6 +1625,7 @@ export interface KAPLAYCtx<
      * @returns The sentry comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Level
      */
     sentry(candidates: SentryCandidates, opt?: SentryCompOpt): SentryComp;
     /**
@@ -1607,6 +1658,7 @@ export interface KAPLAYCtx<
      * @returns The patrol comp.
      * @since v3001.0
      * @group Components
+     * @subgroup Level
      */
     patrol(opts: PatrolCompOpt): PatrolComp;
     /**
@@ -1614,9 +1666,9 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Components
+     * @subgroup Level
      */
     pathfinder(opts: PathfinderCompOpt): PathfinderComp;
-
     /**
      * Construct a level based on symbols.
      *
@@ -1664,6 +1716,7 @@ export interface KAPLAYCtx<
      * @returns A game obj with the level.
      * @since v4000.0
      * @group Components
+     * @subgroup Level
      */
     level(map: string[], opt?: LevelOpt): LevelComp;
 
@@ -2999,7 +3052,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @group Assets
-     * @subgroup Other
+     * @subgroup Util
      */
     loadRoot(path?: string): string;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -2994,6 +2994,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @group Assets
+     * @subgroup Other
      */
     loadRoot(path?: string): string;
     /**
@@ -3029,6 +3030,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Sprites
      */
     loadSprite(
         name: string | null,
@@ -3069,6 +3071,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Sprites
      */
     loadSpriteAtlas(
         src: LoadSpriteSrc,
@@ -3095,6 +3098,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Sprites
      */
     loadSpriteAtlas(
         src: LoadSpriteSrc,
@@ -3114,6 +3118,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Sprites
      */
     loadAseprite(
         name: string | null,
@@ -3138,6 +3143,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Defaults
      */
     loadBean(name?: string): Asset<SpriteData>;
     /**
@@ -3158,6 +3164,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v4000.0
      * @group Assets
+     * @subgroup Defaults
      */
     loadHappy(name?: string, opt?: LoadBitmapFontOpt): Asset<BitmapFontData>;
     /**
@@ -3169,6 +3176,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Data
      */
     loadJSON(name: string | null, url: string): Asset<any>;
     /**
@@ -3189,6 +3197,7 @@ export interface KAPLAYCtx<
      * @returns  The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Audio
      */
     loadSound(
         name: string | null,
@@ -3208,6 +3217,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3001.0
      * @group Assets
+     * @subgroup Audio
      */
     loadMusic(name: string | null, url: string): void;
     /**
@@ -3224,6 +3234,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Fonts
      */
     loadFont(
         name: string,
@@ -3252,6 +3263,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Fonts
      */
     loadBitmapFont(
         name: string | null,
@@ -3276,6 +3288,7 @@ export interface KAPLAYCtx<
      *
      * @returns The generated font data.
      * @group Assets
+     * @subgroup Fonts
      *
      * @see {@link LoadSpriteOpt}
      */
@@ -3353,6 +3366,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Other
      */
     load<T>(l: Promise<T>): Asset<T>;
     /**
@@ -3370,6 +3384,7 @@ export interface KAPLAYCtx<
      * @returns The loading progress.
      * @since v3000.0
      * @group Assets
+     * @subgroup Info
      */
     loadProgress(): number;
     /**
@@ -3380,6 +3395,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Sprites
      */
     getSprite(name: string): Asset<SpriteData> | null;
     /**
@@ -3390,6 +3406,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Audio
      */
     getSound(name: string): Asset<SoundData> | null;
     /**
@@ -3400,6 +3417,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Fonts
      */
     getFont(name: string): Asset<FontData> | null;
     /**
@@ -3410,6 +3428,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Fonts
      */
     getBitmapFont(name: string): Asset<BitmapFontData> | null;
     /**
@@ -3431,22 +3450,26 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Other
      */
     getAsset(name: string): Asset<any> | null;
     /**
      * The asset data.
      *
      * @group Assets
+     * @subgroup Other
      */
     Asset: typeof Asset;
     /**
      * The sprite data.
      *
      * @group Assets
+     * @subgroup Sprites
      */
     SpriteData: typeof SpriteData;
     /**
      * @group Assets
+     * @subgroup Audio
      */
     SoundData: typeof SoundData;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -5921,7 +5921,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v2000.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Stack
      */
     pushTransform(): void;
@@ -5929,7 +5929,7 @@ export interface KAPLAYCtx<
      * Pop the topmost transform matrix from the transform stack.
      *
      * @since v2000.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Stack
      */
     popTransform(): void;
@@ -5948,7 +5948,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v2000.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Stack
      */
     pushTranslate(t?: Vec2): void;
@@ -5956,7 +5956,7 @@ export interface KAPLAYCtx<
      * Scale all subsequent draws.
      *
      * @since v2000.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Stack
      */
     pushScale(s?: Vec2): void;
@@ -5964,7 +5964,7 @@ export interface KAPLAYCtx<
      * Rotate all subsequent draws.
      *
      * @since v2000.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Stack
      */
     pushRotate(angle?: number): void;
@@ -5972,7 +5972,7 @@ export interface KAPLAYCtx<
      * Apply a transform matrix, ignore all prior transforms.
      *
      * @since v3000.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Stack
      */
     pushMatrix(mat?: Mat23): void;
@@ -6157,7 +6157,6 @@ export interface KAPLAYCtx<
      * @returns The explosion object.
      * @since v2000.0
      * @group Game Obj
-     * @subgroup Util
      */
     addKaboom(pos: Vec2, opt?: BoomOpt): GameObj;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -197,6 +197,8 @@ export interface KAPLAYCtx<
     /**
      * Internal data that should not be accessed directly.
      *
+     * @ignore
+     *
      * @readonly
      * @group Misc
      */
@@ -2943,6 +2945,7 @@ export interface KAPLAYCtx<
      * @group Scene
      */
     getSceneName(): string | null;
+    // #region Loaders
     /**
      * Sets the root for all subsequent resource urls.
      *
@@ -2961,7 +2964,6 @@ export interface KAPLAYCtx<
      *
      * @group Assets
      */
-    // #region Loaders
     loadRoot(path?: string): string;
     /**
      * Load a sprite into asset manager, with name and resource url and optional config.
@@ -3110,7 +3112,8 @@ export interface KAPLAYCtx<
     /**
      * Load default font "happy".
      *
-     * @param name - An optional name for happy.
+     * @param name - Optional name for happy. Default to happy.
+     * @param opt - Optional config for {@link loadBitmapFont `loadBitmapFont`}.
      *
      * @example
      * ```js
@@ -3120,6 +3123,10 @@ export interface KAPLAYCtx<
      *     text("ohhi", { font: "happy" }),
      * ]);
      * ```
+     *
+     * @returns The asset data.
+     * @since v4000.0
+     * @group Assets
      */
     loadHappy(name?: string, opt?: LoadBitmapFontOpt): Asset<BitmapFontData>;
     /**
@@ -3269,6 +3276,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
+     * @subgroup Shaders
      */
     loadShader(
         name: string | null,
@@ -3291,6 +3299,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Shaders
      */
     loadShaderURL(
         name: string | null,
@@ -3380,6 +3389,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
+     * @subgroup Shaders
      */
     getShader(name: string): Asset<ShaderData> | null;
     /**
@@ -4820,13 +4830,16 @@ export interface KAPLAYCtx<
      */
     normalizedCurve(curve: (t: number) => Vec2): (s: number) => Vec2;
     /**
-     * A second order function returning an evaluator for the given 1D Hermite curve
-     * @param pt1 - First point
-     * @param m1 - First control point (tangent)
-     * @param m2 - Second control point (tangent)
-     * @param pt2 - Second point
+     * A second order function returning an evaluator for the given 1D Hermite curve.
      *
-     * @returns A function which gives the value on the 1D Hermite curve at t
+     * @param pt1 - First point.
+     * @param m1 - First control point (tangent).
+     * @param m2 - Second control point (tangent).
+     * @param pt2 - Second point.
+     *
+     * @returns A function which gives the value on the 1D Hermite curve at t.
+     * @group Math
+     * @subgroup Advanced
      */
     hermite(
         pt1: number,
@@ -4835,14 +4848,17 @@ export interface KAPLAYCtx<
         pt2: number,
     ): (t: number) => number;
     /**
-     * A second order function returning an evaluator for the given 2D Cardinal curve
-     * @param pt1 - Previous point
-     * @param pt2 - First point
-     * @param pt3 - Second point
-     * @param pt4 - Next point
+     * A second order function returning an evaluator for the given 2D Cardinal curve.
+     *
+     * @param pt1 - Previous point.
+     * @param pt2 - First point.
+     * @param pt3 - Second point.
+     * @param pt4 - Next point.
      * @param tension - The tension of the curve, [0..1] from round to tight.
      *
-     * @returns A function which gives the value on the 2D Cardinal curve at t
+     * @returns A function which gives the value on the 2D Cardinal curve at t.
+     * @group Math
+     * @subgroup Advanced
      */
     cardinal(
         pt1: Vec2,
@@ -4852,36 +4868,45 @@ export interface KAPLAYCtx<
         tension: number,
     ): (t: number) => Vec2;
     /**
-     * A second order function returning an evaluator for the given 2D Catmull-Rom curve
-     * @param pt1 - Previous point
-     * @param pt2 - First point
-     * @param pt3 - Second point
-     * @param pt4 - Next point
+     * A second order function returning an evaluator for the given 2D Catmull-Rom curve.
      *
-     * @returns A function which gives the value on the 2D Catmull-Rom curve at t
+     * @param pt1 - Previous point.
+     * @param pt2 - First point.
+     * @param pt3 - Second point.
+     * @param pt4 - Next point.
+     *
+     * @returns A function which gives the value on the 2D Catmull-Rom curve at t.
+     * @group Math
+     * @subgroup Advanced
      */
     catmullRom(pt1: Vec2, m1: Vec2, m2: Vec2, pt2: Vec2): (t: number) => Vec2;
     /**
-     * A second order function returning an evaluator for the given 2D quadratic Bezier curve
-     * @param pt1 - First point
-     * @param pt2 - First control point
-     * @param pt3 - Second control point
-     * @param pt4 - Second point
+     * A second order function returning an evaluator for the given 2D quadratic Bezier curve.
      *
-     * @returns A function which gives the value on the 2D quadratic Bezier curve at t
+     * @param pt1 - First point.
+     * @param pt2 - First control point.
+     * @param pt3 - Second control point.
+     * @param pt4 - Second point.
+     *
+     * @returns A function which gives the value on the 2D quadratic Bezier curve at t.
+     * @group Math
+     * @subgroup Advanced
      */
     bezier(pt1: Vec2, pt2: Vec2, pt3: Vec2, pt4: Vec2): (t: number) => Vec2;
     /**
-     * A second order function returning an evaluator for the given 2D Kochanek–Bartels curve
-     * @param pt1 - Previous point
-     * @param pt2 - First point
-     * @param pt3 - Second point
-     * @param pt4 - Next point
+     * A second order function returning an evaluator for the given 2D Kochanek–Bartels curve.
+     *
+     * @param pt1 - Previous point.
+     * @param pt2 - First point.
+     * @param pt3 - Second point.
+     * @param pt4 - Next point.
      * @param tension - The tension of the curve, [-1..1] from round to tight.
      * @param continuity - The continuity of the curve, [-1..1] from box corners to inverted corners.
      * @param bias - The bias of the curve, [-1..1] from pre-shoot to post-shoot.
      *
      * @returns A function which gives the value on the 2D Kochanek–Bartels curve at t
+     * @group Math
+     * @subgroup Advanced
      */
     kochanekBartels(
         pt1: Vec2,

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -43,7 +43,7 @@ import type { TextComp, TextCompOpt } from "../ecs/components/draw/text";
 import type { UVQuadComp } from "../ecs/components/draw/uvquad";
 import type { VideoComp, VideoCompOpt } from "../ecs/components/draw/video";
 import type { AgentComp, AgentCompOpt } from "../ecs/components/level/agent";
-import type { LevelComp, LevelOpt } from "../ecs/components/level/level";
+import type { LevelComp, LevelCompOpt } from "../ecs/components/level/level";
 import type {
     PathfinderComp,
     PathfinderCompOpt,
@@ -1718,7 +1718,7 @@ export interface KAPLAYCtx<
      * @group Components
      * @subgroup Level
      */
-    level(map: string[], opt?: LevelOpt): LevelComp;
+    level(map: string[], opt?: LevelCompOpt): LevelComp;
 
     // #endregion
     /**
@@ -5565,7 +5565,9 @@ export interface KAPLAYCtx<
      *
      * @returns A game obj with the level.
      * @since v2000.0
-     * @group Level
+     * @group Game Obj
+     *
+     * @see {@link LevelComp `LevelComp`} The level component for more information in level methods.
      */
     addLevel(
         map: string[],

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -6016,7 +6016,7 @@ export interface KAPLAYCtx<
      *
      * @returns The formatted text object.
      * @since v2000.2
-     * @group Draw
+     * @group Rendering
      * @subgroup Text
      */
     formatText(options: DrawTextOpt): FormattedText;
@@ -6026,7 +6026,7 @@ export interface KAPLAYCtx<
      * active on each character.
      *
      * @since v4000
-     * @group Draw
+     * @group Rendering
      * @subgroup Text
      */
     compileStyledText(text: any): StyledTextInfo;
@@ -6035,7 +6035,7 @@ export interface KAPLAYCtx<
      *
      * @returns The canvas object.
      * @since v3001.0
-     * @group Draw
+     * @group Rendering
      * @subgroup Canvas
      */
     makeCanvas(w: number, h: number): Canvas;
@@ -6046,7 +6046,6 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0
      * @group Draw
-     * @subgroup Canvas
      */
     drawCanvas(opt: DrawCanvasOpt): void;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -164,12 +164,12 @@ import type {
     DrawUVQuadOpt,
     EmptyComp,
     GameObj,
-    GamepadStick,
     GetOpt,
     KAPLAYPlugin,
     Key,
     KGamepad,
     KGamepadButton,
+    KGamepadStick,
     LoadFontOpt,
     Mask,
     MouseButton,
@@ -2143,6 +2143,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadConnect(action: (gamepad: KGamepad) => void): KEventController;
     /**
@@ -2161,6 +2162,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadDisconnect(action: (gamepad: KGamepad) => void): KEventController;
     /**
@@ -2247,6 +2249,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Mouse
      */
     onClick(tag: Tag, action: (a: GameObj) => void): KEventController;
     /**
@@ -2323,6 +2326,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Keyboard
      */
     onKeyDown(key: Key | Key[], action: (key: Key) => void): KEventController;
     /**
@@ -2333,6 +2337,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Keyboard
      */
     onKeyDown(action: (key: Key) => void): KEventController;
     /**
@@ -2356,6 +2361,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Keyboard
      */
     onKeyPress(key: Key | Key[], action: (key: Key) => void): KEventController;
     /**
@@ -2375,6 +2381,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Keyboard
      */
     onKeyPress(action: (key: Key) => void): KEventController;
     /**
@@ -2394,6 +2401,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3000.1
      * @group Input
+     * @subgroup Keyboard
      */
     onKeyPressRepeat(
         k: Key | Key[],
@@ -2417,6 +2425,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Keyboard
      */
     onKeyRelease(k: Key | Key[], action: (k: Key) => void): KEventController;
     /**
@@ -2453,6 +2462,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Keyboard
      */
     onCharInput(action: (ch: string) => void): KEventController;
     /**
@@ -2474,6 +2484,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Mouse
      */
     onMouseDown(
         btn: MouseButton | MouseButton[],
@@ -2496,6 +2507,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Mouse
      */
     onMouseDown(action: (m: MouseButton) => void): KEventController;
     /**
@@ -2519,6 +2531,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Mouse
      */
     onMousePress(action: (m: MouseButton) => void): KEventController;
     /**
@@ -2540,6 +2553,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Mouse
      */
     onMousePress(
         btn: MouseButton | MouseButton[],
@@ -2566,6 +2580,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Mouse
      */
     onMouseRelease(action: (m: MouseButton) => void): KEventController;
     /**
@@ -2592,6 +2607,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Mouse
      */
     onMouseRelease(
         btn: MouseButton | MouseButton[],
@@ -2613,6 +2629,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Mouse
      */
     onMouseMove(action: (pos: Vec2, delta: Vec2) => void): KEventController;
     /**
@@ -2623,6 +2640,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Touch
      */
     onTouchStart(action: (pos: Vec2, t: Touch) => void): KEventController;
     /**
@@ -2633,6 +2651,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Touch
      */
     onTouchMove(action: (pos: Vec2, t: Touch) => void): KEventController;
     /**
@@ -2643,6 +2662,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v2000.1
      * @group Input
+     * @subgroup Touch
      */
     onTouchEnd(action: (pos: Vec2, t: Touch) => void): KEventController;
     /**
@@ -2662,6 +2682,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3000.0
      * @group Input
+     * @subgroup Mouse
      */
     onScroll(action: (delta: Vec2) => void): KEventController;
     /**
@@ -2729,6 +2750,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadButtonDown(
         btn: KGamepadButton | KGamepadButton[],
@@ -2754,6 +2776,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadButtonDown(
         action: (btn: KGamepadButton, gamepad: KGamepad) => void,
@@ -2775,6 +2798,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadButtonPress(
         btn: KGamepadButton | KGamepadButton[],
@@ -2798,6 +2822,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadButtonPress(
         action: (btn: KGamepadButton, gamepad: KGamepad) => void,
@@ -2826,6 +2851,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadButtonRelease(
         btn: KGamepadButton | KGamepadButton[],
@@ -2849,6 +2875,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadButtonRelease(
         action: (btn: KGamepadButton, gamepad: KGamepad) => void,
@@ -2856,7 +2883,7 @@ export interface KAPLAYCtx<
     /**
      * Register an event that runs when the gamepad axis exists.
      *
-     * @param button - The stick to listen for. See {@link GamepadStick `GamepadStick`}.
+     * @param button - The stick to listen for. See {@link KGamepadStick `GamepadStick`}.
      * @param action - The function that is run when a specific gamepad stick is moved.
      *
      * @example
@@ -2876,9 +2903,10 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     onGamepadStick(
-        stick: GamepadStick,
+        stick: KGamepadStick,
         action: (value: Vec2, gameepad: KGamepad) => void,
     ): KEventController;
     /**
@@ -2891,6 +2919,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     onButtonPress(
         btn: TButton | TButton[],
@@ -2906,6 +2935,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     onButtonRelease(
         btn: TButton | TButton[],
@@ -2922,6 +2952,7 @@ export interface KAPLAYCtx<
      * @returns The event controller.
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     onButtonDown(
         btn: TButton | TButton[],
@@ -3510,6 +3541,7 @@ export interface KAPLAYCtx<
      * @returns true if on a touch screen device.
      * @since v3000.0
      * @group Input
+     * @subgroup Touch
      */
     isTouchscreen(): boolean;
     /**
@@ -3518,6 +3550,7 @@ export interface KAPLAYCtx<
      * @returns The current mouse position.
      * @since v2000.0
      * @group Input
+     * @subgroup Mouse
      */
     mousePos(): Vec2;
     /**
@@ -3526,6 +3559,7 @@ export interface KAPLAYCtx<
      * @returns The delta mouse position.
      * @since v2000.0
      * @group Input
+     * @subgroup Mouse
      */
     mouseDeltaPos(): Vec2;
     /**
@@ -3573,6 +3607,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Keyboard
      */
     isKeyDown(k?: Key | Key[]): boolean;
     /**
@@ -3592,6 +3627,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Keyboard
      */
     isKeyPressed(k?: Key | Key[]): boolean;
     /**
@@ -3629,6 +3665,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Keyboard
      */
     isKeyPressedRepeat(k?: Key | Key[]): boolean;
     /**
@@ -3648,6 +3685,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Keyboard
      */
     isKeyReleased(k?: Key | Key[]): boolean;
     /**
@@ -3657,6 +3695,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Mouse
      */
     isMouseDown(btn?: MouseButton | MouseButton[]): boolean;
     /**
@@ -3666,6 +3705,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Mouse
      */
     isMousePressed(btn?: MouseButton | MouseButton[]): boolean;
     /**
@@ -3675,6 +3715,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Input
+     * @subgroup Mouse
      */
     isMouseReleased(btn?: MouseButton | MouseButton[]): boolean;
     /**
@@ -3682,6 +3723,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.1
      * @group Input
+     * @subgroup Mouse
      */
     isMouseMoved(): boolean;
     /**
@@ -3691,6 +3733,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     isGamepadButtonPressed(btn?: KGamepadButton | KGamepadButton[]): boolean;
     /**
@@ -3700,6 +3743,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     isGamepadButtonDown(btn?: KGamepadButton | KGamepadButton): boolean;
     /**
@@ -3709,6 +3753,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Input
+     * @subgroup Gamepad
      */
     isGamepadButtonReleased(btn?: KGamepadButton | KGamepadButton[]): boolean;
     /**
@@ -3728,6 +3773,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     isButtonPressed(btn?: TButton | TButton[]): boolean;
     /**
@@ -3747,6 +3793,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     isButtonDown(btn?: TButton | TButton[]): boolean;
     /**
@@ -3766,6 +3813,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     isButtonReleased(btn?: TButton | TButton[]): boolean;
     /**
@@ -3775,6 +3823,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     getButton(btn: keyof TButtonDef): ButtonBinding;
     /**
@@ -3784,6 +3833,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     setButton(btn: string, def: ButtonBinding): void;
     /**
@@ -3800,6 +3850,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     pressButton(btn: TButton): void;
     /**
@@ -3816,6 +3867,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Input
+     * @subgroup Buttons API
      */
     releaseButton(btn: TButton): void;
     /**
@@ -3826,14 +3878,16 @@ export interface KAPLAYCtx<
      * @returns The stick axis Vec2.
      * @since v3001.0
      * @group Input
+     * @subgroup Gamepad
      */
-    getGamepadStick(stick: GamepadStick): Vec2;
+    getGamepadStick(stick: KGamepadStick): Vec2;
     /**
      * Get the latest input device type that triggered the input event.
      *
      * @returns The last input device type, or null if no input event has been triggered.
      * @since v3001.0
      * @group Input
+     * @subgroup Util
      */
     getLastInputDeviceType(): ButtonBindingDevice | null;
     /**
@@ -3842,6 +3896,7 @@ export interface KAPLAYCtx<
      * @returns An array of characters inputted.
      * @since v3000.0
      * @group Input
+     * @group Keyboard
      */
     charInputted(): string[];
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -3148,7 +3148,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
-     * @subgroup Defaults
+     * @subgroup Default
      */
     loadBean(name?: string): Asset<SpriteData>;
     /**
@@ -3169,7 +3169,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v4000.0
      * @group Assets
-     * @subgroup Defaults
+     * @subgroup Default
      */
     loadHappy(name?: string, opt?: LoadBitmapFontOpt): Asset<BitmapFontData>;
     /**
@@ -3371,14 +3371,15 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Other
+     * @subgroup Util
      */
     load<T>(l: Promise<T>): Asset<T>;
     /**
      * Load a prefab.
      *
      * @since v4000.0.0
-     * @group Prefab
+     * @group Assets
+     * @subgroup Prefabs
      * @experimental
      */
     loadPrefab: (name: string, url: string) => Asset<SerializedGameObj>;
@@ -3389,7 +3390,7 @@ export interface KAPLAYCtx<
      * @returns The loading progress.
      * @since v3000.0
      * @group Assets
-     * @subgroup Info
+     * @subgroup Util
      */
     loadProgress(): number;
     /**
@@ -3455,14 +3456,14 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Other
+     * @subgroup Util
      */
     getAsset(name: string): Asset<any> | null;
     /**
      * The asset data.
      *
      * @group Assets
-     * @subgroup Other
+     * @subgroup Util
      */
     Asset: typeof Asset;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -2128,44 +2128,6 @@ export interface KAPLAYCtx<
      */
     onCleanup(action: () => void): void;
     /**
-     * Register an event that runs when a gamepad is connected.
-     *
-     * @param action - The function that runs when quit() is called.
-     *
-     * @example
-     * ```js
-     * // watch for a controller connecting
-     * onGamepadConnect((gp) => {
-     *     debug.log(`ohhi player ${gp.index + 1}`);
-     * });
-     * ```
-     *
-     * @returns The event controller.
-     * @since v3000.0
-     * @group Input
-     * @subgroup Gamepad
-     */
-    onGamepadConnect(action: (gamepad: KGamepad) => void): KEventController;
-    /**
-     * Register an event that runs when a gamepad is disconnected.
-     *
-     * @param action - The function that runs when quit() is called.
-     *
-     * @example
-     * ```js
-     * // watch for a controller disconnecting
-     * onGamepadDisconnect((gp) => {
-     *     debug.log(`ohbye player ${gp.index + 1}`);
-     * });
-     * ```
-     *
-     * @returns The event controller.
-     * @since v3000.0
-     * @group Input
-     * @subgroup Gamepad
-     */
-    onGamepadDisconnect(action: (gamepad: KGamepad) => void): KEventController;
-    /**
      * Register an event that runs once when 2 game objs with certain tags collides (required to have area() component).
      *
      * @param t1 - The tag of the first game obj.
@@ -2733,6 +2695,44 @@ export interface KAPLAYCtx<
      * @group Events
      */
     onShow(action: () => void): KEventController;
+    /**
+     * Register an event that runs when a gamepad is connected.
+     *
+     * @param action - The function that runs when quit() is called.
+     *
+     * @example
+     * ```js
+     * // watch for a controller connecting
+     * onGamepadConnect((gp) => {
+     *     debug.log(`ohhi player ${gp.index + 1}`);
+     * });
+     * ```
+     *
+     * @returns The event controller.
+     * @since v3000.0
+     * @group Input
+     * @subgroup Gamepad
+     */
+    onGamepadConnect(action: (gamepad: KGamepad) => void): KEventController;
+    /**
+     * Register an event that runs when a gamepad is disconnected.
+     *
+     * @param action - The function that runs when quit() is called.
+     *
+     * @example
+     * ```js
+     * // watch for a controller disconnecting
+     * onGamepadDisconnect((gp) => {
+     *     debug.log(`ohbye player ${gp.index + 1}`);
+     * });
+     * ```
+     *
+     * @returns The event controller.
+     * @since v3000.0
+     * @group Input
+     * @subgroup Gamepad
+     */
+    onGamepadDisconnect(action: (gamepad: KGamepad) => void): KEventController;
     /**
      * Register an event that runs every frame when certain gamepad buttons are held down.
      *
@@ -3896,7 +3896,7 @@ export interface KAPLAYCtx<
      * @returns An array of characters inputted.
      * @since v3000.0
      * @group Input
-     * @group Keyboard
+     * @subgroup Keyboard
      */
     charInputted(): string[];
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -304,6 +304,8 @@ export interface KAPLAYCtx<
      *
      * @returns The serialized game object.
      * @since v4000.0
+     * @group Game Obj
+     * @subgroup Prefabs
      */
     createPrefab(obj: GameObj): SerializedGameObj;
     /**
@@ -4456,7 +4458,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v2000.0
-     * @group Random
+     * @group Math
+     * @subgroup Random
      */
     rand<T = RNGValue>(a?: T, b?: T): T;
     /**
@@ -4474,7 +4477,8 @@ export interface KAPLAYCtx<
      *
      * @returns A random integer between 0 and 1.
      * @since v2000.0
-     * @group Random
+     * @group Math
+     * @subgroup Random
      */
     randi(a?: number, b?: number): number;
     /**
@@ -4489,7 +4493,8 @@ export interface KAPLAYCtx<
      *
      * @returns The new seed.
      * @since v2000.0
-     * @group Random
+     * @group Math
+     * @subgroup Random
      */
     randSeed(seed?: number): number;
     /**
@@ -4513,6 +4518,7 @@ export interface KAPLAYCtx<
      * @returns The vector.
      * @since v2000.0
      * @group Math
+     * @subgroup Vector
      */
     vec2(x: number, y: number): Vec2;
     vec2(p: Vec2): Vec2;
@@ -4534,6 +4540,7 @@ export interface KAPLAYCtx<
      * @returns The color.
      * @since v2000.0
      * @group Math
+     * @subgroup Color
      */
     rgb(r: number, g: number, b: number): Color;
     /**
@@ -4548,6 +4555,8 @@ export interface KAPLAYCtx<
      *
      * @returns The color.
      * @since v2000.0
+     * @group Math
+     * @subgroup Color
      */
     rgb(hex: string): Color;
     /**
@@ -4587,6 +4596,7 @@ export interface KAPLAYCtx<
      * @returns The color.
      * @since v2000.1
      * @group Math
+     * @subgroup Color
      */
     hsl2rgb(hue: number, saturation: number, lightness: number): Color;
     /**
@@ -4600,6 +4610,7 @@ export interface KAPLAYCtx<
      * @returns A Quad object.
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     quad(x: number, y: number, w: number, h: number): Quad;
     /**
@@ -4615,7 +4626,8 @@ export interface KAPLAYCtx<
      *
      * @returns A random item from the list.
      * @since v3001.0
-     * @group Random
+     * @group Math
+     * @subgroup Random
      */
     choose<T>(lst: T[]): T;
     /**
@@ -4626,7 +4638,8 @@ export interface KAPLAYCtx<
      *
      * @returns An array of random items from the list.
      * @since v3001.0
-     * @group Random
+     * @group Math
+     * @subgroup Random
      */
     chooseMultiple<T>(lst: T[], count: number): T[];
     /**
@@ -4636,7 +4649,8 @@ export interface KAPLAYCtx<
      *
      * @returns A shuffled array.
      * @since v3001.0
-     * @group Random
+     * @group Math
+     * @subgroup Random
      */
     shuffle<T>(lst: T[]): T[];
     /**
@@ -4653,12 +4667,14 @@ export interface KAPLAYCtx<
      * ```
      *
      * @group Math
+     * @subgroup Math
      */
     chance(p: number): boolean;
     /**
      * Linear interpolation. Can take a number, vector, or color.
      *
      * @group Math
+     * @subgroup Tween
      */
     lerp<V extends LerpValue>(from: V, to: V, t: number): V;
     /**
@@ -4672,6 +4688,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Math
+     * @subgroup Tween
      */
     tween<V extends LerpValue>(
         from: V,
@@ -4685,6 +4702,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Math
+     * @subgroup Tween
      */
     easings: Record<EaseFuncs, EaseFunc>;
     /**
@@ -4692,13 +4710,15 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Tween
      */
     easingSteps(steps: number, position: StepPosition): (x: number) => number;
     /**
-     * Linear easing with keyframes
+     * Linear easing with keyframes.
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Tween
      */
     easingLinear(keys: Vec2[]): (x: number) => number;
     /**
@@ -4706,6 +4726,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Tween
      */
     easingCubicBezier(p1: Vec2, p2: Vec2): (x: number) => number;
     /**
@@ -4785,31 +4806,36 @@ export interface KAPLAYCtx<
      * Convert degrees to radians.
      *
      * @group Math
+     * @subgroup Angle
      */
     deg2rad(deg: number): number;
     /**
      * Convert radians to degrees.
      *
      * @group Math
+     * @subgroup Angle
      */
     rad2deg(rad: number): number;
     /**
      * Return a value clamped to an inclusive range of min and max.
      *
      * @group Math
+     * @subgroup Util
      */
     clamp(n: number, min: number, max: number): number;
     /**
-     * Evaluate the quadratic Bezier at the given t
+     * Evaluate the quadratic Bezier at the given t.
      *
      * @group Math
+     * @subgroup Advanced
      */
     evaluateQuadratic(pt1: Vec2, pt2: Vec2, pt3: Vec2, t: number): Vec2;
     /**
-     * Evaluate the first derivative of a quadratic bezier at the given t
+     * Evaluate the first derivative of a quadratic bezier at the given t.
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     evaluateQuadraticFirstDerivative(
         pt1: Vec2,
@@ -4822,6 +4848,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     evaluateQuadraticSecondDerivative(
         pt1: Vec2,
@@ -4830,16 +4857,18 @@ export interface KAPLAYCtx<
         t: number,
     ): Vec2;
     /**
-     * Evaluate the cubic Bezier at the given t
+     * Evaluate the cubic Bezier at the given t.
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     evaluateBezier(pt1: Vec2, pt2: Vec2, pt3: Vec2, pt4: Vec2, t: number): Vec2;
     /**
-     * Evaluate the first derivative of a cubic Bezier at the given t
+     * Evaluate the first derivative of a cubic Bezier at the given t.
      *
      * @group Math
+     * @subgroup Advanced
      */
     evaluateBezierFirstDerivative(
         pt1: Vec2,
@@ -4849,10 +4878,11 @@ export interface KAPLAYCtx<
         t: number,
     ): Vec2;
     /**
-     * Evaluate the second derivative of a cubic bezier at the given t
+     * Evaluate the second derivative of a cubic bezier at the given t.
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     evaluateBezierSecondDerivative(
         pt1: Vec2,
@@ -4862,10 +4892,11 @@ export interface KAPLAYCtx<
         t: number,
     ): Vec2;
     /**
-     * Evaluate the Catmull-Rom spline at the given t
+     * Evaluate the Catmull-Rom spline at the given t.
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     evaluateCatmullRom(
         pt1: Vec2,
@@ -4875,10 +4906,11 @@ export interface KAPLAYCtx<
         t: number,
     ): Vec2;
     /**
-     * Evaluate the first derivative of a Catmull-Rom spline at the given t
+     * Evaluate the first derivative of a Catmull-Rom spline at the given t.
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     evaluateCatmullRomFirstDerivative(
         pt1: Vec2,
@@ -4895,6 +4927,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     curveLengthApproximation(
         curve: (t: number) => Vec2,
@@ -4908,6 +4941,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     normalizedCurve(curve: (t: number) => Vec2): (s: number) => Vec2;
     /**
@@ -5097,16 +5131,19 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0
      * @group Math
+     * @subgroup Vector
      */
     anchorToVec2: typeof anchorPt;
     /**
      * @since v4000.0
      * @group Math
+     * @subgroup Advanced
      */
     gjkShapeIntersects(shapeA: Shape, shapeB: Shape): boolean;
     /**
      * @since v4000.0
      * @group Math
+     * @subgroup Advanced
      */
     gjkShapeIntersection(
         shapeA: Shape,
@@ -5287,7 +5324,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Layers
+     * @group Scene
      */
     pushScene(id: SceneName, ...args: unknown[]): void;
 
@@ -5312,7 +5349,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Layers
+     * @group Scene
      */
     popScene(id: SceneName, ...args: unknown[]): void;
     /**
@@ -5384,7 +5421,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.0
-     * @group Scene
+     * @group Layers
      */
     layers(layers: string[], defaultLayer: string): void;
     /**
@@ -6102,6 +6139,9 @@ export interface KAPLAYCtx<
      * Throws a new error and show up the Blue Screen.
      *
      * @param msg - The message for showing in the Blue Screen.
+     *
+     * @since v4000.0
+     * @group Start
      */
     throwError: (msg: string) => void;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -1726,6 +1726,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Raycast
      */
     raycast(origin: Vec2, direction: Vec2, exclude?: string[]): RaycastResult;
     /**
@@ -4588,7 +4589,6 @@ export interface KAPLAYCtx<
      * @returns The vector.
      * @since v2000.0
      * @group Math
-     * @subgroup Vector
      */
     vec2(x: number, y: number): Vec2;
     vec2(p: Vec2): Vec2;
@@ -4610,7 +4610,6 @@ export interface KAPLAYCtx<
      * @returns The color.
      * @since v2000.0
      * @group Math
-     * @subgroup Color
      */
     rgb(r: number, g: number, b: number): Color;
     /**
@@ -4626,7 +4625,6 @@ export interface KAPLAYCtx<
      * @returns The color.
      * @since v2000.0
      * @group Math
-     * @subgroup Color
      */
     rgb(hex: string): Color;
     /**
@@ -4737,7 +4735,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @group Math
-     * @subgroup Math
+     * @subgroup Random
      */
     chance(p: number): boolean;
     /**
@@ -4890,7 +4888,6 @@ export interface KAPLAYCtx<
      * Return a value clamped to an inclusive range of min and max.
      *
      * @group Math
-     * @subgroup Util
      */
     clamp(n: number, min: number, max: number): number;
     /**
@@ -5111,6 +5108,7 @@ export interface KAPLAYCtx<
      * @returns true if the line and point intersects.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testLinePoint(l: Line, pt: Vec2): boolean;
     /**
@@ -5122,6 +5120,7 @@ export interface KAPLAYCtx<
      * @returns The intersection point, or null if the lines are parallel.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testLineLine(l1: Line, l2: Line): Vec2 | null;
     /**
@@ -5133,6 +5132,7 @@ export interface KAPLAYCtx<
      * @returns true if the line and circle intersects.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testLineCircle(l: Line, c: Circle): boolean;
     /**
@@ -5144,6 +5144,7 @@ export interface KAPLAYCtx<
      * @returns true if the rectangles overlap.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testRectRect(r1: Rect, r2: Rect): boolean;
     /**
@@ -5155,6 +5156,7 @@ export interface KAPLAYCtx<
      * @returns true if the line and rectangle overlaps.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testRectLine(r: Rect, l: Line): boolean;
     /**
@@ -5166,6 +5168,7 @@ export interface KAPLAYCtx<
      * @returns true if the point is inside the rectangle.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testRectPoint(r: Rect, pt: Vec2): boolean;
     /**
@@ -5177,16 +5180,19 @@ export interface KAPLAYCtx<
      * @returns true if the circle and polygon intersect linewise.
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     testCirclePolygon(c: Circle, p: Polygon): boolean;
     /**
      * @since v4000.0
      * @group Math
+     * @subgroup Advanced
      */
     clipLineToRect(r: Rect, l: Line, result: Line): boolean;
     /**
      * @since v4000.0
      * @group Math
+     * @subgroup Advanced
      */
     clipLineToCircle(c: Circle, l: Line, result: Line): boolean;
     /**
@@ -5223,23 +5229,27 @@ export interface KAPLAYCtx<
      * @returns true if the given polygon is convex
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     isConvex(pts: Vec2[]): boolean;
     /**
      * @returns 1 if over the edge, 0 otherwise
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     step(edge: number, x: number): number;
     /**
      * @returns 1 if over edge1, 0 if under edge0, a smooth hermite curve value otherwise
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     smoothstep(edge0: number, edge1: number, x: number): number;
     /**
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     triangulate(pts: Vec2[]): Vec2[][];
     /**
@@ -5247,6 +5257,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     NavMesh: typeof NavMesh;
     /**
@@ -5254,6 +5265,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     Point: typeof Point;
     /**
@@ -5261,13 +5273,15 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
+     * @subgroup Advanced
      */
     Line: typeof Line;
     /**
      * A rectangle shape.
      *
      * @since v2000.0
-     * @group Math
+     * @group Physics
+     * @subgroup Shapes
      */
     Rect: typeof Rect;
     /**
@@ -5275,6 +5289,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
+     * @subgroup Shapes
      */
     Circle: typeof Circle;
     /**
@@ -5282,6 +5297,7 @@ export interface KAPLAYCtx<
      *
      * @since v3001.0
      * @group Math
+     * @subgroup Shapes
      */
     Ellipse: typeof Ellipse;
     /**
@@ -5289,6 +5305,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
+     * @subgroup Shapes
      */
     Polygon: typeof Polygon;
     /**
@@ -5296,6 +5313,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
+     * @subgroup Vectors
      */
     Vec2: typeof Vec2;
     /**
@@ -5303,23 +5321,25 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
+     * @subgroup Vectors
      */
     Color: typeof Color;
     /**
      * @since v3001.0
      * @group Math
+     * @subgroup Advanced
      */
     Mat4: typeof Mat4;
     /**
      * @since v4000.0
-     * @group Math
+     * @subgroup Advanced
      */
     Mat23: typeof Mat23;
     /**
      * A 2D quad.
      *
      * @since v3001.0
-     * @group Math
+     * @subgroup Advanced
      */
     Quad: typeof Quad;
     /**
@@ -5327,6 +5347,7 @@ export interface KAPLAYCtx<
      *
      * @since v2000.0
      * @group Math
+     * @subgroup Random
      */
     RNG: typeof RNG;
     /**
@@ -5445,7 +5466,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Layers
+     * @group Rendering
+     * @subgroup Layers
      */
     setLayers(layers: string[], defaultLayer: string): void;
     /**
@@ -5453,7 +5475,8 @@ export interface KAPLAYCtx<
      *
      * @returns The layer names or null if not set.
      * @since v3001.1
-     * @group Layers
+     * @group Rendering
+     * @subgroup Layers
      * @experimental This feature is in experimental phase, it will be fully released in v3001.1
      */
     getLayers(): string[] | null;
@@ -5462,7 +5485,8 @@ export interface KAPLAYCtx<
      *
      * @returns The default layer name or null if not set.
      * @since v3001.0.5
-     * @group Layers
+     * @group Rendering
+     * @subgroup Layers
      * @experimental This feature is in experimental phase, it will be fully released in v3001.1
      */
     getDefaultLayer(): string | null;
@@ -5491,7 +5515,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.0
-     * @group Layers
+     * @group Rendering
+     * @subgroup Layers
      */
     layers(layers: string[], defaultLayer: string): void;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -3202,7 +3202,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v2000.0
      * @group Assets
-     * @subgroup Default
+     * @subgroup Sprites
      */
     loadBean(name?: string): Asset<SpriteData>;
     /**
@@ -3223,7 +3223,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v4000.0
      * @group Assets
-     * @subgroup Default
+     * @subgroup Fonts
      */
     loadHappy(name?: string, opt?: LoadBitmapFontOpt): Asset<BitmapFontData>;
     /**
@@ -3235,7 +3235,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Data
+     * @subgroup Util
      */
     loadJSON(name: string | null, url: string): Asset<any>;
     /**
@@ -3455,7 +3455,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Sprites
+     * @subgroup Getters
      */
     getSprite(name: string): Asset<SpriteData> | null;
     /**
@@ -3466,7 +3466,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Audio
+     * @subgroup Getters
      */
     getSound(name: string): Asset<SoundData> | null;
     /**
@@ -3477,7 +3477,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Fonts
+     * @subgroup Getters
      */
     getFont(name: string): Asset<FontData> | null;
     /**
@@ -3488,7 +3488,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Fonts
+     * @subgroup Getters
      */
     getBitmapFont(name: string): Asset<BitmapFontData> | null;
     /**
@@ -3499,7 +3499,7 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Shaders
+     * @subgroup Getters
      */
     getShader(name: string): Asset<ShaderData> | null;
     /**
@@ -3510,26 +3510,26 @@ export interface KAPLAYCtx<
      * @returns The asset data.
      * @since v3000.0
      * @group Assets
-     * @subgroup Util
+     * @subgroup Getters
      */
     getAsset(name: string): Asset<any> | null;
     /**
      * The asset data.
      *
      * @group Assets
-     * @subgroup Util
+     * @subgroup Data
      */
     Asset: typeof Asset;
     /**
      * The sprite data.
      *
      * @group Assets
-     * @subgroup Sprites
+     * @subgroup Data
      */
     SpriteData: typeof SpriteData;
     /**
      * @group Assets
-     * @subgroup Audio
+     * @subgroup Data
      */
     SoundData: typeof SoundData;
     /**
@@ -3545,7 +3545,7 @@ export interface KAPLAYCtx<
      *
      * @returns The root object.
      * @since v2000.0
-     * @group Info
+     * @group Game Obj
      */
     getTreeRoot(): GameObj;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -263,7 +263,6 @@ export interface KAPLAYCtx<
      *
      * @returns The added game object that contains all properties and methods each component offers.
      * @group Game Obj
-     * @subgroup Prefabs
      */
     addPrefab<T extends CompList<unknown>>(
         nameOrObject: SerializedGameObj | string,
@@ -286,7 +285,6 @@ export interface KAPLAYCtx<
      * @returns The serialized game object.
      * @since v4000.0
      * @group Game Obj
-     * @subgroup Prefabs
      */
     createPrefab(name: string, obj: GameObj): SerializedGameObj;
     /**
@@ -6095,7 +6093,6 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0
      * @group Plugins
-     * @subgroup Systems
      */
     system(name: string, cb: () => void, when: SystemPhase[]): void;
     /**
@@ -6327,6 +6324,7 @@ export interface KAPLAYCtx<
      *
      * @since v3000.0
      * @group Game Obj
+     * @subgroup Types
      */
     KeepFlags: typeof KeepFlags;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -923,7 +923,7 @@ export interface KAPLAYCtx<
      *
      * @returns The layer comp.
      * @since v3001.0
-     * @group Layer
+     * @group Components
      * @subgroup Rendering
      */
     layer(name: string): LayerComp;
@@ -3995,7 +3995,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     setCamPos(pos: Vec2): void;
     setCamPos(x: number, y: number): void;
@@ -4005,7 +4006,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera position.
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     getCamPos(): Vec2;
     /**
@@ -4022,7 +4024,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     setCamScale(scale: Vec2): void;
     setCamScale(x: number, y: number): void;
@@ -4032,7 +4035,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera scale.
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     getCamScale(): Vec2;
     /**
@@ -4047,7 +4051,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     setCamRot(angle: number): void;
     /**
@@ -4055,7 +4060,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera rotation.
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     getCamRot(): number;
     /**
@@ -4063,7 +4069,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera transform.
      * @since v3001.1
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     getCamTransform(): Mat23;
     /**
@@ -4080,7 +4087,8 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3000.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     shake(intensity?: number): void;
     /**
@@ -4099,7 +4107,8 @@ export interface KAPLAYCtx<
      *
      * @returns A timer controller.
      * @since v3001.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     flash(flashColor: Color, fadeOutTime: number): TimerController;
     // #region DEPRECATED CAMERA METHODS ---------------------------------------
@@ -4120,7 +4129,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera position.
      * @since v2000.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     camPos(pos: Vec2): Vec2;
     /** @deprecated */
@@ -4139,7 +4149,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera scale.
      * @since v2000.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     camScale(scale: Vec2): Vec2;
     /** @deprecated */
@@ -4157,7 +4168,8 @@ export interface KAPLAYCtx<
      *
      * @returns The current camera rotation.
      * @since v2000.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     camRot(angle?: number): number;
     /**
@@ -4178,7 +4190,8 @@ export interface KAPLAYCtx<
      *
      * @returns A timer controller.
      * @since v3001.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     camFlash(flashColor: Color, fadeOutTime: number): TimerController;
     /**
@@ -4186,7 +4199,8 @@ export interface KAPLAYCtx<
      *
      * Get camera transform.
      *
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     camTransform(): Mat23;
     // #endregion DEPRECATED CAMERA METHODS ------------------------------------
@@ -4196,7 +4210,8 @@ export interface KAPLAYCtx<
      * @param p - The point to transform.
      *
      * @since v3001.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     toScreen(p: Vec2): Vec2;
     /**
@@ -4205,7 +4220,8 @@ export interface KAPLAYCtx<
      * @param p - The point to transform.
      *
      * @since v3001.0
-     * @group Camera
+     * @group Rendering
+     * @subgroup Camera
      */
     toWorld(p: Vec2): Vec2;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -3433,7 +3433,7 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0.0
      * @group Assets
-     * @subgroup Prefabs
+     * @subgroup Util
      * @experimental
      */
     loadPrefab: (name: string, url: string) => Asset<SerializedGameObj>;

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -3032,7 +3032,7 @@ export interface KAPLAYCtx<
      * Gets the name of the current scene. Returns null if no scene is active.
      *
      * @since v3001.0
-     * @group Scene
+     * @group Scenes
      */
     getSceneName(): string | null;
     // #region Loaders
@@ -5371,7 +5371,7 @@ export interface KAPLAYCtx<
      * });
      * ```
      *
-     * @group Scene
+     * @group Scenes
      */
     scene(name: SceneName, def: SceneDef): void;
     /**
@@ -5390,7 +5390,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v2000.0
-     * @group Scene
+     * @group Scenes
      */
     go(name: SceneName, ...args: any): void;
 
@@ -5417,7 +5417,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Scene
+     * @group Scenes
      */
     pushScene(id: SceneName, ...args: unknown[]): void;
 
@@ -5442,7 +5442,7 @@ export interface KAPLAYCtx<
      * ```
      *
      * @since v3001.1
-     * @group Scene
+     * @group Scenes
      */
     popScene(id: SceneName, ...args: unknown[]): void;
     /**

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -5207,7 +5207,7 @@ export interface KAPLAYCtx<
      *
      * @since v4000.0
      * @group Math
-     * @subgroup Vector
+     * @subgroup Vectors
      */
     anchorToVec2: typeof anchorPt;
     /**

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -37,6 +37,15 @@ export type Engine = ReturnType<typeof createEngine>;
 // Create global variables
 window.kaplayjs_assetsAliases = {};
 
+/**
+ * Creates all necessary contexts and variables for running a KAPLAY instance.
+ *
+ * @ignore
+ *
+ * @param gopt - Global options for create the engine.
+ *
+ * @returns Engine.
+ */
 export const createEngine = (gopt: KAPLAYOpt) => {
     // Default options
     const opt = Object.assign({

--- a/src/core/engineLoop.ts
+++ b/src/core/engineLoop.ts
@@ -1,6 +1,10 @@
 import type { App } from "../app/app";
 import { initAppEvents } from "../app/appEvents";
-import { type AssetsCtx, getFailedAssets, loadProgress } from "../assets/asset";
+import {
+    getFailedAssets,
+    type InternalAssetsCtx,
+    loadProgress,
+} from "../assets/asset";
 import type { Debug } from "../debug/debug";
 import { SystemPhase } from "../ecs/systems/systems";
 import type { Game } from "../game/game";
@@ -15,7 +19,7 @@ import type { FrameRenderer } from "./frameRendering";
 export function startEngineLoop(
     app: App,
     game: Game,
-    assets: AssetsCtx,
+    assets: InternalAssetsCtx,
     gopt: KAPLAYOpt,
     frameRenderer: FrameRenderer,
     debug: Debug,

--- a/src/core/frameRendering.ts
+++ b/src/core/frameRendering.ts
@@ -8,8 +8,21 @@ import { flush, height, width } from "../gfx/stack";
 import { Quad } from "../math/math";
 import { Vec2 } from "../math/Vec2";
 
-export type FrameRenderer = ReturnType<typeof createFrameRenderer>;
+/**
+ * A frame renderer.
+ *
+ * @ignore
+ */
+export interface FrameRenderer {
+    frameStart: () => void;
+    frameEnd: () => void;
+    fixedUpdateFrame: () => void;
+    updateFrame: () => void;
+}
 
+/**
+ * @ignore
+ */
 export const createFrameRenderer = (
     gfx: AppGfxCtx,
     game: Game,

--- a/src/debug/debug.ts
+++ b/src/debug/debug.ts
@@ -1,5 +1,5 @@
 import type { App } from "../app/app";
-import type { AudioCtx } from "../audio/audio";
+import type { InternalAudioCtx } from "../audio/audio";
 import { LOG_MAX } from "../constants/general";
 import type { FrameRenderer } from "../core/frameRendering";
 import type { Game } from "../game/game";
@@ -78,7 +78,7 @@ export const createDebug = (
     gopt: KAPLAYOpt,
     app: App,
     appGfx: AppGfxCtx,
-    audio: AudioCtx,
+    audio: InternalAudioCtx,
     game: Game,
     fr: FrameRenderer,
 ): Debug => {

--- a/src/ecs/components/draw/blend.ts
+++ b/src/ecs/components/draw/blend.ts
@@ -12,7 +12,8 @@ export interface SerializedBlendComp {
 /**
  * The {@link blend `blend()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface BlendComp extends Comp {
     blend: BlendMode;

--- a/src/ecs/components/draw/blend.ts
+++ b/src/ecs/components/draw/blend.ts
@@ -3,7 +3,8 @@ import { BlendMode, type Comp } from "../../../types";
 /**
  * The serialized {@link blend `blend()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedBlendComp {
     blend: BlendMode;

--- a/src/ecs/components/draw/circle.ts
+++ b/src/ecs/components/draw/circle.ts
@@ -9,7 +9,8 @@ import type { outline } from "./outline";
 /**
  * The serialized {@link circle `circle()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedCircleComp {
     radius: number;

--- a/src/ecs/components/draw/circle.ts
+++ b/src/ecs/components/draw/circle.ts
@@ -19,7 +19,8 @@ export interface SerializedCircleComp {
 /**
  * The {@link circle `circle()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface CircleComp extends Comp {
     draw: Comp["draw"];
@@ -37,7 +38,8 @@ export interface CircleComp extends Comp {
 /**
  * Options for the {@link circle `circle()``} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface CircleCompOpt {
     /**

--- a/src/ecs/components/draw/color.ts
+++ b/src/ecs/components/draw/color.ts
@@ -13,7 +13,8 @@ export interface SerializedColorComp {
 /**
  * The {@link color `color()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface ColorComp extends Comp {
     color: Color;

--- a/src/ecs/components/draw/color.ts
+++ b/src/ecs/components/draw/color.ts
@@ -4,7 +4,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link color `color()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedColorComp {
     color: { r: number; g: number; b: number };

--- a/src/ecs/components/draw/drawon.ts
+++ b/src/ecs/components/draw/drawon.ts
@@ -2,16 +2,28 @@ import type { Picture } from "../../../gfx/draw/drawPicture";
 import type { FrameBuffer } from "../../../gfx/FrameBuffer";
 import type { Comp, GameObj } from "../../../types";
 
-export type DrawonOpt = {
+/**
+ * Options for the {@link drawon `drawon()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
+ */
+export type DrawonCompOpt = {
     childrenOnly?: boolean;
     refreshOnly?: boolean;
 };
 
+/**
+ * The {@link drawon `drawon()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
+ */
 export interface DrawonComp extends Comp {
     refresh(): void;
 }
 
-export function drawon(c: FrameBuffer | Picture, opt?: DrawonOpt) {
+export function drawon(c: FrameBuffer | Picture, opt?: DrawonCompOpt) {
     return {
         add(this: GameObj) {
             this.target = {

--- a/src/ecs/components/draw/ellipse.ts
+++ b/src/ecs/components/draw/ellipse.ts
@@ -9,7 +9,8 @@ import type { outline } from "./outline";
 /**
  * The serialized {@link ellipse `ellipse()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedEllipseComp {
     radiusX: number;

--- a/src/ecs/components/draw/ellipse.ts
+++ b/src/ecs/components/draw/ellipse.ts
@@ -20,7 +20,8 @@ export interface SerializedEllipseComp {
 /**
  * The {@link ellipse `ellipse()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface EllipseComp extends Comp {
     draw: Comp["draw"];
@@ -38,7 +39,8 @@ export interface EllipseComp extends Comp {
 /**
  * Options for the {@link ellipse `ellipse()``} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface EllipseCompOpt {
     /**

--- a/src/ecs/components/draw/mask.ts
+++ b/src/ecs/components/draw/mask.ts
@@ -12,7 +12,8 @@ export interface SerializedMaskComp {
 /**
  * The {@link mask `mask()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface MaskComp extends Comp {
     mask: Mask;

--- a/src/ecs/components/draw/mask.ts
+++ b/src/ecs/components/draw/mask.ts
@@ -3,7 +3,8 @@ import type { Comp, Mask } from "../../../types";
 /**
  * The serialized {@link mask `mask()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedMaskComp {
     mask: Mask;

--- a/src/ecs/components/draw/opacity.ts
+++ b/src/ecs/components/draw/opacity.ts
@@ -7,7 +7,8 @@ import type { TweenController } from "../misc/timer";
 /**
  * The serialized {@link opacity `opacity()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedOpacityComp {
     opacity: number;

--- a/src/ecs/components/draw/opacity.ts
+++ b/src/ecs/components/draw/opacity.ts
@@ -16,7 +16,8 @@ export interface SerializedOpacityComp {
 /**
  * The {@link opacity `opacity()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface OpacityComp extends Comp {
     /** Opacity of the current object. */

--- a/src/ecs/components/draw/outline.ts
+++ b/src/ecs/components/draw/outline.ts
@@ -21,7 +21,8 @@ export interface SerializedOutlineComp {
 /**
  * The {@link outline `outline()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface OutlineComp extends Comp {
     outline: Outline;

--- a/src/ecs/components/draw/outline.ts
+++ b/src/ecs/components/draw/outline.ts
@@ -5,7 +5,8 @@ import type { Comp, Outline } from "../../../types";
 /**
  * The serialized {@link outline `outline()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedOutlineComp {
     outline: {

--- a/src/ecs/components/draw/particles.ts
+++ b/src/ecs/components/draw/particles.ts
@@ -38,7 +38,10 @@ class Particle {
 }
 
 /**
- * Options for the {@link particles `particles()`}'s component
+ * Options for the {@link particles `particles()`}'s component.
+ *
+ * @group Components
+ * @subgroup Component Types
  */
 export type EmitterOpt = {
     /**

--- a/src/ecs/components/draw/particles.ts
+++ b/src/ecs/components/draw/particles.ts
@@ -70,7 +70,8 @@ export type EmitterOpt = {
 /**
  * Options for the {@link particles `particles()`}'s component
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type ParticlesOpt = {
     /**
@@ -126,7 +127,8 @@ export type ParticlesOpt = {
 /**
  * The {@link particles `particles()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface ParticlesComp extends Comp {
     emitter: {

--- a/src/ecs/components/draw/picture.ts
+++ b/src/ecs/components/draw/picture.ts
@@ -2,10 +2,22 @@ import { getRenderProps } from "../../../game/utils";
 import { drawPicture, type Picture } from "../../../gfx/draw/drawPicture";
 import type { Comp, GameObj } from "../../../types";
 
+/**
+ * The {@link picture `picture()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
+ */
 export interface PictureComp extends Comp {
     picture: Picture;
 }
 
+/**
+ * Options for the {@link picture `picture()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
+ */
 export type PictureCompOpt = {
     picture: Picture;
 };

--- a/src/ecs/components/draw/polygon.ts
+++ b/src/ecs/components/draw/polygon.ts
@@ -10,7 +10,8 @@ import type { Comp, DrawPolygonOpt, GameObj } from "../../../types";
  * The {@link polygon `polygon()`} component.
  *
  * @since v3001.0
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface PolygonComp extends Comp {
     draw: Comp["draw"];
@@ -48,7 +49,8 @@ export interface PolygonComp extends Comp {
 /**
  * Options for the {@link polygon `polygon()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type PolygonCompOpt = Omit<DrawPolygonOpt, "pts">;
 

--- a/src/ecs/components/draw/polygon.ts
+++ b/src/ecs/components/draw/polygon.ts
@@ -1,10 +1,13 @@
 import { getRenderProps } from "../../../game/utils";
-import { drawPolygon } from "../../../gfx/draw/drawPolygon";
+import {
+    drawPolygon,
+    type DrawPolygonOpt,
+} from "../../../gfx/draw/drawPolygon";
 import type { Texture } from "../../../gfx/gfx";
 import type { Color } from "../../../math/color";
 import { Polygon } from "../../../math/math";
 import { type Vec2 } from "../../../math/Vec2";
-import type { Comp, DrawPolygonOpt, GameObj } from "../../../types";
+import type { Comp, GameObj } from "../../../types";
 
 /**
  * The {@link polygon `polygon()`} component.

--- a/src/ecs/components/draw/rect.ts
+++ b/src/ecs/components/draw/rect.ts
@@ -5,7 +5,8 @@ import type { Comp, GameObj } from "../../../types";
 /**
  * The serialized {@link rect `rect()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedRectComp {
     width: number;

--- a/src/ecs/components/draw/rect.ts
+++ b/src/ecs/components/draw/rect.ts
@@ -17,7 +17,8 @@ export interface SerializedRectComp {
 /**
  * The {@link rect `rect()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface RectComp extends Comp {
     draw: Comp["draw"];
@@ -44,7 +45,8 @@ export interface RectComp extends Comp {
 /**
  * Options for the {@link rect `rect()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface RectCompOpt {
     /**

--- a/src/ecs/components/draw/shader.ts
+++ b/src/ecs/components/draw/shader.ts
@@ -13,7 +13,8 @@ export interface SerializeShaderComp {
 /**
  * The {@link shader `shader()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface ShaderComp extends Comp {
     /**

--- a/src/ecs/components/draw/shader.ts
+++ b/src/ecs/components/draw/shader.ts
@@ -4,7 +4,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link shader `shader()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializeShaderComp {
     shader: string;

--- a/src/ecs/components/draw/sprite.ts
+++ b/src/ecs/components/draw/sprite.ts
@@ -21,7 +21,8 @@ import type { Comp, GameObj, SpriteAnimPlayOpt } from "../../../types";
 /**
  * The serialized {@link sprite `sprite()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export type SerializedSpriteComp = SpriteCompOpt & {
     sprite: string;

--- a/src/ecs/components/draw/sprite.ts
+++ b/src/ecs/components/draw/sprite.ts
@@ -49,7 +49,8 @@ export interface SpriteCurAnim {
 /**
  * The {@link sprite `sprite()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface SpriteComp extends Comp {
     draw: Comp["draw"];
@@ -140,7 +141,8 @@ export interface SpriteComp extends Comp {
 /**
  * Options for the {@link sprite `sprite()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface SpriteCompOpt {
     /**

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -18,7 +18,8 @@ import type { Comp, GameObj } from "../../../types";
 /**
  * The serialized {@link text `text()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedTextComp {
     text: string;

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -34,7 +34,8 @@ export interface SerializedTextComp {
 /**
  * The {@link text `text()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface TextComp extends Comp {
     draw: Comp["draw"];
@@ -104,7 +105,8 @@ export interface TextComp extends Comp {
 /**
  * Options for the {@link text `text()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface TextCompOpt {
     /**

--- a/src/ecs/components/draw/uvquad.ts
+++ b/src/ecs/components/draw/uvquad.ts
@@ -6,7 +6,8 @@ import type { Comp, GameObj } from "../../../types";
 /**
  * The {@link uvquad `uvquad()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface UVQuadComp extends Comp {
     draw: Comp["draw"];

--- a/src/ecs/components/level/agent.ts
+++ b/src/ecs/components/level/agent.ts
@@ -7,7 +7,8 @@ import type { TileComp } from "./tile";
 /**
  * The {@link agent `agent()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface AgentComp extends Comp {
     agentSpeed: number;
@@ -29,7 +30,8 @@ export interface AgentComp extends Comp {
 /**
  * Options for the {@link agent `agent()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type AgentCompOpt = {
     speed?: number;

--- a/src/ecs/components/level/level.ts
+++ b/src/ecs/components/level/level.ts
@@ -93,9 +93,10 @@ export interface LevelComp extends Comp {
 /**
  * Options for the {@link level `level()`} component.
  *
- * @group Options
+ * @group Components
+ * @subgroup Types
  */
-export interface LevelOpt {
+export interface LevelCompOpt {
     /**
      * Width of each block.
      */
@@ -127,7 +128,7 @@ export type PathFindOpt = {
     allowDiagonals?: boolean;
 };
 
-export function level(map: string[], opt: LevelOpt): LevelComp {
+export function level(map: string[], opt: LevelCompOpt): LevelComp {
     const numRows = map.length;
     let numColumns = 0;
 

--- a/src/ecs/components/level/level.ts
+++ b/src/ecs/components/level/level.ts
@@ -21,7 +21,8 @@ import { tile } from "./tile";
 /**
  * The {@link level `level()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface LevelComp extends Comp {
     tileWidth(): number;
@@ -119,7 +120,8 @@ export interface LevelOpt {
 }
 
 /**
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type PathFindOpt = {
     allowDiagonals?: boolean;

--- a/src/ecs/components/level/level.ts
+++ b/src/ecs/components/level/level.ts
@@ -94,7 +94,7 @@ export interface LevelComp extends Comp {
  * Options for the {@link level `level()`} component.
  *
  * @group Components
- * @subgroup Types
+ * @subgroup Component Types
  */
 export interface LevelCompOpt {
     /**

--- a/src/ecs/components/level/sentry.ts
+++ b/src/ecs/components/level/sentry.ts
@@ -8,7 +8,8 @@ import type { PosComp } from "../transform/pos";
 /**
  * The {@link sentry `sentry()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface SentryComp extends Comp {
     /**
@@ -53,7 +54,8 @@ export interface SentryComp extends Comp {
 /**
  * Options for the {@link sentry `sentry()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface SentryCompOpt {
     /**

--- a/src/ecs/components/level/tile.ts
+++ b/src/ecs/components/level/tile.ts
@@ -6,7 +6,8 @@ import type { LevelComp } from "./level";
 /**
  * The {@link tile `tile()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface TileComp extends Comp {
     /**
@@ -41,7 +42,8 @@ export interface TileComp extends Comp {
 /**
  * Options for the {@link tile `tile()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type TileCompOpt = {
     /**

--- a/src/ecs/components/misc/animate.ts
+++ b/src/ecs/components/misc/animate.ts
@@ -76,6 +76,9 @@ export interface BaseValues {
     opacity: number;
 }
 
+/**
+ * The {@link animate `animate()`} component.
+ */
 export interface AnimateComp extends Comp {
     /**
      * Animates a property on this object.

--- a/src/ecs/components/misc/fakeMouse.ts
+++ b/src/ecs/components/misc/fakeMouse.ts
@@ -4,6 +4,9 @@ import type { PosComp } from "../transform/pos";
 
 /**
  * The {@link fakeMouse `fakeMouse()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
  */
 export interface FakeMouseComp extends Comp {
     /**
@@ -30,6 +33,9 @@ export interface FakeMouseComp extends Comp {
 
 /**
  * Options for the {@link fakeMouse `fakeMouse()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
  */
 export type FakeMouseOpt = {
     /**

--- a/src/ecs/components/misc/health.ts
+++ b/src/ecs/components/misc/health.ts
@@ -15,7 +15,8 @@ export interface SerializeHealthComp {
 /**
  * The {@link health `health()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface HealthComp extends Comp {
     /**

--- a/src/ecs/components/misc/health.ts
+++ b/src/ecs/components/misc/health.ts
@@ -5,7 +5,8 @@ import type { Comp, GameObj } from "../../../types";
 /**
  * The serialized {@link health `health()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializeHealthComp {
     hp: number;

--- a/src/ecs/components/misc/lifespan.ts
+++ b/src/ecs/components/misc/lifespan.ts
@@ -6,7 +6,8 @@ import type { OpacityComp } from "../draw/opacity";
 /**
  * The {@link lifespan `lifespan()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface LifespanCompOpt {
     /**

--- a/src/ecs/components/misc/named.ts
+++ b/src/ecs/components/misc/named.ts
@@ -3,7 +3,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link color `color()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializeNameComp {
     name: string;

--- a/src/ecs/components/misc/named.ts
+++ b/src/ecs/components/misc/named.ts
@@ -12,7 +12,8 @@ export interface SerializeNameComp {
 /**
  * The {@link named `named()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface NamedComp extends Comp {
     /** The name assigned to this object. */

--- a/src/ecs/components/misc/state.ts
+++ b/src/ecs/components/misc/state.ts
@@ -4,7 +4,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link state `state()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializeStateComp {
     initState: string;

--- a/src/ecs/components/misc/state.ts
+++ b/src/ecs/components/misc/state.ts
@@ -15,7 +15,8 @@ export interface SerializeStateComp {
 /**
  * The {@link state `state()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface StateComp<T extends string> extends Comp {
     /**

--- a/src/ecs/components/misc/stay.ts
+++ b/src/ecs/components/misc/stay.ts
@@ -3,7 +3,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link stay `stay()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializeStayComp {
     scenesToStay: string[];

--- a/src/ecs/components/misc/stay.ts
+++ b/src/ecs/components/misc/stay.ts
@@ -12,7 +12,8 @@ export interface SerializeStayComp {
 /**
  * The {@link stay `stay()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface StayComp extends Comp {
     /**

--- a/src/ecs/components/misc/textInput.ts
+++ b/src/ecs/components/misc/textInput.ts
@@ -6,7 +6,8 @@ import type { TextComp } from "../draw/text";
 /**
  * The {@link textInput `textInput()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface TextInputComp extends Comp {
     /**

--- a/src/ecs/components/misc/timer.ts
+++ b/src/ecs/components/misc/timer.ts
@@ -46,7 +46,8 @@ export interface TweenController extends TimerController {
 /**
  * The {@link timer `timer()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface TimerComp extends Comp {
     /**

--- a/src/ecs/components/physics/area.ts
+++ b/src/ecs/components/physics/area.ts
@@ -31,7 +31,8 @@ export function usesArea() {
 /**
  * The {@link area `area()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface AreaComp extends Comp {
     /**
@@ -194,7 +195,8 @@ export interface AreaComp extends Comp {
 /**
  * Options for the {@link area `area()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface AreaCompOpt {
     /**

--- a/src/ecs/components/physics/body.ts
+++ b/src/ecs/components/physics/body.ts
@@ -14,7 +14,8 @@ import type { AreaComp } from "./area";
 /**
  * The {@link body `body()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface BodyComp extends Comp {
     /**
@@ -143,7 +144,8 @@ export interface BodyComp extends Comp {
 /**
  * Options for the {@link body `body()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface BodyCompOpt {
     /**

--- a/src/ecs/components/physics/doubleJump.ts
+++ b/src/ecs/components/physics/doubleJump.ts
@@ -5,7 +5,8 @@ import type { BodyComp } from "./body";
 /**
  * The {@link doubleJump `doubleJump()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface DoubleJumpComp extends Comp {
     /**

--- a/src/ecs/components/transform/anchor.ts
+++ b/src/ecs/components/transform/anchor.ts
@@ -15,7 +15,8 @@ export interface SerializedAnchorComp {
 /**
  * The {@link anchor `anchor()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface AnchorComp extends Comp {
     /**

--- a/src/ecs/components/transform/anchor.ts
+++ b/src/ecs/components/transform/anchor.ts
@@ -6,7 +6,8 @@ import type { Anchor, Comp } from "../../../types";
 /**
  * The serialized {@link anchor `anchor()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedAnchorComp {
     anchor: SerializedVec2;

--- a/src/ecs/components/transform/fixed.ts
+++ b/src/ecs/components/transform/fixed.ts
@@ -3,7 +3,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link fixed `fixed()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedFixedComp {
     fixed?: boolean;

--- a/src/ecs/components/transform/fixed.ts
+++ b/src/ecs/components/transform/fixed.ts
@@ -12,7 +12,8 @@ export interface SerializedFixedComp {
 /**
  * The {@link fixed `fixed()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface FixedComp extends Comp {
     /**

--- a/src/ecs/components/transform/follow.ts
+++ b/src/ecs/components/transform/follow.ts
@@ -6,7 +6,8 @@ import type { PosComp } from "./pos";
 /**
  * The {@link follow `follow()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface FollowComp extends Comp {
     follow: {

--- a/src/ecs/components/transform/layer.ts
+++ b/src/ecs/components/transform/layer.ts
@@ -4,7 +4,8 @@ import type { Comp } from "../../../types";
 /**
  * The {@link layer `layer()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface LayerComp extends Comp {
     /**

--- a/src/ecs/components/transform/move.ts
+++ b/src/ecs/components/transform/move.ts
@@ -15,7 +15,8 @@ interface SerializedMoveComp {
 /**
  * The {@link move `move()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface MoveComp extends Comp {
     serialize: () => SerializedMoveComp;

--- a/src/ecs/components/transform/move.ts
+++ b/src/ecs/components/transform/move.ts
@@ -5,7 +5,8 @@ import type { PosComp } from "./pos";
 /**
  * The serialized {@link move `move()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 interface SerializedMoveComp {
     dir: SerializedVec2 | number;

--- a/src/ecs/components/transform/offscreen.ts
+++ b/src/ecs/components/transform/offscreen.ts
@@ -10,7 +10,8 @@ import type { PosComp } from "./pos";
 /**
  * The {@link offscreen `offscreen()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface OffScreenComp extends Comp {
     /**
@@ -37,7 +38,8 @@ export interface OffScreenComp extends Comp {
 /**
  * Options for {@link offscreen `offscreen()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface OffScreenCompOpt {
     /**

--- a/src/ecs/components/transform/pos.ts
+++ b/src/ecs/components/transform/pos.ts
@@ -20,7 +20,8 @@ export interface SerializedPosComp {
 /**
  * The {@link pos `pos()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface PosComp extends Comp {
     /**

--- a/src/ecs/components/transform/pos.ts
+++ b/src/ecs/components/transform/pos.ts
@@ -11,7 +11,8 @@ import type { FixedComp } from "./fixed";
 /**
  * The serialized {@link pos `pos()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedPosComp {
     pos: { x: number; y: number };

--- a/src/ecs/components/transform/rotate.ts
+++ b/src/ecs/components/transform/rotate.ts
@@ -3,7 +3,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link rotate `rotate()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedRotateComp {
     angle: number;

--- a/src/ecs/components/transform/rotate.ts
+++ b/src/ecs/components/transform/rotate.ts
@@ -12,7 +12,8 @@ export interface SerializedRotateComp {
 /**
  * The {@link rotate `rotate()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface RotateComp extends Comp {
     /**

--- a/src/ecs/components/transform/scale.ts
+++ b/src/ecs/components/transform/scale.ts
@@ -14,7 +14,8 @@ export interface SerializedScaleComp {
 /**
  * The {@link scale `scale()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface ScaleComp extends Comp {
     /**

--- a/src/ecs/components/transform/scale.ts
+++ b/src/ecs/components/transform/scale.ts
@@ -5,7 +5,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link scale `scale()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedScaleComp {
     scale: SerializedVec2;

--- a/src/ecs/components/transform/z.ts
+++ b/src/ecs/components/transform/z.ts
@@ -12,7 +12,8 @@ export interface SerializedZComp {
 /**
  * The {@link z `z()`} component.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export interface ZComp extends Comp {
     /**

--- a/src/ecs/components/transform/z.ts
+++ b/src/ecs/components/transform/z.ts
@@ -3,7 +3,8 @@ import type { Comp } from "../../../types";
 /**
  * The serialized {@link z `z()`} component.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedZComp {
     z: number;

--- a/src/ecs/entity/GameObjRaw.ts
+++ b/src/ecs/entity/GameObjRaw.ts
@@ -72,6 +72,7 @@ export type SetParentOpt = {
  *
  * @since v2000.0
  * @group Game Obj
+ * @subgroup Types
  */
 export interface GameObjRaw {
     /**

--- a/src/ecs/entity/prefab.ts
+++ b/src/ecs/entity/prefab.ts
@@ -8,7 +8,8 @@ import type { GameObjRaw, InternalGameObjRaw } from "./GameObjRaw";
  * A serialized game object. Created using {@link GameObjRaw.serialize `GameObjRaw.serialize()` } method.
  *
  * @since v4000.0
- * @group Serialization
+ * @group Game Obj
+ * @subgroup Prefabs
  */
 export interface SerializedGameObj {
     components: Record<string, any>;

--- a/src/ecs/entity/premade/addKaboom.ts
+++ b/src/ecs/entity/premade/addKaboom.ts
@@ -10,7 +10,8 @@ import { pos } from "../../components/transform/pos";
 import { scale } from "../../components/transform/scale";
 
 /**
- * @group Options
+ * @group Game Obj
+ * @subgroup Types
  */
 export interface BoomOpt {
     /**

--- a/src/ecs/entity/premade/addLevel.ts
+++ b/src/ecs/entity/premade/addLevel.ts
@@ -5,16 +5,17 @@ import type { GameObj } from "../../../types";
 import {
     level,
     type LevelComp,
-    type LevelOpt,
+    type LevelCompOpt,
 } from "../../components/level/level";
 import { pos, type PosComp } from "../../components/transform/pos";
 
 /**
  * Options for the {@link addLevel `addLevel()`}.
  *
- * @group Options
+ * @group Game Obj
+ * @subgroup Types
  */
-export interface AddLevelOpt extends LevelOpt {
+export interface AddLevelOpt extends LevelCompOpt {
     /**
      * Position of the first block.
      */

--- a/src/ecs/systems/Collision.ts
+++ b/src/ecs/systems/Collision.ts
@@ -6,7 +6,7 @@ import type { GameObj } from "../../types";
 /**
  * Collision resolution data.
  *
- * @group Math
+ * @group Physics
  */
 
 export class Collision {

--- a/src/ecs/systems/systems.ts
+++ b/src/ecs/systems/systems.ts
@@ -1,12 +1,19 @@
 import { _k } from "../../shared";
 
+/**
+ * @group Plugins
+ * @subgroup Systems
+ */
 export type System = {
     name: string;
     run: () => void;
     when: SystemPhase[];
 };
 
-// Lifecycle events
+/**
+ * @group Plugins
+ * @subgroup Systems
+ */
 export enum SystemPhase {
     BeforeUpdate,
     BeforeFixedUpdate,

--- a/src/ecs/systems/systems.ts
+++ b/src/ecs/systems/systems.ts
@@ -2,7 +2,6 @@ import { _k } from "../../shared";
 
 /**
  * @group Plugins
- * @subgroup Systems
  */
 export type System = {
     name: string;
@@ -10,10 +9,6 @@ export type System = {
     when: SystemPhase[];
 };
 
-/**
- * @group Plugins
- * @subgroup Systems
- */
 export enum SystemPhase {
     BeforeUpdate,
     BeforeFixedUpdate,

--- a/src/events/eventMap.ts
+++ b/src/events/eventMap.ts
@@ -26,6 +26,7 @@ import type {
  * If looking for use it with `obj.on()`, ignore first parameter (Game Obj)
  *
  * @group Events
+ * @subgroup Game Obj
  */
 export type GameObjEventMap = {
     /** Triggered every frame */
@@ -206,14 +207,24 @@ export type GameObjEventMap = {
     navigationMapChanged: [GameObj];
 };
 
+/**
+ * @group Events
+ * @subgroup Game Obj
+ */
 export type GameObjEvents = GameObjEventMap & {
     [key: string]: any[];
 };
 
+/**
+ * @group Events
+ * @subgroup Game Obj
+ */
 export type GameObjEventNames = keyof GameObjEventMap;
 
 /**
  * App events with their arguments
+ *
+ * @group Events
  */
 export type AppEventMap = {
     mouseMove: [];
@@ -246,6 +257,8 @@ export type AppEventMap = {
 
 /**
  * All Game State events with their arguments
+ *
+ * @group Events
  */
 export type GameEventMap = {
     load: [];

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,5 +1,8 @@
 import { EVENT_CANCEL_SYMBOL } from "../constants/general";
 
+/**
+ * @group Events
+ */
 export class Registry<T> extends Map<number, T> {
     private lastID: number = 0;
     push(v: T): number {

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -114,8 +114,15 @@ export type Game = {
     warned: Set<string>;
 };
 
+/**
+ * @group Debug
+ */
 type Log = { msg: string | { toString(): string }; time: number };
 
+/**
+ * @group Rendering
+ * @subgroup Camera
+ */
 type CamData = {
     pos: Vec2 | null;
     scale: Vec2;

--- a/src/game/scenes.ts
+++ b/src/game/scenes.ts
@@ -5,9 +5,26 @@ import { _k } from "../shared";
 
 /**
  * The name of a scene.
+ *
+ * @group Scenes
+ * @subgroup Types
  */
 export type SceneName = string;
+
+/**
+ * The function definition for a scene
+ *
+ * @group Scenes
+ * @subgroup Types
+ */
 export type SceneDef = (...args: any) => void;
+
+/**
+ * The state of a scene.
+ *
+ * @group Scenes
+ * @subgroup Types
+ */
 export type SceneState = {
     sceneID: string | null;
     args: unknown[];

--- a/src/gfx/FrameBuffer.ts
+++ b/src/gfx/FrameBuffer.ts
@@ -2,9 +2,9 @@ import type { TextureOpt } from "../types";
 import { type GfxCtx, Texture } from "./gfx";
 
 /**
- * @group GFX
+ * @group Rendering
+ * @subgroup Canvas
  */
-
 export class FrameBuffer {
     ctx: GfxCtx;
     tex: Texture;

--- a/src/gfx/draw/drawBezier.ts
+++ b/src/gfx/draw/drawBezier.ts
@@ -2,6 +2,10 @@ import { evaluateBezier } from "../../math/math";
 import { type Vec2 } from "../../math/Vec2";
 import { drawCurve, type DrawCurveOpt } from "./drawCurve";
 
+/**
+ * @group Draw
+ * @subgroup Types
+ */
 export type DrawBezierOpt = DrawCurveOpt & {
     /**
      * The first point.

--- a/src/gfx/draw/drawCanvas.ts
+++ b/src/gfx/draw/drawCanvas.ts
@@ -1,8 +1,12 @@
 import { vec2 } from "../../math/math";
-import type { Canvas, DrawUVQuadOpt, RenderProps } from "../../types";
+import type { Canvas } from "../../types";
 import { height } from "../stack";
-import { drawUVQuad } from "./drawUVQuad";
+import { drawUVQuad, type DrawUVQuadOpt } from "./drawUVQuad";
 
+/**
+ * @group Draw
+ * @subgroup Types
+ */
 export type DrawCanvasOpt = DrawUVQuadOpt & {
     canvas: Canvas;
 };

--- a/src/gfx/draw/drawCircle.ts
+++ b/src/gfx/draw/drawCircle.ts
@@ -5,6 +5,8 @@ import { drawEllipse } from "./drawEllipse";
 
 /**
  * How the circle should look like.
+ * @group Draw
+ * @subgroup Types
  */
 export type DrawCircleOpt = Omit<RenderProps, "angle"> & {
     /**

--- a/src/gfx/draw/drawCurve.ts
+++ b/src/gfx/draw/drawCurve.ts
@@ -2,6 +2,10 @@ import type { Vec2 } from "../../math/Vec2";
 import type { RenderProps } from "../../types";
 import { drawLines } from "./drawLine";
 
+/**
+ * @group Draw
+ * @subgroup Types
+ */
 export type DrawCurveOpt = RenderProps & {
     /**
      * The amount of line segments to draw.

--- a/src/gfx/draw/drawEllipse.ts
+++ b/src/gfx/draw/drawEllipse.ts
@@ -1,8 +1,52 @@
+import type { Color } from "../../math/color";
 import { getArcPts } from "../../math/various";
 import { Vec2 } from "../../math/Vec2";
-import type { DrawEllipseOpt } from "../../types";
+import type { Anchor, RenderProps } from "../../types";
 import { anchorPt } from "../anchor";
 import { drawPolygon } from "./drawPolygon";
+
+/**
+ * How the ellipse should look like.
+ *
+ * @group Draw
+ * @subgroup Types
+ */
+export type DrawEllipseOpt = RenderProps & {
+    /**
+     * The horizontal radius.
+     */
+    radiusX: number;
+    /**
+     * The vertical radius.
+     */
+    radiusY: number;
+    /**
+     * Starting angle.
+     */
+    start?: number;
+    /**
+     * Ending angle.
+     */
+    end?: number;
+    /**
+     * If fill the shape with color (set this to false if you only want an outline).
+     */
+    fill?: boolean;
+    /**
+     * Use gradient instead of solid color.
+     *
+     * @since v3000.0
+     */
+    gradient?: [Color, Color];
+    /**
+     * Multiplier for circle vertices resolution (default 1)
+     */
+    resolution?: number;
+    /**
+     * The anchor point, or the pivot point. Default to "topleft".
+     */
+    anchor?: Anchor | Vec2;
+};
 
 export function drawEllipse(opt: DrawEllipseOpt) {
     if (opt.radiusX === undefined || opt.radiusY === undefined) {

--- a/src/gfx/draw/drawFormattedText.ts
+++ b/src/gfx/draw/drawFormattedText.ts
@@ -16,6 +16,9 @@ import { drawUVQuad } from "./drawUVQuad";
 
 /**
  * Formatted text with info on how and where to render each character.
+ *
+ * @group Rendering
+ * @subgroup Text
  */
 export type FormattedText = {
     width: number;
@@ -26,7 +29,10 @@ export type FormattedText = {
 };
 
 /**
- * One formated character.
+ * One formatted character.
+ *
+ * @group Rendering
+ * @subgroup Text
  */
 export interface FormattedChar {
     ch: string;

--- a/src/gfx/draw/drawLine.ts
+++ b/src/gfx/draw/drawLine.ts
@@ -1,16 +1,16 @@
-import { opacity } from "../../ecs/components/draw/opacity";
 import { Color } from "../../math/color";
 import { lerp } from "../../math/lerp";
 import { deg2rad, vec2 } from "../../math/math";
 import { Vec2 } from "../../math/Vec2";
 import { _k } from "../../shared";
 import type { RenderProps } from "../../types";
-import { center } from "../stack";
-import { drawCircle } from "./drawCircle";
 import { drawRaw } from "./drawRaw";
 
 /**
  * How the line should look like.
+ *
+ * @group Draw
+ * @subgroup Types
  */
 export type DrawLineOpt = Omit<RenderProps, "angle" | "scale"> & {
     /**

--- a/src/gfx/draw/drawPicture.ts
+++ b/src/gfx/draw/drawPicture.ts
@@ -6,6 +6,10 @@ import type { BlendMode, RenderProps } from "../../types";
 import { Mesh, type Texture } from "../gfx";
 import { height, width } from "../stack";
 
+/**
+ * @group Draw
+ * @subgroup Picture
+ */
 export type Material = {
     tex?: Texture;
     shader?: Shader;
@@ -13,6 +17,10 @@ export type Material = {
     blend?: BlendMode;
 };
 
+/**
+ * @group Draw
+ * @subgroup Picture
+ */
 export type PictureCommand = {
     material: Material;
     index: number;
@@ -21,6 +29,9 @@ export type PictureCommand = {
 
 /**
  * A picture holding drawing data
+ *
+ * @group Draw
+ * @subgroup Picture
  */
 export class Picture {
     vertices: number[];
@@ -72,6 +83,9 @@ export class Picture {
 
 /**
  * Drawing options for drawPicture
+ *
+ * @group Draw
+ * @subgroup Types
  */
 export type DrawPictureOpt = RenderProps & {};
 

--- a/src/gfx/draw/drawPolygon.ts
+++ b/src/gfx/draw/drawPolygon.ts
@@ -2,7 +2,8 @@ import { Color } from "../../math/color";
 import { triangulate } from "../../math/math";
 import { Vec2 } from "../../math/Vec2";
 import { _k } from "../../shared";
-import { BlendMode, type DrawPolygonOpt } from "../../types";
+import { BlendMode, type RenderProps } from "../../types";
+import type { Texture } from "../gfx";
 import {
     multRotate,
     multScaleV,
@@ -12,6 +13,65 @@ import {
 } from "../stack";
 import { drawLines } from "./drawLine";
 import { drawRaw } from "./drawRaw";
+
+/**
+ * How the polygon should look like.
+ *
+ * @group Draw
+ * @subgroup Types
+ */
+export type DrawPolygonOpt = RenderProps & {
+    /**
+     * The points that make up the polygon
+     */
+    pts: Vec2[];
+    /**
+     * If fill the shape with color (set this to false if you only want an outline).
+     */
+    fill?: boolean;
+    /**
+     * Manual triangulation.
+     */
+    indices?: number[];
+    /**
+     * The center point of transformation in relation to the position.
+     */
+    offset?: Vec2;
+    /**
+     * The radius of each corner.
+     */
+    radius?: number | number[];
+    /**
+     * The color of each vertex.
+     *
+     * @since v3000.0
+     */
+    colors?: Color[];
+    /**
+     * The opacity of each vertex.
+     *
+     * @since v4000.0
+     */
+    opacities?: number[];
+    /**
+     * The uv of each vertex.
+     *
+     * @since v3001.0
+     */
+    uv?: Vec2[];
+    /**
+     * The texture if uv are supplied.
+     *
+     * @since v3001.0
+     */
+    tex?: Texture;
+    /**
+     * Triangulate concave polygons.
+     *
+     * @since v3001.0
+     */
+    triangulate?: boolean;
+};
 
 export function drawPolygon(opt: DrawPolygonOpt) {
     if (!opt.pts) {

--- a/src/gfx/draw/drawRect.ts
+++ b/src/gfx/draw/drawRect.ts
@@ -9,6 +9,9 @@ import { drawPolygon } from "./drawPolygon";
 
 /**
  * How the rectangle should look like.
+ *
+ * @group Draw
+ * @subgroup Types
  */
 export type DrawRectOpt = RenderProps & {
     /**

--- a/src/gfx/draw/drawSprite.ts
+++ b/src/gfx/draw/drawSprite.ts
@@ -7,6 +7,9 @@ import { drawTexture } from "./drawTexture";
 
 /**
  * How the sprite should look like.
+ *
+ * @group Draw
+ * @subgroup Types
  */
 export type DrawSpriteOpt = RenderProps & {
     /**

--- a/src/gfx/draw/drawText.ts
+++ b/src/gfx/draw/drawText.ts
@@ -12,6 +12,7 @@ import { drawFormattedText } from "./drawFormattedText";
  * How the text should look like.
  *
  * @group Draw
+ * @subgroup Types
  */
 export type DrawTextOpt = RenderProps & {
     /**
@@ -78,13 +79,17 @@ export type DrawTextOpt = RenderProps & {
 
 /**
  * A function that returns a character transform config. Useful if you're generating dynamic styles.
+ *
+ * @group Rendering
+ * @subgroup Text
  */
 export type CharTransformFunc = (idx: number, ch: string) => CharTransform;
 
 /**
  * Describes how to transform each character.
  *
- * @group Options
+ * @group Rendering
+ * @subgroup Text
  */
 export interface CharTransform {
     /**
@@ -156,7 +161,8 @@ export interface CharTransform {
 /**
  * How the text should be aligned.
  *
- * @group Draw
+ * @group Rendering
+ * @subgroup Text
  */
 export type TextAlign =
     | "center"

--- a/src/gfx/draw/drawTexture.ts
+++ b/src/gfx/draw/drawTexture.ts
@@ -2,10 +2,28 @@ import { DEF_ANCHOR } from "../../constants/general";
 import { Color } from "../../math/color";
 import { Quad } from "../../math/math";
 import { Vec2 } from "../../math/Vec2";
-import { BlendMode, type DrawTextureOpt, type Vertex } from "../../types";
+import { type Anchor, BlendMode, type RenderProps } from "../../types";
 import { anchorPt } from "../anchor";
+import type { Texture } from "../gfx";
 import { drawRaw } from "./drawRaw";
 import { drawUVQuad } from "./drawUVQuad";
+
+/**
+ * How the texture should look like.
+ *
+ * @group Draw
+ * @subgroup Types
+ */
+export type DrawTextureOpt = RenderProps & {
+    tex: Texture;
+    width?: number;
+    height?: number;
+    tiled?: boolean;
+    flipX?: boolean;
+    flipY?: boolean;
+    quad?: Quad;
+    anchor?: Anchor | Vec2;
+};
 
 export function drawTexture(opt: DrawTextureOpt) {
     if (!opt.tex) {

--- a/src/gfx/draw/drawTriangle.ts
+++ b/src/gfx/draw/drawTriangle.ts
@@ -4,6 +4,9 @@ import { drawPolygon } from "./drawPolygon";
 
 /**
  * How the triangle should look like.
+ *
+ * @group Draw
+ * @subgroup Types
  */
 export type DrawTriangleOpt = RenderProps & {
     /**

--- a/src/gfx/draw/drawUVQuad.ts
+++ b/src/gfx/draw/drawUVQuad.ts
@@ -1,9 +1,10 @@
 import { DEF_ANCHOR, UV_PAD } from "../../constants/general";
-import { Color, rgb } from "../../math/color";
+import { Color } from "../../math/color";
 import { Quad } from "../../math/math";
 import { Vec2 } from "../../math/Vec2";
-import { BlendMode, type DrawUVQuadOpt } from "../../types";
+import { type Anchor, BlendMode, type RenderProps } from "../../types";
 import { anchorPt } from "../anchor";
+import type { Texture } from "../gfx";
 import {
     multRotate,
     multScaleV,
@@ -13,6 +14,43 @@ import {
     pushTransform,
 } from "../stack";
 import { drawRaw } from "./drawRaw";
+
+/**
+ * How the UV Quad should look like.
+ *
+ * @group Draw
+ * @subgroup Types
+ */
+export type DrawUVQuadOpt = RenderProps & {
+    /**
+     * Width of the UV quad.
+     */
+    width: number;
+    /**
+     * Height of the UV quad.
+     */
+    height: number;
+    /**
+     * If flip the texture horizontally.
+     */
+    flipX?: boolean;
+    /**
+     * If flip the texture vertically.
+     */
+    flipY?: boolean;
+    /**
+     * The texture to sample for this quad.
+     */
+    tex?: Texture;
+    /**
+     * The texture sampling area.
+     */
+    quad?: Quad;
+    /**
+     * The anchor point, or the pivot point. Default to "topleft".
+     */
+    anchor?: Anchor | Vec2;
+};
 
 export function drawUVQuad(opt: DrawUVQuadOpt) {
     if (opt.width === undefined || opt.height === undefined) {

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -18,6 +18,10 @@ import type { FormattedChar, FormattedText } from "./draw/drawFormattedText";
 import type { CharTransform, DrawTextOpt } from "./draw/drawText";
 import { Texture } from "./gfx";
 
+/**
+ * @group Rendering
+ * @subgroup Text
+ */
 export type FontAtlas = {
     font: BitmapFontData;
     cursor: Vec2;
@@ -25,6 +29,10 @@ export type FontAtlas = {
     outline: Outline | null;
 };
 
+/**
+ * @group Rendering
+ * @subgroup Text
+ */
 export type StyledTextInfo = {
     charStyleMap: Record<number, string[]>;
     text: string;

--- a/src/gfx/gfx.ts
+++ b/src/gfx/gfx.ts
@@ -12,6 +12,10 @@ import type { Picture } from "./draw/drawPicture";
 
 export type GfxCtx = ReturnType<typeof initGfx>;
 
+/**
+ * @group Rendering
+ * @subgroup Canvas
+ */
 export class Texture {
     ctx: GfxCtx;
     src: null | ImageSource = null;
@@ -109,11 +113,19 @@ export class Texture {
     }
 }
 
+/**
+ * @group Rendering
+ * @subgroup Shaders
+ */
 export type VertexFormat = {
     name: string;
     size: number;
 }[];
 
+/**
+ * @group Rendering
+ * @subgroup Canvas
+ */
 export class BatchRenderer {
     ctx: GfxCtx;
 
@@ -381,6 +393,10 @@ export class BatchRenderer {
     }
 }
 
+/**
+ * @group Rendering
+ * @subgroup Shaders
+ */
 export class Mesh {
     ctx: GfxCtx;
     glVBuf: WebGLBuffer;

--- a/src/gfx/gfxApp.ts
+++ b/src/gfx/gfxApp.ts
@@ -57,6 +57,10 @@ export type AppGfxCtx = {
     scratchPt: Vec2;
 };
 
+/**
+ * @group Rendering
+ * @subgroup Canvas
+ */
 export type Viewport = {
     x: number;
     y: number;

--- a/src/kaplay.ts
+++ b/src/kaplay.ts
@@ -13,6 +13,7 @@ import happyFontSrc from "./data/assets/happy.png";
 import kaSpriteSrc from "./data/assets/ka.png";
 import { createCollisionSystem } from "./ecs/systems/createCollisionSystem";
 import { system, SystemPhase } from "./ecs/systems/systems";
+import { Vec2 } from "./math/Vec2";
 import { _k, updateEngine } from "./shared";
 import {
     type KAPLAYOpt,

--- a/src/math/Vec2.ts
+++ b/src/math/Vec2.ts
@@ -6,7 +6,8 @@ import { deg2rad, rad2deg, Rect, vec2, type Vec2Args } from "./math";
 /**
  * A serialized 2d vector.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedVec2 {
     x: number;

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -24,6 +24,7 @@ export interface SerializedColor {
  * 0-255 RGBA color.
  *
  * @group Math
+ * @subgroup Colors
  */
 export class Color {
     /** Red (0-255. */

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -3,9 +3,22 @@ import { _k } from "../shared";
 import { clamp } from "./clamp";
 import { lerpNumber } from "./lerpNumber";
 
+/**
+ * @group Math
+ * @subgroup Colors
+ */
 export type RGBValue = [number, number, number];
+
+/**
+ * @group Math
+ * @subgroup Colors
+ */
 export type RGBAValue = [number, number, number, number];
 
+/**
+ * @group Math
+ * @subgroup Colors
+ */
 export type CSSColor = keyof typeof CSS_COLOR_MAP;
 
 /**
@@ -267,6 +280,12 @@ export class Color {
     }
 }
 
+/**
+ * Possible color arguments for various functions.
+ *
+ * @group Math
+ * @subgroup Colors
+ */
 export type ColorArgs =
     // rgb(new Color(255, 255, 255))
     | [Color]

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -11,7 +11,8 @@ export type CSSColor = keyof typeof CSS_COLOR_MAP;
 /**
  * A serialized color.
  *
- * @group Component Serialization
+ * @group Components
+ * @subgroup Component Serialization
  */
 export interface SerializedColor {
     r: number;

--- a/src/math/easings.ts
+++ b/src/math/easings.ts
@@ -2,6 +2,7 @@
  * The list of easing functions available.
  *
  * @group Math
+ * @subgroup Tween
  */
 export type EaseFuncs =
     | "linear"
@@ -40,6 +41,7 @@ export type EaseFuncs =
  * A function that takes a time value and returns a new time value.
  *
  * @group Math
+ * @subgroup Tween
  */
 export type EaseFunc = (t: number) => number;
 

--- a/src/math/gjk.ts
+++ b/src/math/gjk.ts
@@ -240,7 +240,7 @@ enum PolygonWinding {
     CounterClockwise,
 }
 
-type Edge = {
+type GjkEdge = {
     distance: number;
     normal: Vec2;
     index: number;
@@ -253,7 +253,7 @@ type Edge = {
  *
  * @returns The edge closest to the origin.
  */
-function findClosestEdge(simplex: Vec2[], winding: PolygonWinding): Edge {
+function findClosestEdge(simplex: Vec2[], winding: PolygonWinding): GjkEdge {
     let minDistance: number = Number.POSITIVE_INFINITY;
     let minNormal = new Vec2();
     let minIndex = 0;
@@ -327,7 +327,7 @@ function getIntersection(
 
     let intersection = new Vec2();
     for (let i = 0; i < MAX_TRIES; i++) {
-        var edge: Edge = findClosestEdge(simplex, winding);
+        var edge: GjkEdge = findClosestEdge(simplex, winding);
         // Calculate the difference for the two vertices furthest along the direction of the edge normal
         var support = calculateSupport(colliderA, colliderB, edge.normal);
         // Check distance to the origin

--- a/src/math/lerp.ts
+++ b/src/math/lerp.ts
@@ -5,7 +5,7 @@ import { Vec2 } from "./Vec2";
  * A valid value for lerp.
  *
  * @group Math
- * @subgroup Tweens
+ * @subgroup Tween
  */
 export type LerpValue = number | Vec2 | Color;
 

--- a/src/math/lerp.ts
+++ b/src/math/lerp.ts
@@ -5,6 +5,7 @@ import { Vec2 } from "./Vec2";
  * A valid value for lerp.
  *
  * @group Math
+ * @subgroup Tweens
  */
 export type LerpValue = number | Vec2 | Color;
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1331,7 +1331,7 @@ export function testPointPoint(p1: Vec2, p2: Vec2): boolean {
 
 /**
  * @group Math
- * @subgroup ShapeType
+ * @subgroup Shapes
  */
 export type ShapeType = Point | Circle | Line | Rect | Polygon | Ellipse;
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1331,6 +1331,7 @@ export function testPointPoint(p1: Vec2, p2: Vec2): boolean {
 
 /**
  * @group Math
+ * @subgroup ShapeType
  */
 export type ShapeType = Point | Circle | Line | Rect | Polygon | Ellipse;
 
@@ -1510,6 +1511,7 @@ export function testShapeShape(shape1: ShapeType, shape2: ShapeType): boolean {
 
 /**
  * @group Math
+ * @subgroup Raycast
  */
 export type RaycastHit = {
     fraction: number;
@@ -1521,6 +1523,7 @@ export type RaycastHit = {
 
 /**
  * @group Math
+ * @subgroup Raycast
  */
 export type RaycastResult = RaycastHit | null;
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -13,6 +13,7 @@ import { Vec2 } from "./Vec2";
  * Possible arguments for a Vec2.
  *
  * @group Math
+ * @subgroup Vectors
  */
 export type Vec2Args =
     | [number, number]
@@ -73,6 +74,7 @@ export function vec2(...args: Vec2Args): Vec2 {
 
 /**
  * @group Math
+ * @subgroup Advanced
  */
 export class Quad {
     x: number = 0;
@@ -597,6 +599,7 @@ export const M = 2147483648;
  * A random number generator using the linear congruential generator algorithm.
  *
  * @group Math
+ * @subgroup Random
  */
 export class RNG {
     /**
@@ -1806,9 +1809,6 @@ export class Point {
     }
 }
 
-/**
- * @group Math
- */
 export class Line {
     p1: Vec2;
     p2: Vec2;

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -117,6 +117,7 @@ export function quad(x: number, y: number, w: number, h: number): Quad {
 }
 
 // Internal class
+/** @ignore */
 class Mat2 {
     // 2x2 matrix
     a: number;
@@ -2854,6 +2855,10 @@ export function easingCubicBezier(p1: Vec2, p2: Vec2) {
     };
 }
 
+/**
+ * @group Math
+ * @subgroup Tween
+ */
 export type StepPosition =
     | "jump-start"
     | "jump-end"

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -118,7 +118,7 @@ export function quad(x: number, y: number, w: number, h: number): Quad {
 
 // Internal class
 /** @ignore */
-class Mat2 {
+export class Mat2 {
     // 2x2 matrix
     a: number;
     b: number;

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -116,8 +116,10 @@ export function quad(x: number, y: number, w: number, h: number): Quad {
     return new Quad(x, y, w, h);
 }
 
-// Internal class
-/** @ignore */
+/**
+ * @group Math
+ * @subgroup Advanced
+ */
 export class Mat2 {
     // 2x2 matrix
     a: number;
@@ -216,7 +218,6 @@ export class Mat2 {
     }
 }
 
-// Internal class
 export class Mat23 {
     // 2x3 matrix, since the last column is always (0, 0, 1)
     a: number;
@@ -452,7 +453,6 @@ export class Mat23 {
     }
 }
 
-// Internal class
 class Mat3 {
     // m11 m12 m13
     // m21 m22 m23

--- a/src/math/spatial/sweepandprune.ts
+++ b/src/math/spatial/sweepandprune.ts
@@ -6,7 +6,7 @@ import { calcTransform } from "../various";
 /**
  * Left or right edge of an object's bbox
  */
-class Edge {
+class SapEdge {
     obj: GameObj<AreaComp>;
     x: number;
     isLeft: boolean;
@@ -22,12 +22,12 @@ class Edge {
  * One dimensional sweep and prune
  */
 export class SweepAndPrune {
-    edges: Array<Edge>;
-    objects: Map<GameObj<AreaComp>, [Edge, Edge]>;
+    edges: Array<SapEdge>;
+    objects: Map<GameObj<AreaComp>, [SapEdge, SapEdge]>;
 
     constructor() {
         this.edges = [];
-        this.objects = new Map<GameObj<AreaComp>, [Edge, Edge]>();
+        this.objects = new Map<GameObj<AreaComp>, [SapEdge, SapEdge]>();
     }
 
     /**
@@ -35,8 +35,8 @@ export class SweepAndPrune {
      * @param obj - The object to add
      */
     add(obj: GameObj<AreaComp>) {
-        const left = new Edge(obj, true);
-        const right = new Edge(obj, false);
+        const left = new SapEdge(obj, true);
+        const right = new SapEdge(obj, false);
         this.edges.push(left);
         this.edges.push(right);
         this.objects.set(obj, [left, right]);

--- a/src/math/spatial/sweepandprune.ts
+++ b/src/math/spatial/sweepandprune.ts
@@ -20,6 +20,8 @@ class SapEdge {
 
 /**
  * One dimensional sweep and prune
+ *
+ * @ignore
  */
 export class SweepAndPrune {
     edges: Array<SapEdge>;

--- a/src/math/vec3.ts
+++ b/src/math/vec3.ts
@@ -2,6 +2,7 @@
  * A 3D vector.
  *
  * @group Math
+ * @subgroup Vectors
  */
 export class Vec3 {
     x: number;

--- a/src/math/vec3.ts
+++ b/src/math/vec3.ts
@@ -1,3 +1,8 @@
+/**
+ * A 3D vector.
+ *
+ * @group Math
+ */
 export class Vec3 {
     x: number;
     y: number;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,10 +2,12 @@ import type { Engine } from "./core/engine";
 
 /**
  * KAPLAY.js internal data
+ *
+ * @ignore
  */
-
 export let _k: Engine;
 
+/** @ignore */
 export function updateEngine(e: Engine) {
     _k = e;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type Tag = string;
  * The basic unit of object in KAPLAY. The player, a butterfly, a tree, or even a piece of text.
  *
  * @group Game Obj
+ * @subgroup Types
  */
 export type GameObj<T = any> = GameObjRaw & MergeComps<T>;
 
@@ -780,7 +781,10 @@ export interface Comp {
 }
 
 /**
+ * A valid game object id.
+ *
  * @group Game Obj
+ * @subgroup GameObjID
  */
 export type GameObjID = number;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -515,8 +515,16 @@ export interface SpriteAnimPlayOpt {
     onEnd?: () => void;
 }
 
+/**
+ * @group Assets
+ * @subgroup Data
+ */
 export type MusicData = string;
 
+/**
+ * @group Assets
+ * @subgroup Types
+ */
 export interface LoadFontOpt {
     filter?: TexFilter;
     outline?: number | Outline;
@@ -528,13 +536,25 @@ export interface LoadFontOpt {
     size?: number;
 }
 
+/**
+ * @group Assets
+ * @subgroup Types
+ */
 export type TextureOpt = {
     filter?: TexFilter;
     wrap?: TexWrap;
 };
 
+/**
+ * @group Assets
+ * @subgroup Types
+ */
 export type ImageSource = Exclude<TexImageSource, VideoFrame>;
 
+/**
+ * @group Rendering
+ * @subgroup Canvas
+ */
 export type Canvas = {
     width: number;
     height: number;
@@ -546,6 +566,10 @@ export type Canvas = {
     readonly fb: FrameBuffer;
 };
 
+/**
+ * @group Rendering
+ * @subgroup Shaders
+ */
 export interface Vertex {
     pos: Vec2;
     uv: Vec2;
@@ -553,6 +577,10 @@ export interface Vertex {
     opacity: number;
 }
 
+/**
+ * @group Rendering
+ * @subgroup Shaders
+ */
 export enum BlendMode {
     Normal = 0,
     Add = 1,
@@ -561,6 +589,10 @@ export enum BlendMode {
     Overlay = 4,
 }
 
+/**
+ * @group Rendering
+ * @subgroup Shaders
+ */
 export interface Attributes {
     pos: number[];
     uv: number[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -821,11 +821,13 @@ export type Anchor =
 
 /**
  * @group Math
+ * @subgroup Random
  */
 export type RNGValue = number | Vec2 | Color;
 
 /**
  * @group Components
+ * @subgroup Component Types
  */
 export interface Comp {
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,8 @@ type RemoveCompProps<T> = Defined<
 /**
  * A type to merge the components of a game object, omitting the default component properties.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type MergeComps<T> = MergeObj<RemoveCompProps<T>>;
 
@@ -49,7 +50,8 @@ export type MergePlugins<T extends PluginList<any>> = MergeObj<
 /**
  * A component list.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type CompList<T extends any | undefined> = (T | Tag)[];
 export type PluginList<T> = Array<T | KAPLAYPlugin<any>>;
@@ -868,7 +870,8 @@ export type GameObjID = number;
 /**
  * A component without own properties.
  *
- * @group Component Types
+ * @group Components
+ * @subgroup Component Types
  */
 export type EmptyComp = { id: string } & Comp;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export type PluginList<T> = Array<T | KAPLAYPlugin<any>>;
  * A key.
  *
  * @group Input
+ * @subgroup Keyboard
  */
 export type Key =
     | (
@@ -144,6 +145,7 @@ export type Key =
  * A mouse button.
  *
  * @group Input
+ * @subgroup Mouse
  */
 export type MouseButton = "left" | "right" | "middle" | "back" | "forward";
 
@@ -151,6 +153,7 @@ export type MouseButton = "left" | "right" | "middle" | "back" | "forward";
  * A gamepad button.
  *
  * @group Input
+ * @subgroup Gamepad
  */
 export type KGamepadButton =
     | "north"
@@ -176,18 +179,27 @@ export type KGamepadButton =
  * A gamepad stick.
  *
  * @group Input
+ * @subgroup Gamepad
  */
-export type GamepadStick = "left" | "right";
+export type KGamepadStick = "left" | "right";
 
 /**
- * A gamepad definition.
+ * A gamepad definition. Used in {@link KAPLAYOpt `KAPLAYOpt`}
+ *
+ * @group Input
+ * @subgroup Gamepad
  */
 export type GamepadDef = {
     buttons: Record<string, KGamepadButton>;
-    sticks: Partial<Record<GamepadStick, { x: number; y: number }>>;
+    sticks: Partial<Record<KGamepadStick, { x: number; y: number }>>;
 };
 
-/** A KAPLAY gamepad */
+/**
+ *  A KAPLAY gamepad
+ *
+ * @group Input
+ * @subgroup Gamepad
+ */
 export type KGamepad = {
     /** The order of the gamepad in the gamepad list. */
     index: number;
@@ -198,7 +210,7 @@ export type KGamepad = {
     /** If certain button is released. */
     isReleased(b: KGamepadButton): boolean;
     /** Get the value of a stick. */
-    getStick(stick: GamepadStick): Vec2;
+    getStick(stick: KGamepadStick): Vec2;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -898,11 +898,13 @@ export type Mask = "intersect" | "subtract";
 
 /**
  * @group Math
+ * @subgroup Advanced
  */
 export type Edge = "left" | "right" | "top" | "bottom";
 
 /**
  * @group Math
+ * @subgroup Advanced
  */
 export enum EdgeMask {
     None = 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,6 +420,10 @@ export type KAPLAYPlugin<T> = (
     k: KAPLAYCtx,
 ) => T | ((...args: any) => (k: KAPLAYCtx) => T);
 
+/**
+ * @group Rendering
+ * @subgroup Canvas
+ */
 export type RenderTarget = {
     destination: FrameBuffer | Picture | null;
     childrenOnly?: boolean;
@@ -428,7 +432,8 @@ export type RenderTarget = {
 };
 
 /**
- * @group Options
+ * @group Game Obj
+ * @subgroup Types
  */
 export type GetOpt = {
     /**
@@ -446,7 +451,8 @@ export type GetOpt = {
 };
 
 /**
- * @group Options
+ * @group Game Obj
+ * @subgroup Types
  */
 export type QueryOpt = {
     /**
@@ -489,6 +495,9 @@ export type QueryOpt = {
 
 /**
  * Sprite animation configuration when playing.
+ *
+ * @group Components
+ * @subgroup Component Types
  */
 export interface SpriteAnimPlayOpt {
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ import type { GameObjRaw } from "./ecs/entity/GameObjRaw";
 import type { LineCap, LineJoin } from "./gfx/draw/drawLine";
 import type { Picture } from "./gfx/draw/drawPicture";
 import type { FrameBuffer } from "./gfx/FrameBuffer";
-import type { Texture } from "./gfx/gfx";
 import type { Color, RGBAValue, RGBValue } from "./math/color";
 import type {
     Circle,
@@ -631,144 +630,6 @@ export interface RenderProps {
     outline?: Outline;
 }
 
-export type DrawTextureOpt = RenderProps & {
-    tex: Texture;
-    width?: number;
-    height?: number;
-    tiled?: boolean;
-    flipX?: boolean;
-    flipY?: boolean;
-    quad?: Quad;
-    anchor?: Anchor | Vec2;
-};
-
-export type DrawUVQuadOpt = RenderProps & {
-    /**
-     * Width of the UV quad.
-     */
-    width: number;
-    /**
-     * Height of the UV quad.
-     */
-    height: number;
-    /**
-     * If flip the texture horizontally.
-     */
-    flipX?: boolean;
-    /**
-     * If flip the texture vertically.
-     */
-    flipY?: boolean;
-    /**
-     * The texture to sample for this quad.
-     */
-    tex?: Texture;
-    /**
-     * The texture sampling area.
-     */
-    quad?: Quad;
-    /**
-     * The anchor point, or the pivot point. Default to "topleft".
-     */
-    anchor?: Anchor | Vec2;
-};
-
-/**
- * How the ellipse should look like.
- */
-export type DrawEllipseOpt = RenderProps & {
-    /**
-     * The horizontal radius.
-     */
-    radiusX: number;
-    /**
-     * The vertical radius.
-     */
-    radiusY: number;
-    /**
-     * Starting angle.
-     */
-    start?: number;
-    /**
-     * Ending angle.
-     */
-    end?: number;
-    /**
-     * If fill the shape with color (set this to false if you only want an outline).
-     */
-    fill?: boolean;
-    /**
-     * Use gradient instead of solid color.
-     *
-     * @since v3000.0
-     */
-    gradient?: [Color, Color];
-    /**
-     * Multiplier for circle vertices resolution (default 1)
-     */
-    resolution?: number;
-    /**
-     * The anchor point, or the pivot point. Default to "topleft".
-     */
-    anchor?: Anchor | Vec2;
-};
-
-/**
- * How the polygon should look like.
- */
-export type DrawPolygonOpt = RenderProps & {
-    /**
-     * The points that make up the polygon
-     */
-    pts: Vec2[];
-    /**
-     * If fill the shape with color (set this to false if you only want an outline).
-     */
-    fill?: boolean;
-    /**
-     * Manual triangulation.
-     */
-    indices?: number[];
-    /**
-     * The center point of transformation in relation to the position.
-     */
-    offset?: Vec2;
-    /**
-     * The radius of each corner.
-     */
-    radius?: number | number[];
-    /**
-     * The color of each vertex.
-     *
-     * @since v3000.0
-     */
-    colors?: Color[];
-    /**
-     * The opacity of each vertex.
-     *
-     * @since v4000.0
-     */
-    opacities?: number[];
-    /**
-     * The uv of each vertex.
-     *
-     * @since v3001.0
-     */
-    uv?: Vec2[];
-    /**
-     * The texture if uv are supplied.
-     *
-     * @since v3001.0
-     */
-    tex?: Texture;
-    /**
-     * Triangulate concave polygons.
-     *
-     * @since v3001.0
-     */
-    triangulate?: boolean;
-};
-
 export interface Outline {
     /**
      * The width, or thickness of the line.
@@ -805,7 +666,8 @@ export interface Outline {
 }
 
 /**
- * @group Draw
+ * @group Rendering
+ * @subgroup Screen
  */
 export type Cursor =
     | string


### PR DESCRIPTION
## Please describe what issue(s) this PR fixes.

This PR improves a lot of JSDoc descriptions, group, tags, etc.

# Errors in DG

## To do

- `Asset` shows empty members

## Convert Type to Interfaces

For doc generations, if we can do an Interface instead of a Type, it is preferable.

- `FrameRenderer`: Type -> Interface
- `InternalAudioCtx`: Type -> Interface

## Renames

- `AudioCtx` -> `InternalAudioCtx`
- `AssetsCtx` -> `InternalAssetsCtx`
- `Edge` in SaP -> `SapEdge` for removing weird duplicated

## Group

Many elements had an incorrect group

- Grouped in Math:
    - `Vec3`
    - `hermite()`
    - `cardinal()`
    - `catmullRom()`
    - `bezier()`
    - `kochanekBartels()`
    
- Grouped in Assets
    - `loadHappy()`
    - `Shader`
    - `Uniform`
    - `UniformKey`
    - `UniformValue`
    - `ShaderData`

### Subgroups

- Subgrouped Assets/Shaders
    - `loadShader()`
    - `getShader()`
    - `loadShaderURL()`
    - `Uniform`
    - `UniformKey`
    - `UniformValue`
    - `Shader`

- New Subgroup Math/Advanced
    - `hermite()`
    - `cardinal()`
    - `catmullRom()`
    - `bezier()`
    - `kochanekBartels()`
    
## Hide

We needed to hide some stuff

- `initApp()`, it's internal
- `initAppState()`, it's internal
- `createEngine()`, it's internal
- `createFrameRenderer()`, it's internal
- `FrameRenderer`, it's internal
- `initAudio()`, it's internal
- `_k`, it's internal
- `KAPLAYCtx._k`, it's internal
- `SweepAndPrune`, it's internal



## Summary

- [ ] Changeloged
