### PR TITLE
fix: call sprite anim onEnd *after* stopping it, so that onEnd can start another anim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ best friend, lajbel, can put the correct version name here
 - Fixed the `fakeMouse()` component not giving the right position when the
   camera transform was not the identity matrix - @dragoncoder047
 - Fixed tall fonts being cropped - @anthonygood
+- Fixed the sprite animation `onEnd()` callback being called before the
+  animation actually stopped, so if the onEnd callback started a new animation,
+  the new animation was instantly stopped - @dragoncoder047
 
 ## [4000.0.0-alpha.23] - 2025-11-05
 

--- a/src/ecs/components/draw/sprite.ts
+++ b/src/ecs/components/draw/sprite.ts
@@ -479,8 +479,8 @@ export function sprite(
                     }
                     else {
                         this.frame = frames.at(-1)!;
-                        curAnim.onEnd();
                         this.stop();
+                        curAnim.onEnd();
                         return;
                     }
                 }
@@ -494,8 +494,8 @@ export function sprite(
                     }
                     else {
                         this.frame = frames[0];
-                        curAnim.onEnd();
                         this.stop();
+                        curAnim.onEnd();
                         return;
                     }
                 }


### PR DESCRIPTION
closes #969

## Summary

- [X] Changeloged
