### PR TITLE
feat: add gamepad definition for ps5 controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ best friend, lajbel, can put the correct version name here
 
 ## [unreleased]
 
+### Added
+
+- Added a mapping for PS5 (DualSense) gamepads, so now you can bind actions to
+  the touchpad press (only works in Chrome for some reason) - @dragoncoder047
+
 ## [unreleased] (v3001)
 
 ---
@@ -167,7 +172,7 @@ best friend, lajbel, can put the correct version name here
 ### Changed
 
 - **BREAKING**: Changed default behavior to
-  `kaplay({ tagsAsComponents: false })`.
+  `kaplay({ tagComponentIds: false })`. Also the flag has been renamed!
 - The physics engine creates less garbage - @mflerackers
 - Tag-based events are slightly faster - @dragoncoder047
 - Moved camera to the shader - @mflerackers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@ best friend, lajbel, can put the correct version name here
 ### Changed
 
 - **BREAKING**: Changed default behavior to
-  `kaplay({ tagComponentIds: false })`. Also the flag has been renamed!
+  `kaplay({ tagsAsComponents: false })`.
 - The physics engine creates less garbage - @mflerackers
 - Tag-based events are slightly faster - @dragoncoder047
 - Moved camera to the shader - @mflerackers

--- a/src/data/gamepad.json
+++ b/src/data/gamepad.json
@@ -83,6 +83,32 @@
       "right": { "x": 2, "y": 3 }
     }
   },
+  "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)": {
+    "buttons": {
+      "0": "south",
+      "1": "east",
+      "2": "west",
+      "3": "north",
+      "4": "lshoulder",
+      "5": "rshoulder",
+      "6": "ltrigger",
+      "7": "rtrigger",
+      "8": "select",
+      "9": "start",
+      "10": "lstick",
+      "11": "rstick",
+      "12": "dpad-up",
+      "13": "dpad-down",
+      "14": "dpad-left",
+      "15": "dpad-right",
+      "16": "home",
+      "17": "touchpad"
+    },
+    "sticks": {
+      "left": { "x": 0, "y": 1 },
+      "right": { "x": 2, "y": 3 }
+    }
+  },
   "default": {
     "buttons": {
       "0": "south",

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,8 @@ export type KGamepadButton =
     | "dpad-down"
     | "dpad-left"
     | "home"
-    | "capture";
+    | "capture"
+    | "touchpad";
 
 /**
  * A gamepad stick.


### PR DESCRIPTION
includes new button 'touchpad'

i discovered this by accident lol. opened the 'gamepad' example in chrome and pressed the touchpad, and it logged 'undefined'.

- [X] Changeloged
