### PR TITLE
fix(health): added check if object was 'alive' before triggering on death event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ best friend, lajbel, can put the correct version name here
   single character (#1016) - @dragoncoder047
 - Fixed input events attached to paused ancestors not being paused (#1009) - @amyspark-ng, @dragoncoder047 
 - Fixed type `UniformValue` union not including `Texture`, a valid option (#1018) - @dragoncoder047 
+- Fixed `onDeath` event triggering even when object was already dead (#1014) - @Stanko
 
 ## [4000.0.0-alpha.26] - 2026-01-12
 

--- a/src/ecs/components/misc/health.ts
+++ b/src/ecs/components/misc/health.ts
@@ -80,7 +80,9 @@ export function health(
             else if (hp > origHP) {
                 (this as unknown as GameObj).trigger("heal", origHP - hp);
             }
-            if (hp <= 0) (this as unknown as GameObj).trigger("death");
+            if (hp <= 0 && origHP > 0) {
+                (this as unknown as GameObj).trigger("death");
+            }
         },
         get maxHP() {
             return maxHP as number;


### PR DESCRIPTION
`onDeath` event triggers even when object is already dead:

[example, alpha 26](https://play.kaplayjs.com/?code=eJyVUctKxDAU3fcrDsFFinU6HXAzUkFxIbhxb4WmTWjK1CQ0GXQs%2BXeTWp8ganfn3vPK7Y6ZgR3olCB8DWt33aj3im9BmiEgkvj0LEkGzfilYIpG0GplHZoAUYJxTu9msTVj7wQlcUHSbJ4Zbeljz52kKXJsMpyulw1TrdQjJa1QToxvfCnYEMhFmtzHpDzHBedwUsCJJ7ckD7r7EhxXtJYmDI%2BmmL6SxmfggvGPUUS%2BUmYU1oaqrA2WGlyjAH%2FoKlVnmGD7Z7HFZg3%2FU%2F9i%2Ff0BTpvYfu47J2l1JVhQBEl5jtfDhsqrWBPHJepKTQvH4y%2Bt6%2FAP3r2v96P7xTpSPP5hrdWNONzGy1Ayn4Zk%2BByxWOCkRBEEL4g0pOk%3D&version=4000.0.0-alpha.26)


## Summary

- Fixed, `onDeath` event would trigger even when object was already dead
