### PR TITLE
fix: also check gl.getProgramInfoLog for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ best friend, lajbel, can put the correct version name here
 
 ## [unreleased]
 
+- `loadShader()` now also checks for link errors as well as compile errors and
+  reports them rather than just silently trying to use a borked shader -
+  @dragoncoder047
+
 ## [unreleased] (v3001)
 
 ---
@@ -159,9 +163,6 @@ best friend, lajbel, can put the correct version name here
 - PatrolComp is not going to last waypoint
   ([#734](https://github.com/kaplayjs/kaplay/issues/734)) - @nojaf
 - Fixed non-focused textInput component backspace - @KeSuave
-- `loadShader()` now also checks for link errors as well as compile errors and
-  reports them rather than just silently trying to use a borked shader -
-  @dragoncoder047
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - PatrolComp is not going to last waypoint
   ([#734](https://github.com/kaplayjs/kaplay/issues/734)) - @nojaf
 - Fixed non-focused textInput component backspace - @KeSuave
+- `loadShader()` now also checks for link errors as well as compile errors and
+  reports them rather than just silently trying to use a borked shader -
+  @dragoncoder047
 
 ### Removed
 

--- a/src/assets/shader.ts
+++ b/src/assets/shader.ts
@@ -100,6 +100,9 @@ export class Shader {
             if (vertError) throw new Error("VERTEX SHADER " + vertError);
             const fragError = gl.getShaderInfoLog(fragShader!);
             if (fragError) throw new Error("FRAGMENT SHADER " + fragError);
+            const linkError = gl.getProgramInfoLog(prog!);
+            if (linkError) throw new Error("LINK ERROR: " + linkError);
+            throw new Error("Unknown shader error (gl.LINK_STATUS was false)");
         }
 
         gl.deleteShader(vertShader);


### PR DESCRIPTION
This also checks the final program error log and reports any errors there, in case the program was syntactically correct and compiles, but still can't be linked into a runnable shader.

I have not been able to trigger this bug in the kaplayground for some reason... but it nonetheless occurred in my game so I'm fixing it

- [X] Changeloged
