### PR TITLE
fix: don't drop remaining quads when 9sliced sprite has zero width quads

### DIFF
--- a/src/ecs/components/draw/sprite.ts
+++ b/src/ecs/components/draw/sprite.ts
@@ -401,7 +401,7 @@ export function sprite(
                     const uv = quads[i];
                     const transform = quads[i + 9];
                     if (transform.w == 0 || transform.h == 0) {
-                        return;
+                        continue;
                     }
                     drawTexture(
                         Object.assign(props, {

--- a/tests/playtests/slice9zero.js
+++ b/tests/playtests/slice9zero.js
@@ -1,0 +1,16 @@
+kaplay({ background: "black" });
+loadSprite("9slice", "/sprites/9slice.png", {
+    slice9: {
+        left: 32,
+        right: 32,
+        top: 32,
+        bottom: 32,
+    },
+});
+const g = add([
+    sprite("9slice"),
+]);
+onUpdate(() => {
+    // Should not blink
+    g.width = g.height = Math.round(wave(63, 65, time() * 4));
+});


### PR DESCRIPTION
closes #667

yeah