### PR TITLE
fix(timer): use timeScale in loop/wait/tween

### DIFF
--- a/src/ecs/components/misc/timer.ts
+++ b/src/ecs/components/misc/timer.ts
@@ -102,7 +102,7 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
             let t: number = waitFirst ? 0 : time;
             let onEndEvents = new KEvent();
             const ev = this.onUpdate(() => {
-                t += _k.app.state.dt;
+                t += _k.app.dt();
                 for (let i = 0; t >= time && i < this.maxLoopsPerFrame; i++) {
                     count--;
                     action();
@@ -162,7 +162,7 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
 
             const onEndEvents: Array<() => void> = [];
             const ev = this.onUpdate(() => {
-                curTime += _k.app.state.dt;
+                curTime += _k.app.dt();
                 const t = Math.min(curTime / duration, 1);
                 setValue(lerp(from, to, easeFunc(t)));
                 if (t === 1) {


### PR DESCRIPTION
Timer's wait/loop/tween didn't take `k.debug.timeScale` into calculations. They were using `_k.app.state.dt` directly instead of `_k.app.dt()`. As far as I can see this seems the only place in the codebase to use dt property directly.

Here is [an example of the issue on current master](https://play.kaplayjs.com/?code=eJx1UsFuwjAMvfcrrG5CicZKi8SlFZym%2FQC7bZMIbRZFDQlqg2BD%2FffZbWFQmA%2BV%2Ffzy7LxmMoGlF5WvQYCVe1BiI4Pc2dpDCXMoxdaIb3YMAGMt8lJVbmeLFMKHuI0waHgW9Ce8PHg6FImiYO8hleEYS0pYmGB%2BhFr%2FyBSm8RiMtnK5Fbm2KoUkhoYTd%2BtqNsPuLOafPAiM9KCMWwvzVmmlZCULnPCcZG3H642sho3TMtS73Ibqbh3KGMpnnb5xOcojiOwYsTIq5HqnWt4SWy0eTc%2FK%2BPWVM6aXd%2FalEnvGOMwX0Dn1p%2FhEjMIznEUNciLqbVqRfgqPx24jxiPvXvVBFmzKmysVIp2LS9aHHXhDzAFEUtc%2BEekaaVbtdvoL2NDsBcQwGg2dRpT3d6X4cyTKhc2lOd23wedBhu6F9iwZw6VJt7%2F1jhEZCbTD72rcPIB%2FJH4B04LlYw%3D%3D&version=master).

And here is the result of same example on my fork:
<img width="1356" height="318" alt="Screenshot 2026-01-12 at 20 23 35" src="https://github.com/user-attachments/assets/8a750eb0-69da-4297-95b1-6b54a2fb24d0" />


## Summary

- Fixed `timer's` wait/loop/tween methods not taking `k.debug.timeScale` into calculations. 
