### PR TITLE
feat: add sound() component for game objects

### DIFF
--- a/examples/soundComponent.js
+++ b/examples/soundComponent.js
@@ -1,0 +1,200 @@
+/**
+ * @file Sound Component
+ * @description How to use the sound() component to attach audio to game objects with spatial audio
+ * @difficulty 0
+ * @tags basics, audio, component
+ * @minver 4000.0
+ * @category basics
+ * @test
+ */
+
+// Sound component demonstration - attach sounds to game objects
+
+kaplay({
+    backgroundAudio: true,
+    background: "2a2a3a",
+});
+
+// Load assets
+loadSound("bell", "/sounds/bell.mp3");
+loadMusic("OtherworldlyFoe", "/sounds/OtherworldlyFoe.mp3");
+loadSprite("bean", "/sprites/bean.png");
+loadSprite("bag", "/sprites/bag.png");
+
+// Global volume
+volume(0.7);
+
+// Instruction text
+add([
+    text(
+        `Sound Component Demo
+
+[click] spawn sound at mouse
+[space] toggle ambient sound
+[arrows] move bee for spatial audio
+
+Moving sounds auto-pan left/right
+and fade with distance!`,
+        { size: 16 },
+    ),
+    pos(10, 10),
+    color(WHITE),
+]);
+
+// ========================================
+// Example 1: Ambient looping sound attached to object
+// ========================================
+const ambient = add([
+    pos(center()),
+    circle(30),
+    color(YELLOW),
+    // Attach a looping ambient sound that auto-plays
+    sound("OtherworldlyFoe", {
+        loop: true,
+        autoPlay: true,
+        volume: 0.3,
+    }),
+]);
+
+// Toggle ambient sound with space
+onKeyPress("space", () => {
+    ambient.soundPaused = !ambient.soundPaused;
+});
+
+// Status indicator for ambient
+const ambientStatus = add([
+    text("Ambient: Playing", { size: 14 }),
+    pos(10, height() - 30),
+    color(GREEN),
+]);
+
+onUpdate(() => {
+    ambientStatus.text = `Ambient: ${
+        ambient.soundPaused ? "Paused" : "Playing"
+    }`;
+    ambientStatus.color = ambient.soundPaused ? RED : GREEN;
+});
+
+// ========================================
+// Example 2: Spatial audio on a moving object
+// ========================================
+const bee = add([
+    sprite("bean"),
+    pos(center()),
+    anchor("center"),
+    // Spatial sound: pans left/right based on screen position
+    // Volume decreases with distance from center
+    sound("OtherworldlyFoe", {
+        loop: true,
+        autoPlay: true,
+        volume: 0.5,
+        speed: 1.5, // Higher pitch for bee-like sound
+        spatial: true, // Enable spatial audio!
+    }),
+]);
+
+// Move the bee with arrow keys
+const moveSpeed = 200;
+onKeyDown("left", () => bee.pos.x -= moveSpeed * dt());
+onKeyDown("right", () => bee.pos.x += moveSpeed * dt());
+onKeyDown("up", () => bee.pos.y -= moveSpeed * dt());
+onKeyDown("down", () => bee.pos.y += moveSpeed * dt());
+
+// Show spatial audio indicator
+add([
+    text("Move with arrows!", { size: 12 }),
+    pos(() => bee.pos.add(0, 40)),
+    anchor("center"),
+    color(WHITE),
+]);
+
+// ========================================
+// Example 3: One-shot sounds on click
+// ========================================
+onClick(() => {
+    const sfx = add([
+        pos(mousePos()),
+        circle(10),
+        color(CYAN),
+        lifespan(1, { fade: 0.5 }),
+        // Spatial one-shot sound
+        sound("bell", {
+            spatial: true,
+            autoPlay: true,
+        }),
+    ]);
+
+    // Clean up when sound ends (redundant with lifespan but demonstrates the event)
+    sfx.onSoundEnd(() => {
+        debug.log("Sound ended at " + sfx.pos);
+    });
+});
+
+// For mobile
+onTouchStart((pos) => {
+    add([
+        pos(pos),
+        circle(10),
+        color(CYAN),
+        lifespan(1, { fade: 0.5 }),
+        sound("bell", { spatial: true, autoPlay: true }),
+    ]);
+});
+
+// ========================================
+// Example 4: Manual sound control
+// ========================================
+const manualSfx = add([
+    pos(width() - 100, 100),
+    sprite("bag"),
+    anchor("center"),
+    rotate(0),
+    // Sound that doesn't auto-play
+    sound("bell", {
+        loop: true,
+        volume: 0.4,
+        spatial: true,
+    }),
+]);
+
+// Click on the bag to toggle sound
+manualSfx.onClick(() => {
+    if (manualSfx.soundPaused) {
+        manualSfx.playSound();
+    }
+    else {
+        manualSfx.stopSound();
+    }
+});
+
+// Rotate when playing
+manualSfx.onUpdate(() => {
+    if (!manualSfx.soundPaused) {
+        manualSfx.angle += dt() * 100;
+    }
+});
+
+add([
+    text("Click bag\nto toggle", { size: 12, align: "center" }),
+    pos(manualSfx.pos.add(0, 60)),
+    anchor("center"),
+    color(WHITE),
+]);
+
+// Draw center reference for spatial audio
+onDraw(() => {
+    // Draw center crosshair
+    const c = center();
+    drawLine({
+        p1: vec2(c.x - 20, c.y),
+        p2: vec2(c.x + 20, c.y),
+        color: rgb(100, 100, 100),
+        width: 1,
+    });
+    drawLine({
+        p1: vec2(c.x, c.y - 20),
+        p2: vec2(c.x, c.y + 20),
+        color: rgb(100, 100, 100),
+        width: 1,
+    });
+});

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -62,6 +62,7 @@ import { fakeMouse } from "../ecs/components/misc/fakeMouse";
 import { health } from "../ecs/components/misc/health";
 import { lifespan } from "../ecs/components/misc/lifespan";
 import { named } from "../ecs/components/misc/named";
