### PR TITLE
fix: pass info.slice9 when loading sprite atlas

### DIFF
--- a/src/assets/spriteAtlas.ts
+++ b/src/assets/spriteAtlas.ts
@@ -81,7 +81,12 @@ export function loadSpriteAtlas(
                         info.width / w * quad.w,
                         info.height / h * quad.h,
                     );
-                const spr = new SpriteData(atlas.tex, frames, info.anims, info.slice9);
+                const spr = new SpriteData(
+                    atlas.tex,
+                    frames,
+                    info.anims,
+                    info.slice9,
+                );
                 _k.assets.sprites.addLoaded(name, spr);
                 map[name] = spr;
             }


### PR DESCRIPTION
idk if it needs to be changeloged because the docs say that slice9 is already available on loadSpriteAtlas. now it actually *works* like it should