### PR TITLE
fix: don't crash when calling anim onEnd

### DIFF
--- a/src/ecs/components/draw/sprite.ts
+++ b/src/ecs/components/draw/sprite.ts
@@ -479,8 +479,9 @@ export function sprite(
                     }
                     else {
                         this.frame = frames.at(-1)!;
+                        const anim = curAnim;
                         this.stop();
-                        curAnim.onEnd();
+                        anim.onEnd();
                         return;
                     }
                 }
@@ -494,8 +495,9 @@ export function sprite(
                     }
                     else {
                         this.frame = frames[0];
+                        const anim = curAnim;
                         this.stop();
-                        curAnim.onEnd();
+                        anim.onEnd();
                         return;
                     }
                 }

--- a/tests/playtests/sprite_anim_onend_restart.js
+++ b/tests/playtests/sprite_anim_onend_restart.js
@@ -1,0 +1,32 @@
+kaplay();
+
+loadSprite("dino", "/sprites/dungeon-dino.png", {
+    sliceX: 9,
+    anims: {
+        idle: {
+            from: 0,
+            to: 3,
+            speed: 5,
+        },
+        run: {
+            from: 4,
+            to: 7,
+            speed: 10,
+        },
+    },
+});
+
+const s = add([
+    sprite("dino"),
+    pos(100, 100),
+    scale(10),
+]);
+
+function anim() {
+    s.play("idle", {
+        onEnd() {
+            s.play("run", { onEnd: anim });
+        },
+    });
+}
+anim();


### PR DESCRIPTION
now when the onEnd is called it won't get nuked by stop() before it's called

closes #930