+import { sound } from "../ecs/components/misc/sound";
 import { state } from "../ecs/components/misc/state";
 import { stay } from "../ecs/components/misc/stay";
 import { textInput } from "../ecs/components/misc/textInput";
@@ -401,6 +402,7 @@ export const createContext = (
         shader,
         textInput,
         timer,
+        sound,
         fixed,
         stay,
         health,

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -67,6 +67,7 @@ import type {
 import type { HealthComp } from "../ecs/components/misc/health";
 import type { LifespanCompOpt } from "../ecs/components/misc/lifespan";
 import type { NamedComp } from "../ecs/components/misc/named";
+import type { SoundComp, SoundCompOpt } from "../ecs/components/misc/sound";
 import type { StateComp } from "../ecs/components/misc/state";
 import type { StayComp } from "../ecs/components/misc/stay";
 import type { TextInputComp } from "../ecs/components/misc/textInput";
@@ -1463,6 +1464,43 @@ export interface KAPLAYCtx {
      * @subgroup Behaviour
      */
     timer(maxLoopsPerFrame?: number): TimerComp;
+    /**
+     * Attach a sound to a game object with optional spatial audio.
+     *
+     * @param src - The sound source name (loaded via `loadSound`).
+     * @param opt - Sound component options.
+     *
+     * @example
+     * ```js
+     * // Basic usage - auto-playing looping sound
+     * const enemy = add([
+     *     sprite("enemy"),
+     *     pos(100, 100),
+     *     sound("enemy_hum", { loop: true, autoPlay: true }),
+     * ]);
+     *
+     * // Spatial audio - pans left/right, quieter when far from center
+     * const bee = add([
+     *     sprite("bee"),
+     *     pos(200, 300),
+     *     sound("buzz", { loop: true, spatial: true, autoPlay: true }),
+     * ]);
+     *
+     * // Manual control
+     * const sfx = add([
+     *     pos(mousePos()),
+     *     sound("explosion", { spatial: true }),
+     * ]);
+     * sfx.playSound();
+     * sfx.onSoundEnd(() => sfx.destroy());
+     * ```
+     *
+     * @returns The sound comp.
+     * @since v4000.0
+     * @group Components
+     * @subgroup Behaviour
+     */
+    sound(src: string, opt?: SoundCompOpt): SoundComp;
     /**
      * Make a game obj unaffected by camera or parent object transforms, and render at last.
      * Useful for UI elements.

--- a/src/ecs/components/misc/sound.ts
+++ b/src/ecs/components/misc/sound.ts
@@ -1,0 +1,352 @@
+import { type AudioPlay, type AudioPlayOpt, play } from "../../../audio/play";
+import { KEvent, type KEventController } from "../../../events/events";
+import { center, height, width } from "../../../gfx/stack";
+import { clamp } from "../../../math/clamp";
+import type { Comp, GameObj } from "../../../types";
+import type { PosComp } from "../transform/pos";
+
+/**
+ * Options for the {@link sound `sound()`} component.
+ *
+ * @group Components
+ * @subgroup Component Options
+ */
+export interface SoundCompOpt {
+    /**
+     * Play automatically when added to game object.
+     *
+     * @default false
+     */
+    autoPlay?: boolean;
+    /**
+     * Loop when finished.
+     *
+     * @default false
+     */
+    loop?: boolean;
+    /**
+     * Base volume (0-1).
+     *
+     * @default 1
+     */
+    volume?: number;
+    /**
+     * Playback speed.
+     *
+     * @default 1
+     */
+    speed?: number;
+    /**
+     * Detune in cents.
+     *
+     * @default 0
+     */
+    detune?: number;
+    /**
+     * Enable spatial audio (pan based on screen x, volume based on distance from center).
+     *
+     * @default false
+     */
+    spatial?: boolean;
+    /**
+     * Max distance for volume falloff in spatial audio.
+     * Defaults to half the screen diagonal.
+     */
+    maxDistance?: number;
+    /**
+     * Start paused.
+     *
+     * @default false
+     */
+    paused?: boolean;
+}
+
+/**
+ * The {@link sound `sound()`} component.
+ *
+ * @group Components
+ * @subgroup Component Types
+ */
+export interface SoundComp extends Comp {
+    /**
+     * The sound source name.
+     */
+    readonly sound: string;
+    /**
+     * Play the sound from the start or from a specific time.
+     *
+     * @param time - The time to start playing from (in seconds).
+     */
+    playSound(time?: number): void;
+    /**
+     * Stop the sound.
+     */
+    stopSound(): void;
+    /**
+     * Pause the sound.
+     */
+    pauseSound(): void;
+    /**
+     * Resume the sound.
+     */
+    resumeSound(): void;
+    /**
+     * Whether the sound is paused.
+     */
+    soundPaused: boolean;
+    /**
+     * Base volume (0-1). This is the volume before spatial audio adjustments.
+     */
+    volume: number;
+    /**
+     * Playback speed.
+     */
+    soundSpeed: number;
+    /**
+     * Detune in cents.
+     */
+    soundDetune: number;
+    /**
+     * Whether the sound loops.
+     */
+    soundLoop: boolean;
+    /**
+     * Whether spatial audio is enabled.
+     */
+    spatial: boolean;
+    /**
+     * Get the current playback time.
+     */
+    soundTime(): number;
+    /**
+     * Get the total duration of the sound.
+     */
+    soundDuration(): number;
+    /**
+     * Seek to a specific time.
+     *
+     * @param time - The time to seek to (in seconds).
+     */
+    seekSound(time: number): void;
+    /**
+     * Register an event handler that runs when the sound ends.
+     */
+    onSoundEnd(action: () => void): KEventController;
+    /**
+     * Get the underlying AudioPlay instance.
+     */
+    getAudioPlay(): AudioPlay | null;
+}
+
+/**
+ * Attach a sound to a game object with optional spatial audio.
+ *
+ * @param src - The sound source name (loaded via `loadSound`).
+ * @param opt - Sound component options.
+ *
+ * @returns The sound component.
+ * @group Components
+ */
+export function sound(src: string, opt: SoundCompOpt = {}): SoundComp {
+    let audioPlay: AudioPlay | null = null;
+    let baseVolume = opt.volume ?? 1;
+    let spatialEnabled = opt.spatial ?? false;
+    let maxDistance = opt.maxDistance;
+    let isDestroyed = false;
+    const onEndEvents = new KEvent();
+
+    // Calculate default max distance (half screen diagonal)
+    const getMaxDistance = (): number => {
+        if (maxDistance !== undefined) return maxDistance;
+        const w = width();
+        const h = height();
+        return Math.sqrt(w * w + h * h) / 2;
+    };
+
+    const updateSpatialAudio = (obj: GameObj<SoundComp & PosComp>) => {
+        if (!audioPlay || !spatialEnabled) return;
+
+        // Get the screen position of the object
+        const screenPos = obj.screenPos;
+        if (!screenPos) return;
+
+        const c = center();
+        const w = width();
+
+        // Calculate pan: -1 (left) to 1 (right)
+        const pan = clamp((screenPos.x - c.x) / (w / 2), -1, 1);
+
+        // Calculate distance from center for volume falloff
+        const dx = screenPos.x - c.x;
+        const dy = screenPos.y - c.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        const maxDist = getMaxDistance();
+        const volumeMultiplier = clamp(1 - distance / maxDist, 0, 1);
+
+        // Apply spatial adjustments
+        audioPlay.pan = pan;
+        audioPlay.volume = baseVolume * volumeMultiplier;
+    };
+
+    return {
+        id: "sound",
+
+        get sound(): string {
+            return src;
+        },
+
+        add(this: GameObj<SoundComp & PosComp>) {
+            const playOpt: AudioPlayOpt = {
+                loop: opt.loop ?? false,
+                volume: baseVolume,
+                speed: opt.speed ?? 1,
+                detune: opt.detune ?? 0,
+                paused: opt.paused ?? !opt.autoPlay,
+            };
+
+            audioPlay = play(src, playOpt);
+
+            // Forward end events
+            audioPlay.onEnd(() => {
+                if (!isDestroyed) {
+                    onEndEvents.trigger();
+                }
+            });
+
+            // Apply initial spatial audio if enabled
+            if (spatialEnabled && this.screenPos) {
+                updateSpatialAudio(this);
+            }
+        },
+
+        update(this: GameObj<SoundComp & PosComp>) {
+            if (spatialEnabled && audioPlay && !audioPlay.paused) {
+                updateSpatialAudio(this);
+            }
+        },
+
+        destroy() {
+            isDestroyed = true;
+            if (audioPlay) {
+                audioPlay.stop();
+                audioPlay = null;
+            }
+        },
+
+        playSound(time?: number) {
+            if (audioPlay) {
+                audioPlay.play(time);
+            }
+        },
+
+        stopSound() {
+            if (audioPlay) {
+                audioPlay.stop();
+            }
+        },
+
+        pauseSound() {
+            if (audioPlay) {
+                audioPlay.paused = true;
+            }
+        },
+
+        resumeSound() {
+            if (audioPlay) {
+                audioPlay.paused = false;
+            }
+        },
+
+        get soundPaused(): boolean {
+            return audioPlay?.paused ?? true;
+        },
+
+        set soundPaused(p: boolean) {
+            if (audioPlay) {
+                audioPlay.paused = p;
+            }
+        },
+
+        get volume(): number {
+            return baseVolume;
+        },
+
+        set volume(v: number) {
+            baseVolume = v;
+            if (audioPlay && !spatialEnabled) {
+                audioPlay.volume = v;
+            }
+        },
+
+        get soundSpeed(): number {
+            return audioPlay?.speed ?? 1;
+        },
+
+        set soundSpeed(s: number) {
+            if (audioPlay) {
+                audioPlay.speed = s;
+            }
+        },
+
+        get soundDetune(): number {
+            return audioPlay?.detune ?? 0;
+        },
+
+        set soundDetune(d: number) {
+            if (audioPlay) {
+                audioPlay.detune = d;
+            }
+        },
+
+        get soundLoop(): boolean {
+            return audioPlay?.loop ?? false;
+        },
+
+        set soundLoop(l: boolean) {
+            if (audioPlay) {
+                audioPlay.loop = l;
+            }
+        },
+
+        get spatial(): boolean {
+            return spatialEnabled;
+        },
+
+        set spatial(s: boolean) {
+            spatialEnabled = s;
+            if (!s && audioPlay) {
+                // Reset to base volume and center pan when disabling spatial
+                audioPlay.volume = baseVolume;
+                audioPlay.pan = 0;
+            }
+        },
+
+        soundTime(): number {
+            return audioPlay?.time() ?? 0;
+        },
+
+        soundDuration(): number {
+            return audioPlay?.duration() ?? 0;
+        },
+
+        seekSound(time: number) {
+            if (audioPlay) {
+                audioPlay.seek(time);
+            }
+        },
+
+        onSoundEnd(action: () => void): KEventController {
+            return onEndEvents.add(action);
+        },
+
+        getAudioPlay(): AudioPlay | null {
+            return audioPlay;
+        },
+
+        inspect() {
+            const paused = audioPlay?.paused ? " (paused)" : "";
+            const spatial = spatialEnabled ? " [spatial]" : "";
+            return `sound: "${src}"${paused}${spatial}`;
+        },
+    };
+}

--- a/tests/auto/sound.spec.ts
+++ b/tests/auto/sound.spec.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, test } from "vitest";
+
+describe("Sound Component", async () => {
+    beforeAll(async () => {
+        await page.addScriptTag({ path: "dist/kaplay.js" });
+    });
+
+    test(
+        "sound() component should be available on context",
+        async () => {
+            const hasSound = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                return typeof k.sound === "function";
+            });
+
+            expect(hasSound).toBe(true);
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should have correct id",
+        async () => {
+            const compId = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("test");
+                return comp.id;
+            });
+
+            expect(compId).toBe("sound");
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should expose the sound source name",
+        async () => {
+            const soundName = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("mySoundFile");
+                return comp.sound;
+            });
+
+            expect(soundName).toBe("mySoundFile");
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should have default properties",
+        async () => {
+            const defaults = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("test");
+                return {
+                    volume: comp.volume,
+                    spatial: comp.spatial,
+                };
+            });
+
+            expect(defaults.volume).toBe(1);
+            expect(defaults.spatial).toBe(false);
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should accept options",
+        async () => {
+            const opts = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("test", {
+                    volume: 0.5,
+                    spatial: true,
+                    loop: true,
+                });
+                return {
+                    volume: comp.volume,
+                    spatial: comp.spatial,
+                };
+            });
+
+            expect(opts.volume).toBe(0.5);
+            expect(opts.spatial).toBe(true);
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should allow changing volume",
+        async () => {
+            const newVolume = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("test", { volume: 1 });
+                comp.volume = 0.3;
+                return comp.volume;
+            });
+
+            expect(newVolume).toBe(0.3);
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should allow toggling spatial",
+        async () => {
+            const spatialState = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("test", { spatial: false });
+                comp.spatial = true;
+                return comp.spatial;
+            });
+
+            expect(spatialState).toBe(true);
+        },
+        20000,
+    );
+
+    test(
+        "sound() component should have inspect method",
+        async () => {
+            const inspectResult = await page.evaluate(() => {
+                const k = kaplay({ global: false });
+                const comp = k.sound("mySound");
+                return comp.inspect ? comp.inspect() : null;
+            });
+
+            expect(inspectResult).toContain("mySound");
+        },
+        20000,
+    );
+});


