### PR TITLE
fix: remove uv pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ best friend, lajbel, can put the correct version name here
   @dragoncoder047
 - The debug `record()` function now records with sound enabled like it should -
   @dragoncoder047
-- Now `KAPLAYOpt.spriteAtlasPadding` is set to `2` by default
+- Now `KAPLAYOpt.spriteAtlasPadding` is set to `2` by default - @lajbel
 
 ## [unreleased] (v3001)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ best friend, lajbel, can put the correct version name here
 
 - `loadShader()` now also checks for link errors as well as compile errors and
   reports them rather than just silently trying to use a borked shader -
+  @dragoncoder047
 - The debug `record()` function now records with sound enabled like it should -
   @dragoncoder047
+- Now `KAPLAYOpt.spriteAtlasPadding` is set to `2` by default
 
 ## [unreleased] (v3001)
 

--- a/src/assets/asset.ts
+++ b/src/assets/asset.ts
@@ -4,6 +4,7 @@ import { KEvent, KEventHandler } from "../events/events";
 import type { GfxCtx } from "../gfx/gfx";
 import { TexPacker } from "../gfx/TexPacker";
 import { _k } from "../shared";
+import type { MustKAPLAYOpt } from "../types";
 import type { BitmapFontData } from "./bitmapFont";
 import type { FontData } from "./font";
 import type { ShaderData } from "./shader";
