### PR TITLE
fix: broadphase objects with stay cleared on scene switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ So your change should look like:
 - Fixed broadphase event duplication on scene switch, causing repeated
   broadphase object registrations, which resulted in a performance drop (#1074)
   - @imaginarny, @mflerackers
+- Fixed broadphase objects cleared on scene switch including those with `stay()`
+  (#1077) - @imaginarny, @mflerackers
 
 ## [4000.0.0-alpha.27] - 2026-03-19
 

--- a/src/ecs/systems/createCollisionSystem.ts
+++ b/src/ecs/systems/createCollisionSystem.ts
@@ -104,10 +104,6 @@ export const createCollisionSystem = (
                 }
             });
 
-            _k.appScope.onSceneLeave(scene => {
-                broadPhaseIntersection.clear();
-            });
-
             for (const obj of _k.game.root.get("*", { recursive: true })) {
                 if (obj.has("area")) {
                     broadPhaseIntersection.add(obj as GameObj<AreaComp>);

--- a/tests/playtests/sceneSwitchPerfStay.js
+++ b/tests/playtests/sceneSwitchPerfStay.js
@@ -1,0 +1,76 @@
+kaplay({
+    background: "#4a3052",
+    font: "happy-o",
+    logMax: 1,
+    broadPhaseCollisionAlgorithm: "sap",
+    narrowPhaseCollisionAlgorithm: "gjk",
+});
+
+loadBitmapFont("happy-o", "/crew/happy-o.png", 36, 45);
+loadBean();
+
+// Try to find the highest number of colliding objects your PC can handles at
+// your stable monitor refresh rate for the best FPS drop observation
+const OBJ_COUNT = 320;
+
+const cols = Math.ceil(Math.sqrt(OBJ_COUNT));
+const rows = Math.ceil(OBJ_COUNT / cols);
+
+let switchCount = 0;
+
+scene("game", async () => {
+    const { width: w, height: h } = getSprite("bean").data;
+
+    if (switchCount == 0) {
+        let i = 0;
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                if (i++ >= OBJ_COUNT) break;
+
+                add([
+                    sprite("bean"),
+                    pos(
+                        center()
+                            .sub((cols * w) / 2, (rows * h) / 2)
+                            .add(x * w, y * h),
+                    ),
+                    area({ isSensor: true }),
+                    stay(),
+                    {
+                        add() {
+                            this.onClick(() => debug.log(this.id, "clicked"));
+                        },
+                    },
+                ]);
+            }
+        }
+    }
+
+    debug.log(
+        "\n" + [
+            `Objects with stay: ${get("*").length}`,
+            `Scene: ${++switchCount}`,
+            "Switch in..",
+        ].join("\n"),
+    );
+
+    let countDown = 7;
+
+    loop(1, () => {
+        if (!--countDown) go("game");
+        if (countDown < 4) debug.log(countDown);
+    }, countDown);
+
+    add([{
+        draw() {
+            drawText({
+                text: debug.fps().toFixed(),
+                size: 120,
+                pos: center(),
+                anchor: "center",
+            });
+        },
+    }]);
+});
+
+onLoad(() => go("game"));


### PR DESCRIPTION
Turns out that onSceneLeave has to be removed completely from broadphase and its objects can't be cleared there since there are also objects with stay(). Addition to #1074.

- [x] Changeloged
