### PR TITLE
feat: add jsdoc to all color overloads and allow hexadecimal literal numbers in `color()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,8 @@ best friend, lajbel, can put the correct version name here
 
 ### Changed
 
-- Now, you can use `color(c)` with a hexadecimal literal number (ex: 0x00ff00) - @lajbel
+- Now, you can use `color(c)` with a hexadecimal literal number (ex: 0x00ff00) -
+  @lajbel
   ```js
   // blue frog
   add([

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ best friend, lajbel, can put the correct version name here
 
 ### Changed
 
+- Now, you can use `color(c)` with a hexadecimal literal number (ex: 0x00ff00) - @lajbel
+  ```js
+  // blue frog
+  add([
+      sprite("bean"),
+      color(0x0000ff),
+  ]);
+  ```
 - **(!)** `KAPLAYCtx` doesn't use generics anymore. Now, `KAPLAYCtxT` uses
   them - @lajbel
 - Now, `kaplay` will return `KAPLAYCtx` or `KAPLAYCtxT` depending if it's using

--- a/examples/ai.js
+++ b/examples/ai.js
@@ -1,108 +1,22 @@
-/**
- * @file AI with State Machines
- * @description How to create simple game AI using state machines.
- * @difficulty 1
- * @tags ai
- * @minver 3001.0
- * @category concepts
- * @test
- */
-
-// Use state() component to handle basic AI
-
-// Start KAPLAY
+// Starts a new game
 kaplay();
 
-// Load assets
-loadSprite("bean", "/sprites/bean.png");
-loadSprite("ghosty", "/sprites/ghosty.png");
+// Load a bean
+loadBean();
 
-// Some constants
-const SPEED = 320;
-const ENEMY_SPEED = 160;
-const BULLET_SPEED = 800;
-
-// Add player game object
-const player = add([
-    sprite("bean"),
-    pos(80, 80),
-    area(),
-    anchor("center"),
+// Add the bean
+const bean = add([
+    sprite("bean"), // add sprite
+    pos(center()), // set position, center of the screen
+    scale(2), // set scale
+    anchor("center"), // set anchor, pivot
+    rotate(0), // set rotation
+    color(0x0000ff),
 ]);
 
-const enemy = add([
-    sprite("ghosty"),
-    pos(width() - 80, height() - 80),
-    anchor("center"),
-    // This enemy cycle between 3 states, and start from "idle" state
-    state("move", ["idle", "attack", "move"]),
+// Add the text
+add([
+    text("Hello, KAWORLD!"), // add text
+    pos(center().add(0, -130)), // set position
+    anchor("center"), // set anchor, pivot
 ]);
-
-// Run the callback once every time we enter "idle" state.
-// Here we stay "idle" for 0.5 second, then enter "attack" state.
-enemy.onStateEnter("idle", async () => {
-    await wait(0.5);
-    enemy.enterState("attack");
-});
-
-// When we enter "attack" state, we fire a bullet, and enter "move" state after 1 sec
-enemy.onStateEnter("attack", async () => {
-    // Don't do anything if player doesn't exist anymore
-    if (player.exists()) {
-        const dir = player.pos.sub(enemy.pos).unit();
-
-        add([
-            pos(enemy.pos),
-            move(dir, BULLET_SPEED),
-            rect(12, 12),
-            area(),
-            offscreen({ destroy: true }),
-            anchor("center"),
-            color(BLUE),
-            "bullet",
-        ]);
-    }
-
-    // Waits 1 second to make the enemy enter in "move" state
-    await wait(1);
-    enemy.enterState("move");
-});
-
-// When we enter "move" state, we stay there for 2 sec and then go back to "idle"
-enemy.onStateEnter("move", async () => {
-    await wait(2);
-    enemy.enterState("idle");
-});
-
-// .onStateUpdate() is similar to .onUpdate(), it'll run every frame, but in this case
-// Only when the current state is "move"
-enemy.onStateUpdate("move", () => {
-    // We move the enemy in the direction of the player
-    if (!player.exists()) return;
-    const dir = player.pos.sub(enemy.pos).unit();
-    enemy.move(dir.scale(ENEMY_SPEED));
-});
-
-// Taking a bullet makes us disappear
-player.onCollide("bullet", (bullet) => {
-    destroy(bullet);
-    destroy(player);
-    addKaboom(bullet.pos);
-});
-
-// Register input handlers & movement
-onKeyDown("left", () => {
-    player.move(-SPEED, 0);
-});
-
-onKeyDown("right", () => {
-    player.move(SPEED, 0);
-});
-
-onKeyDown("up", () => {
-    player.move(0, -SPEED);
-});
-
-onKeyDown("down", () => {
-    player.move(0, SPEED);
-});

--- a/examples/ai.js
+++ b/examples/ai.js
@@ -1,22 +1,108 @@
-// Starts a new game
+/**
+ * @file AI with State Machines
+ * @description How to create simple game AI using state machines.
+ * @difficulty 1
+ * @tags ai
+ * @minver 3001.0
+ * @category concepts
+ * @test
+ */
+
+// Use state() component to handle basic AI
+
+// Start KAPLAY
 kaplay();
 
-// Load a bean
-loadBean();
+// Load assets
+loadSprite("bean", "/sprites/bean.png");
+loadSprite("ghosty", "/sprites/ghosty.png");
 
-// Add the bean
-const bean = add([
-    sprite("bean"), // add sprite
-    pos(center()), // set position, center of the screen
-    scale(2), // set scale
-    anchor("center"), // set anchor, pivot
-    rotate(0), // set rotation
-    color(0x0000ff),
+// Some constants
+const SPEED = 320;
+const ENEMY_SPEED = 160;
+const BULLET_SPEED = 800;
+
+// Add player game object
+const player = add([
+    sprite("bean"),
+    pos(80, 80),
+    area(),
+    anchor("center"),
 ]);
 
-// Add the text
-add([
-    text("Hello, KAWORLD!"), // add text
-    pos(center().add(0, -130)), // set position
-    anchor("center"), // set anchor, pivot
+const enemy = add([
+    sprite("ghosty"),
+    pos(width() - 80, height() - 80),
+    anchor("center"),
+    // This enemy cycle between 3 states, and start from "idle" state
+    state("move", ["idle", "attack", "move"]),
 ]);
+
+// Run the callback once every time we enter "idle" state.
+// Here we stay "idle" for 0.5 second, then enter "attack" state.
+enemy.onStateEnter("idle", async () => {
+    await wait(0.5);
+    enemy.enterState("attack");
+});
+
+// When we enter "attack" state, we fire a bullet, and enter "move" state after 1 sec
+enemy.onStateEnter("attack", async () => {
+    // Don't do anything if player doesn't exist anymore
+    if (player.exists()) {
+        const dir = player.pos.sub(enemy.pos).unit();
+
+        add([
+            pos(enemy.pos),
+            move(dir, BULLET_SPEED),
+            rect(12, 12),
+            area(),
+            offscreen({ destroy: true }),
+            anchor("center"),
+            color(BLUE),
+            "bullet",
+        ]);
+    }
+
+    // Waits 1 second to make the enemy enter in "move" state
+    await wait(1);
+    enemy.enterState("move");
+});
+
+// When we enter "move" state, we stay there for 2 sec and then go back to "idle"
+enemy.onStateEnter("move", async () => {
+    await wait(2);
+    enemy.enterState("idle");
+});
+
+// .onStateUpdate() is similar to .onUpdate(), it'll run every frame, but in this case
+// Only when the current state is "move"
+enemy.onStateUpdate("move", () => {
+    // We move the enemy in the direction of the player
+    if (!player.exists()) return;
+    const dir = player.pos.sub(enemy.pos).unit();
+    enemy.move(dir.scale(ENEMY_SPEED));
+});
+
+// Taking a bullet makes us disappear
+player.onCollide("bullet", (bullet) => {
+    destroy(bullet);
+    destroy(player);
+    addKaboom(bullet.pos);
+});
+
+// Register input handlers & movement
+onKeyDown("left", () => {
+    player.move(-SPEED, 0);
+});
+
+onKeyDown("right", () => {
+    player.move(SPEED, 0);
+});
+
+onKeyDown("up", () => {
+    player.move(0, -SPEED);
+});
+
+onKeyDown("down", () => {
+    player.move(0, SPEED);
+});

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -140,7 +140,7 @@ import type { FrameBuffer } from "../gfx/FrameBuffer";
 import type { DecisionNode, DecisionTree } from "../math/ai/decisiontree";
 import type { Rule, RuleSystem } from "../math/ai/rulesystem";
 import type { StateMachine } from "../math/ai/statemachine";
-import type { Color, CSSColor } from "../math/color";
+import type { Color, CSSColorKeywords } from "../math/color";
 import type { EaseFunc, EaseFuncs } from "../math/easings";
 import type { GjkCollisionResult } from "../math/gjk";
 import type { LerpValue } from "../math/lerp";
@@ -624,7 +624,7 @@ export interface KAPLAYCtx {
      */
     color(c: Color): ColorComp;
     /**
-     * Sets the color of a Game Object using an array (rgb 255).
+     * Sets the color of a Game Object using an array (rgb 0-255).
      *
      * @param rgb - The color array to set [r, g, b].
      *
@@ -644,9 +644,9 @@ export interface KAPLAYCtx {
      */
     color(rgb: [number, number, number]): ColorComp;
     /**
-     * Sets the color of a Game Object using a CSS color or Hex string.
+     * Sets the color of a Game Object using a CSS color keywords or hexadecimal string.
      *
-     * @param c - The CSS color name or Hex code to set.
+     * @param c - The CSS color keyword or hexadecimal code to set.
      *
      * @example
      * ```js
@@ -668,11 +668,11 @@ export interface KAPLAYCtx {
      * @group Components
      * @subgroup Rendering
      */
-    color(c: OptionalString<CSSColor>): ColorComp;
+    color(c: OptionalString<CSSColorKeywords>): ColorComp;
     /**
-     * Sets the color of a Game Object using a CSS color or Hex string.
+     * Sets the color of a Game Object using a hexadecimal literal number.
      *
-     * @param c - The CSS color HEX number.
+     * @param c - The hexadecimal literal number.
      *
      * @example
      * ```js
@@ -4782,9 +4782,9 @@ export interface KAPLAYCtx {
      */
     rgb(hex: string): Color;
     /**
-     * Create a color from CSS name.
+     * Create a color from CSS keyword.
      *
-     * @param cssColor - The CSS name.
+     * @param cssColor - The CSS keyword.
      *
      * @example
      * ```js
@@ -4795,7 +4795,7 @@ export interface KAPLAYCtx {
      * @since v3001.0.10
      * @experimental This feature is in experimental phase, it will be fully released in v3001.1.0
      */
-    rgb(cssColor: CSSColor): Color;
+    rgb(cssColor: CSSColorKeywords): Color;
     /**
      * Same as rgb(255, 255, 255).
      */

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -186,6 +186,7 @@ import type {
 } from "../types";
 import type { TupleWithoutFirst } from "../utils/types";
 import type { Engine } from "./engine";
+import type { OptionalString } from "./taf";
 
 /**
  * Context handle that contains every KAPLAY function.
@@ -600,9 +601,111 @@ export interface KAPLAYCtx {
      * @subgroup Rendering
      */
     color(r: number, g: number, b: number): ColorComp;
+    /**
+     * Sets the color of a Game Object using a previously created Color Object.
+     *
+     * @param c - The color to clone and set.
+     *
+     * @example
+     * ```js
+     * // blue frog
+     * const blue = rgb(0, 0, 255);
+     *
+     * add([
+     *     sprite("bean"),
+     *     color(blue),
+     * ]);
+     * ```
+     *
+     * @returns The color comp.
+     * @since v2000.0
+     * @group Components
+     * @subgroup Rendering
+     */
     color(c: Color): ColorComp;
+    /**
+     * Sets the color of a Game Object using an array (rgb 255).
+     *
+     * @param rgb - The color array to set [r, g, b].
+     *
+     * @example
+     * ```js
+     * // blue frog
+     * add([
+     *     sprite("bean"),
+     *     color([0, 0, 255]),
+     * ]);
+     * ```
+     *
+     * @returns The color comp.
+     * @since v2000.0
+     * @group Components
+     * @subgroup Rendering
+     */
     color(rgb: [number, number, number]): ColorComp;
-    color(c: CSSColor & (string | {})): ColorComp;
+    /**
+     * Sets the color of a Game Object using a CSS color or Hex string.
+     *
+     * @param c - The CSS color name or Hex code to set.
+     *
+     * @example
+     * ```js
+     * // blue frog (HEX)
+     * add([
+     *     sprite("bean"),
+     *     color("#0000ff"),
+     * ]);
+     *
+     * // red cheese (CSS)
+     * add([
+     *     sprite("mark"),
+     *     color("red"),
+     * ]);
+     * ```
+     *
+     * @returns The color comp.
+     * @since v2000.0
+     * @group Components
+     * @subgroup Rendering
+     */
+    color(c: OptionalString<CSSColor>): ColorComp;
+    /**
+     * Sets the color of a Game Object using a CSS color or Hex string.
+     *
+     * @param c - The CSS color HEX number.
+     *
+     * @example
+     * ```js
+     * // blue frog
+     * add([
+     *     sprite("bean"),
+     *     color(0x0000ff),
+     * ]);
+     * ```
+     *
+     * @returns The color comp.
+     * @since v2000.0
+     * @group Components
+     * @subgroup Rendering
+     */
+    color(c: number): ColorComp;
+    /**
+     * Sets the color of a Game Object to white (no effect).
+     *
+     * @example
+     * ```js
+     * // normal frog
+     * add([
+     *     sprite("bean"),
+     *     color(),
+     * ]);
+     * ```
+     *
+     * @returns The color comp.
+     * @since v2000.0
+     * @group Components
+     * @subgroup Rendering
+     */
     color(): ColorComp;
     /**
      * Sets the blend mode of a Game Object.

--- a/src/core/taf.ts
+++ b/src/core/taf.ts
@@ -20,7 +20,7 @@ export type InfKAPLAYOpt<T extends KAPLAYOpt = KAPLAYOpt> = {
         : undefined;
 };
 
-type OptionalString<T extends string> = T | {} & string;
+export type OptionalString<T extends string> = T | {} & string;
 
 /**
  * Type options for the KAPLAY context.

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -19,7 +19,7 @@ export type RGBAValue = [number, number, number, number];
  * @group Math
  * @subgroup Colors
  */
-export type CSSColor = keyof typeof CSS_COLOR_MAP;
+export type CSSColorKeywords = keyof typeof CSS_COLOR_MAP;
 
 /**
  * A serialized color.
@@ -150,7 +150,7 @@ export class Color {
      * @returns The color.
      * @experimental This feature is in experimental phase, it will be fully released in v3001.1.0
      */
-    static fromCSS(cssColor: CSSColor) {
+    static fromCSS(cssColor: CSSColorKeywords) {
         const color = CSS_COLOR_MAP[cssColor];
         // for js users
         if (!color) throw new Error("Can't use an invalid CSS color");
@@ -309,7 +309,7 @@ export type ColorArgs =
     | [string]
     | [number[]]
     | []
-    | [CSSColor & (string & {})]
+    | [CSSColorKeywords & (string & {})]
     | [number];
 
 export function rgb(...args: ColorArgs): Color {
@@ -324,8 +324,8 @@ export function rgb(...args: ColorArgs): Color {
             return cl.clone();
         }
         else if (typeof cl === "string") {
-            if (cl[0] != "#" && CSS_COLOR_MAP[cl as CSSColor]) {
-                return Color.fromCSS(cl as CSSColor);
+            if (cl[0] != "#" && CSS_COLOR_MAP[cl as CSSColorKeywords]) {
+                return Color.fromCSS(cl as CSSColorKeywords);
             }
 
             return Color.fromHex(args[0]);

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -329,6 +329,9 @@ export function rgb(...args: ColorArgs): Color {
 
             return Color.fromHex(args[0]);
         }
+        else if (typeof cl === "number") {
+            return Color.fromHex(cl);
+        }
         else if (Array.isArray(args[0]) && args[0].length === 3) {
             // rgb([255, 255, 255])
             return Color.fromArray(args[0] as [number, number, number]);

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -310,7 +310,7 @@ export type ColorArgs =
     | [number[]]
     | []
     | [CSSColor & (string & {})]
-    | [number]
+    | [number];
 
 export function rgb(...args: ColorArgs): Color {
     if (args.length === 0) {

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -309,7 +309,8 @@ export type ColorArgs =
     | [string]
     | [number[]]
     | []
-    | [CSSColor & (string & {})];
+    | [CSSColor & (string & {})]
+    | [number]
 
 export function rgb(...args: ColorArgs): Color {
     if (args.length === 0) {


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

## Summary

- [x] Changeloged
