### PR TITLE
fix: ignore destroyed objects when colliding

### DIFF
--- a/src/ecs/components/physics/area.ts
+++ b/src/ecs/components/physics/area.ts
@@ -267,12 +267,7 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
 
             events.push(
                 this.onCollideUpdate((obj, col) => {
-                    if (!obj.id) {
-                        if (!obj.exists()) return;
-                        throw new Error(
-                            "area() requires the object to have an id",
-                        );
-                    }
+                    if (!obj.exists()) return;
                     if (!colliding[obj.id]) {
                         this.trigger("collide", obj, col);
                     }

--- a/src/ecs/components/physics/area.ts
+++ b/src/ecs/components/physics/area.ts
@@ -268,6 +268,7 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
             events.push(
                 this.onCollideUpdate((obj, col) => {
                     if (!obj.id) {
+                        if (!obj.exists()) return;
                         throw new Error(
                             "area() requires the object to have an id",
                         );


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

now that #849 was merged I have started to notice that the area object can ocasionally trigger the 'area() requires the obj to have an id' error when it collides with a destroyed object in the tick immediately after it is destroyed but before it is removed from the physics system. This makes the area component ignore objects that don't exist() which is probably what was intended anyway.

(For example, launch the platformer example, and then stomp on a ghosty.)
