### PR TITLE
fix: perf optimization for the shooter game kaplayground example

### DIFF
--- a/examples/shooter.js
+++ b/examples/shooter.js
@@ -245,6 +245,7 @@ scene("battle", () => {
             pos(rand(0, width()), 0),
             health(OBJ_HEALTH),
             anchor("bot"),
+            offscreen({ destroy: true }),
             "trash",
             "enemy",
             { speed: rand(TRASH_SPEED * 0.5, TRASH_SPEED * 1.5) },


### PR DESCRIPTION
Someone mentioned under my KAPLAY in 5 mins video that the performance of the shooter example would degrade after 20s if they increased the trash spawn rate to 0.1.

After investigation, I noticed that the offscreen component was not being used, therefore trash game objects would not be destroyed once they fall outside the screen. Since we continually add trash game objects in this game, this would lead to degraded performance over time.

The fix is simple, use the offscreen() component.
