### PR TITLE
Fix textmetrics incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ best friend, lajbel, can put the correct version name here
 ### Fixed
 
 - Fixed shader error messages - @dragoncoder047
+- Fixed compatibility issues when calculating font height with missing TextMetrics
+  props - @imaginarny
 
 ## [4000.0.0-alpha.20] - 2025-06-15
 

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -199,8 +199,9 @@ function updateFontAtlas(font: FontData | string, ch: string) {
         const m = c2d.measureText(ch);
         let w = Math.ceil(m.width);
         if (!w) return;
-        let h = Math.ceil(Math.abs(m.actualBoundingBoxAscent))
-            + Math.ceil(Math.abs(m.actualBoundingBoxDescent));
+        let h = (Math.ceil(Math.abs(m.actualBoundingBoxAscent))
+            + Math.ceil(Math.abs(m.actualBoundingBoxDescent)))
+            || atlas.font.size;
 
         // TODO: Test if this works with the verification of width and color
         if (


### PR DESCRIPTION
## Please describe what issue(s) this PR fixes.

Fixes compatibility issues when calculating font height with missing TextMetrics props.

## Summary

- [ x] Changeloged