### PR DESCRIPTION
## Summary

- Add new `sound()` component that attaches audio to game objects
- Automatic cleanup when objects are destroyed
- Spatial audio support (pan based on screen x, volume based on distance from center)
- Methods: `playSound()`, `stopSound()`, `pauseSound()`, `resumeSound()`, `seekSound()`, `soundTime()`, `soundDuration()`, `onSoundEnd()`, `getAudioPlay()`
- Properties: `volume`, `soundSpeed`, `soundDetune`, `soundLoop`, `spatial`

## Usage

```js
// Basic usage - auto-playing looping sound
const enemy = add([
    sprite("enemy"),
    pos(100, 100),
    sound("enemy_hum", { loop: true, autoPlay: true }),
]);

// Spatial audio - pans left/right, quieter when far from center
const bee = add([
    sprite("bee"),
    pos(200, 300),
    sound("buzz", { loop: true, spatial: true, autoPlay: true }),
]);

// Manual control
const sfx = add([
    pos(mousePos()),
    sound("explosion", { spatial: true }),
]);
sfx.playSound();
sfx.onSoundEnd(() => sfx.destroy());
```

## Test plan

- [x] Unit tests added (`tests/auto/sound.spec.ts`)
- [x] Example added (`examples/soundComponent.js`)
- [x] Type checking passes (`pnpm check`)
- [x] Build succeeds (`pnpm build`)
- [x] All tests pass (`pnpm test:vite`)

Closes #1030

🤖 Generated with [Claude Code](https://claude.ai/code)