### PR TITLE
fix: advance time when framerate is not capped

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -378,8 +378,7 @@ export const initApp = (
                         fixedUpdate();
                     }
                     state.restDt = fixedAccumulatedDt;
-                    state.dt = desiredDt;
-                    state.time += dt();
+                    state.time += state.dt = desiredDt > 0 ? desiredDt : realDt;
                     state.fpsCounter.tick(state.dt);
                 }
                 if (desiredDt > 0) {


### PR DESCRIPTION
so MF's recent PR to fix framerate flickering when you cap the maxFPS, made it so if you *don't* cap the maxFPS then dt will always be 0 on each frame and time() will never advance, this fixes that