### PR TITLE
feat: enable shader to be monkeypatched

### DIFF
--- a/src/assets/shader.ts
+++ b/src/assets/shader.ts
@@ -67,8 +67,12 @@ export class Shader {
     constructor(ctx: GfxCtx, vert: string, frag: string, attribs: string[]) {
         this.ctx = ctx;
         ctx.onDestroy(() => this.free());
+        this.glProgram = this.compile(vert, frag, attribs);
+    }
 
-        const gl = ctx.gl;
+    compile(vert: string, frag: string, attribs: string[]) {
+
+        const gl = this.ctx.gl;
         const vertShader = gl.createShader(gl.VERTEX_SHADER);
         const fragShader = gl.createShader(gl.FRAGMENT_SHADER);
 
@@ -84,7 +88,6 @@ export class Shader {
         gl.compileShader(fragShader);
 
         const prog = gl.createProgram();
-        this.glProgram = prog!;
 
         gl.attachShader(prog!, vertShader!);
         gl.attachShader(prog!, fragShader!);
@@ -102,6 +105,8 @@ export class Shader {
 
         gl.deleteShader(vertShader);
         gl.deleteShader(fragShader);
+
+        return prog!;
     }
 
     bind() {

--- a/src/assets/shader.ts
+++ b/src/assets/shader.ts
@@ -71,7 +71,6 @@ export class Shader {
     }
 
     compile(vert: string, frag: string, attribs: string[]) {
-
         const gl = this.ctx.gl;
         const vertShader = gl.createShader(gl.VERTEX_SHADER);
         const fragShader = gl.createShader(gl.FRAGMENT_SHADER);


### PR DESCRIPTION
This literally changes nothing. Functionally at least, but now it moves the actual compilation of the GLSL into a separate method, that is just called by the constructor.

That way, I can write a plugin to monkeypatch the new compile() method to be able to do stuff like `#include` stuff and still be able to load shaders via `loadShader()` because the Shader compilation has been patched like so

```js
const Shader = _k.gfx.defShader.constructor;
const oldCompile = Shader.prototype.compile;
Shader.prototype.compile = function(vert, frag, attribs) {
    /* do some string processing here */
    return oldCompile.call(this, vert, frag, attribs);
}
```