### PR TITLE
feat: add turn cost option to pathfinding logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ best friend, lajbel, can put the correct version name here
 
 ## Added
 
+- Added `turnCost` option to pathfinding logic, allowing you to specify a
+  penalty for direction changes when calculating paths
 - Added `AreaCompOpt.isSensor`. Areas without body or is sensor will no longer
   be eligible for collisions - @mflerackers
 

--- a/examples/pathfinding.js
+++ b/examples/pathfinding.js
@@ -1,0 +1,81 @@
+/**
+ * @file Maze
+ * @description How to create a maze using math and addLevel().
+ * @difficulty 2
+ * @tags math, game
+ * @minver 4000.0
+ * @category concepts
+ * @test
+ */
+
+kaplay({
+    scale: 0.5,
+    background: [0, 0, 0],
+});
+
+loadSprite("bean", "sprites/bean.png");
+loadSprite("steel", "sprites/steel.png");
+
+const TILE_WIDTH = 64;
+const TILE_HEIGHT = TILE_WIDTH;
+
+const level = addLevel(
+    [
+        "########",
+        "#      #",
+        "#      #",
+        "#      #",
+        "#      #",
+        "#      #",
+        "#      #",
+        "########",
+    ],
+    {
+        tileWidth: TILE_WIDTH,
+        tileHeight: TILE_HEIGHT,
+        tiles: {
+            "#": () => [sprite("steel"), tile({ isObstacle: true })],
+        },
+    },
+);
+
+let turnCost = 0;
+let allowDiagonals = false;
+
+const bean = level.spawn(
+    [
+        sprite("bean"),
+        anchor("center"),
+        pos(32, 32),
+        tile(),
+        agent({ speed: 640, allowDiagonals, turnCost }),
+        "bean",
+    ],
+    1,
+    1,
+);
+
+onClick(() => {
+    const pos = mousePos();
+    bean.setTarget(
+        vec2(
+            Math.floor(pos.x / TILE_WIDTH) * TILE_WIDTH + TILE_WIDTH / 2,
+            Math.floor(pos.y / TILE_HEIGHT) * TILE_HEIGHT + TILE_HEIGHT / 2,
+        ),
+    );
+});
+
+onKeyPress("c", () => {
+    turnCost = turnCost === 5 ? 0 : 5;
+    bean.use(agent({ speed: 640, allowDiagonals, turnCost }));
+    debug.log(`turnCost set to ${turnCost}`);
+});
+
+onKeyPress("d", () => {
+    allowDiagonals = !allowDiagonals;
+    bean.use(agent({ speed: 640, allowDiagonals, turnCost }));
+    debug.log(`allowDiagonals set to ${allowDiagonals}`);
+});
+
+add([pos(0, 510), color(WHITE), text(`Press C to toggle "turnCost"`)]);
+add([pos(0, 550), color(WHITE), text(`Press D to toggle "allowDiagonals"`)]);

--- a/src/ecs/components/level/agent.ts
+++ b/src/ecs/components/level/agent.ts
@@ -13,6 +13,7 @@ import type { TileComp } from "./tile";
 export interface AgentComp extends Comp {
     agentSpeed: number;
     allowDiagonals: boolean;
+    turnCost: number;
     getDistanceToTarget(): number;
     getNextLocation(): Vec2 | null;
     getPath(): Vec2[] | null;
@@ -36,6 +37,7 @@ export interface AgentComp extends Comp {
 export type AgentCompOpt = {
     speed?: number;
     allowDiagonals?: boolean;
+    turnCost?: number;
 };
 
 export function agent(opts: AgentCompOpt = {}): AgentComp {
@@ -48,6 +50,7 @@ export function agent(opts: AgentCompOpt = {}): AgentComp {
         require: ["pos", "tile"],
         agentSpeed: opts.speed ?? 100,
         allowDiagonals: opts.allowDiagonals ?? true,
+        turnCost: opts.turnCost ?? 0,
         getDistanceToTarget(this: GameObj<AgentComp | PosComp>) {
             return target ? this.pos.dist(target) : 0;
         },
@@ -73,6 +76,7 @@ export function agent(opts: AgentCompOpt = {}): AgentComp {
             target = p;
             path = this.getLevel().getPath(this.pos, target, {
                 allowDiagonals: this.allowDiagonals,
+                turnCost: this.turnCost,
             });
             index = path ? 0 : null;
             if (path && index !== null) {


### PR DESCRIPTION
## Summary
Added `turnCost` option to pathfinding logic, allowing you to specify a penalty for direction changes when calculating paths.

Added pathfinding example

---

- [x] Changeloged
