### PR TITLE
fix: broadphase event duplication on scene switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ So your change should look like:
 - Added `exists()` which also checks whether the object is not undefined. This
   should temporarily fix the problem with undefined objects during collision due
   to iterators being invalidated by destroy. - @mflerackers
+- Fixed broadphase event duplication on scene switch, causing repeated
+  broadphase object registrations, which resulted in a performance drop -
+  @imaginarny, @mflerackers
 
 ## [4000.0.0-alpha.27] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ So your change should look like:
   should temporarily fix the problem with undefined objects during collision due
   to iterators being invalidated by destroy. - @mflerackers
 - Fixed broadphase event duplication on scene switch, causing repeated
-  broadphase object registrations, which resulted in a performance drop -
-  @imaginarny, @mflerackers
+  broadphase object registrations, which resulted in a performance drop (#1074)
+  - @imaginarny, @mflerackers
 
 ## [4000.0.0-alpha.27] - 2026-03-19
 

--- a/src/ecs/systems/createCollisionSystem.ts
+++ b/src/ecs/systems/createCollisionSystem.ts
@@ -105,7 +105,6 @@ export const createCollisionSystem = (
             });
 
             _k.appScope.onSceneLeave(scene => {
-                broadInit = false;
                 broadPhaseIntersection.clear();
             });
 

--- a/tests/playtests/sceneSwitchPerf.js
+++ b/tests/playtests/sceneSwitchPerf.js
@@ -1,0 +1,68 @@
+kaplay({
+    background: "#4a3052",
+    font: "happy-o",
+    logMax: 1,
+    broadPhaseCollisionAlgorithm: "sap",
+    narrowPhaseCollisionAlgorithm: "gjk",
+});
+
+loadBitmapFont("happy-o", "/crew/happy-o.png", 36, 45);
+loadBean();
+
+// Try to find the highest number of colliding objects your PC can handles at
+// your stable monitor refresh rate for the best FPS drop observation
+const OBJ_COUNT = 320;
+
+const cols = Math.ceil(Math.sqrt(OBJ_COUNT));
+const rows = Math.ceil(OBJ_COUNT / cols);
+
+let switchCount = 0;
+
+scene("game", async () => {
+    const { width: w, height: h } = getSprite("bean").data;
+
+    let i = 0;
+    for (let y = 0; y < rows; y++) {
+        for (let x = 0; x < cols; x++) {
+            if (i++ >= OBJ_COUNT) break;
+
+            add([
+                sprite("bean"),
+                pos(
+                    center()
+                        .sub((cols * w) / 2, (rows * h) / 2)
+                        .add(x * w, y * h),
+                ),
+                area({ isSensor: true }),
+            ]);
+        }
+    }
+
+    debug.log(
+        "\n" + [
+            `Objects: ${get("*").length}`,
+            `Scene: ${++switchCount}`,
+            "Switch in..",
+        ].join("\n"),
+    );
+
+    let countDown = 7;
+
+    loop(1, () => {
+        if (!--countDown) go("game");
+        if (countDown < 4) debug.log(countDown);
+    }, countDown);
+
+    add([{
+        draw() {
+            drawText({
+                text: debug.fps().toFixed(),
+                size: 120,
+                pos: center(),
+                anchor: "center",
+            });
+        },
+    }]);
+});
+
+onLoad(() => go("game"));


### PR DESCRIPTION
Broadphase events are re-registered on a scene switch.

PR fixes a huge performance drop on scene switching, most noticeable either immediately when having a number of objects you can still handle at your refresh rate, or after n switches where broadphase events would double gradually to a sudden drop in performance. E.g. a few tries playing the flappy example, depending on your device performance. Or, a scene with ~35 objects would be substantially noticeable after ~15th switch, but a scene with 400 objects would become 10 FPS in a single scene switch.

The issue is that broadphase event listeners are re-registered on each scene switch, causing repeated object registrations. Previously the scope on which events were registered would be cleared on a scene switch, but since #977 the app scope and scene scope are separated and only scene events are cleared. So there is no need to re-register them on a scene switch, which is the cause of the issue. It was a simple fix to make it only register them once on the app scope creation.

Including the same example as in PR playtest on KAPLAYGROUND: 
[https://play.kaplayjs.com/?code=eJx1VF1v2jAUf...&version=4000.0.0-alpha.27](https://play.kaplayjs.com/?code=eJx1VF1v2jAUfedX3GV7cEoaWtpuEv2QVqY%2BTOtaie5pq1YnMbFLsDPbLDCU%2F75rhxIo1A%2FEOT73w%2BceMqFlQRdk2QFcCU0nuVYzmQ0geH9KT47O%2BkHkj8ZKWgQ5LcvFoVqBhcpv6XwAx81rrweJVjS759SwoSoKYYSSn4tcaWH5FMMNLYM1V1KtVfU2OX%2BeILkOzzudArNeCzul5Q32Qdo2IOilmlW9FRCXMkfw5GMEp2cY6OMYlcQlwZIPegFWwVjIDCxnwEXOmbEgZ9OEaVBjSF0nmZA5qOSZpdbAQs003A8hpRI4lVnBDFDrsvkTY2lSMJgqKazSoNlYM8NBU8tQNO3LJK7Gzf0IMq1KTGyY%2FkstXreTKolHd9dffw%2Fvfnx%2FgEs46R9hrw2OzRiEbqnlccpEQfzO%2FNGWrENCvFrDRjG32W3ank%2FllWQWTCVsyoc4Z4t8V86kTDIS5HTKUD5qFjIFEsLlFTTGaAosoRKZ5QOoIuAMpUNHcKgxR87sqMS5YY4E5Q7COKOWYmLvEiwpmkKNkzQQhy08ho8L3zruut1wVXCLOG%2BIcyS6a%2BBum%2BiWGAMR3S5cXbZqhmhHRierNl4WzTLycwtxy2y1H%2B2cl8oQFMkyTcKdQ7diM0sI8RM7gCpEyfsRED%2BTA%2BD%2B%2FY1A19DcBUWohePu0Pb0Q%2FFmZAnCjJg0Sg%2FA6hmD%2BhXzMTxfv9ed5tc%2FMpbM8hj%2FvyT4JQPoQqvI011j%2FAF8WOJcSXCA4yyYzC2vn9r0TyPnGUfqdjcMtUkJRh4HIeM48Ohj%2FKyE9DWdb9f2SF3oF1VJnPSnF1ypkhxHWz50y0363eHhOiSEXK2su3Fbx2qzXsBpuHHnNrYJqCPYhDzmbdJWzTStyGvTOfCBzS1Z7szHIjxYlRyXhoSxVTdizjKyZ5hG%2FEMlj%2FtHe303gBfj7bGBTLmbftBQgm1GvTn%2B5qh%2BDJtPqpLf8ONIGnVbBfHoP2tfnIo%3D&version=4000.0.0-alpha.27)

Change the `OBJ_COUNT` if it's too demanding for you or let it run switching the scene for a while to see the huge FPS drop. It could make your whole tab unresponsive so remember you can stop it from the navbar or `CTRL+ALT+S`. 

With the fix you will maintain your FPS, test in `tests/playtests/sceneSwitchPerf.js`.

- [x] Changeloged
