### PR TITLE
fix: account for tilePos.x getting out of the level boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ So your change should look like
   `drawSprite` (#1026) - @benhuangbmj
 - Fixed `onClick()` and `onCollide()` tag variants no longer working -
   @mflerackers
+- Fixed `levelComp.getAt` to account for `tilePos.x` getting outside of the
+  level boundary - @benhuangbmj
 
 ## [4000.0.0-alpha.26] - 2026-01-12
 

--- a/src/ecs/components/level/level.ts
+++ b/src/ecs/components/level/level.ts
@@ -476,6 +476,7 @@ export function level(map: string[], opt: LevelCompOpt): LevelComp {
             if (!spatialMap) {
                 createSpatialMap(this);
             }
+            if (tilePos.x >= numColumns) return [];
             const hash = tile2Hash(tilePos);
             return spatialMap![hash] || [];
         },

--- a/src/ecs/components/level/level.ts
+++ b/src/ecs/components/level/level.ts
@@ -476,7 +476,7 @@ export function level(map: string[], opt: LevelCompOpt): LevelComp {
             if (!spatialMap) {
                 createSpatialMap(this);
             }
-            if (tilePos.x >= numColumns) return [];
+            if (tilePos.x >= numColumns || tilePos.x < 0) return [];
             const hash = tile2Hash(tilePos);
             return spatialMap![hash] || [];
         },


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.
`levelComp.getAt` returns incorrect results when `tilePos.x` is beyond the scope of the level. 
## Summary
  When the `tilePos` is beyond the scope of the level, the `getAt` method should return an empty array. The `tile2Hash` function already accounts for `tilePos.y` getting outside of the level. However, it doesn't work for `tilePos.x` properly. I added a simple check in the `getAt` method without touching any other part of the code to avoid unexpected breaking behavior.
- [x] Changeloged