@@ -260,7 +261,7 @@ export function load<T>(prom: Promise<T>): Asset<T> {
 export type InternalAssetsCtx = ReturnType<typeof initAssets>;
 
 /** @ignore */
-export const initAssets = (ggl: GfxCtx, spriteAtlasPadding: number) => {
+export const initAssets = (ggl: GfxCtx, opt: MustKAPLAYOpt) => {
     const assets = {
         urlPrefix: "",
         // asset holders
@@ -276,7 +277,7 @@ export const initAssets = (ggl: GfxCtx, spriteAtlasPadding: number) => {
             ggl,
             SPRITE_ATLAS_WIDTH,
             SPRITE_ATLAS_HEIGHT,
-            spriteAtlasPadding,
+            opt.spriteAtlasPadding,
         ),
         // if we finished initially loading all assets
         loaded: false,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -48,9 +48,13 @@ window.kaplayjs_assetsAliases = {};
  */
 export const createEngine = (gopt: KAPLAYOpt) => {
     // Default options
-    const opt = Object.assign({
-        scale: 1,
-    }, gopt);
+    const opt = Object.assign(
+        {
+            scale: 1,
+            spriteAtlasPadding: 2,
+        } satisfies KAPLAYOpt,
+        gopt,
+    );
 
     const canvas = createCanvas(opt);
     const { fontCacheC2d, fontCacheCanvas } = createFontCache();
@@ -73,7 +77,7 @@ export const createEngine = (gopt: KAPLAYOpt) => {
     // TODO: Investigate correctly what's the differente between GFX and AppGFX and reduce to 1 method
     const gfx = initGfx(gl, opt);
     const appGfx = initAppGfx(gfx, opt);
-    const assets = initAssets(gfx, opt.spriteAtlasPadding ?? 0);
+    const assets = initAssets(gfx, opt);
     const audio = initAudio();
     const game = createGame();
 

--- a/src/gfx/draw/drawUVQuad.ts
+++ b/src/gfx/draw/drawUVQuad.ts
@@ -72,14 +72,6 @@ export function drawUVQuad(opt: DrawUVQuadOpt) {
     const color = opt.color || Color.WHITE;
     const opacity = opt.opacity ?? 1;
 
-    // apply uv padding to avoid artifacts
-    const uvPadX = opt.tex ? UV_PAD / opt.tex.width : 0;
-    const uvPadY = opt.tex ? UV_PAD / opt.tex.height : 0;
-    const qx = q.x + uvPadX;
-    const qy = q.y + uvPadY;
-    const qw = q.w - uvPadX * 2;
-    const qh = q.h - uvPadY * 2;
-
     pushTransform();
     multTranslateV(opt.pos);
     multRotate(opt.angle);
@@ -99,14 +91,14 @@ export function drawUVQuad(opt: DrawUVQuadOpt) {
                 h / 2,
             ],
             uv: [
-                opt.flipX ? qx + qw : qx,
-                opt.flipY ? qy : qy + qh,
-                opt.flipX ? qx + qw : qx,
-                opt.flipY ? qy + qh : qy,
-                opt.flipX ? qx : qx + qw,
-                opt.flipY ? qy + qh : qy,
-                opt.flipX ? qx : qx + qw,
-                opt.flipY ? qy : qy + qh,
+                opt.flipX ? q.x + q.w : q.x,
+                opt.flipY ? q.y : q.y + q.h,
+                opt.flipX ? q.x + q.w : q.x,
+                opt.flipY ? q.y + q.h : q.y,
+                opt.flipX ? q.x : q.x + q.w,
+                opt.flipY ? q.y + q.h : q.y,
+                opt.flipX ? q.x : q.x + q.w,
+                opt.flipY ? q.y : q.y + q.h,
             ],
             color: [
                 color.r,

--- a/src/gfx/gfxApp.ts
+++ b/src/gfx/gfxApp.ts
@@ -6,11 +6,10 @@ import {
     MAX_BATCHED_VERTS,
     VERTEX_FORMAT,
 } from "../constants/general";
-import { go, popScene, pushScene } from "../game/scenes";
 import { type Color, rgb } from "../math/color";
 import { Mat23 } from "../math/math";
 import { Vec2 } from "../math/Vec2";
-import type { KAPLAYOpt, MustKAPLAYOpt } from "../types";
+import type { MustKAPLAYOpt } from "../types";
 import type { FontAtlas } from "./formatText";
 import { FrameBuffer } from "./FrameBuffer";
 import { BatchRenderer, type GfxCtx, Texture } from "./gfx";

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,11 +211,10 @@ export type KGamepad = {
  */
 export type GameObjInspect = Record<Tag, string | null>;
 
-export type MustKAPLAYOpt =
-    & {
-        [K in keyof Pick<KAPLAYOpt, "scale">]-?: KAPLAYOpt[K];
-    }
-    & KAPLAYOpt;
+export type MustKAPLAYOpt = {
+    scale: number;
+    spriteAtlasPadding: number;
+} & KAPLAYOpt;
 
 /**
  * KAPLAY configurations.

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,7 +358,8 @@ export interface KAPLAYOpt<
     tagComponentIds?: boolean;
     /**
      * Padding used when adding sprites to texture atlas.
-     * @default 0
+     *
+     * @default 2
      */
     spriteAtlasPadding?: number;
     /**

--- a/tests/playtests/pixelPerfect.js
+++ b/tests/playtests/pixelPerfect.js
@@ -1,0 +1,87 @@
+// Starts a new game
+kaplay({
+    scale: 1,
+    width: 1920,
+    height: 1080,
+    crisp: true,
+    spriteAtlasPadding: 2,
+});
+
+// Load a bean
+loadBean();
+
+let zoom = 1;
+let rotation = 0;
+let zoomVector = vec2(zoom);
+
+onLoad(() => {
+    add([
+        sprite("bean"),
+        pos(25, 50),
+        {
+            update() {
+                this.scale = zoomVector;
+                this.angle = rotation;
+            },
+        },
+    ]);
+
+    const data = getSprite("bean").data;
+
+    onDraw(() => {
+        drawSprite({
+            pos: vec2(300, 50),
+            sprite: "bean",
+            scale: zoomVector,
+            angle: rotation,
+        });
+        drawPolygon({
+            angle: rotation,
+            pts: [
+                vec2(0, 0),
+                vec2(data.width, 0),
+                vec2(data.width, data.height),
+                vec2(0, data.height),
+            ],
+            pos: vec2(500, 50),
+            scale: zoomVector,
+            tex: data.tex,
+            uv: [
+                vec2(data.frames[0].x, data.frames[0].y),
+                vec2(data.frames[0].x + data.frames[0].w, data.frames[0].y),
+                vec2(
+                    data.frames[0].x + data.frames[0].w,
+                    data.frames[0].y + data.frames[0].h,
+                ),
+                vec2(data.frames[0].x, data.frames[0].y + data.frames[0].h),
+            ],
+        });
+
+        drawRect({
+            height: 2048,
+            width: 2048,
+            pos: vec2(0, center().y),
+            scale: vec2(2),
+        });
+
+        drawUVQuad({
+            tex: data.tex,
+            height: 2048,
+            width: 2048,
+            pos: vec2(0, center().y),
+        });
+    });
+});
+
+onScroll((d) => {
+    zoom += dt() * d.y / 10;
+    zoomVector.set(zoom, zoom);
+});
+
+onKeyPress("left", () => {
+    rotation -= dt() * 10;
+});
+
+onKeyPress("right", () => {
+    rotation += dt() * 10;
+});


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

It removes UV_PAD as it is not working correctly for removing artifacts. Instead, we're going to set a default `spriteAtlasPadding`

## Summary

- [ ] Changeloged
