### PR TITLE
make TimerController.timeLeft return remaining time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking changes are marked with: **(!)**.
 - [Jump to v3001 changelog](#changelog-for-v3001).
 
-<!-- [CHANGELOG GUIDELINES PLEASE FOLLOW]
-===============================================================================
+# <!-- [CHANGELOG GUIDELINES PLEASE FOLLOW]
+
 Hey, KAPLAY Dev! Add your new changes in [unreleased] heading, below one of
 these heading:
 
@@ -34,9 +34,8 @@ So your change should look like:
 
 ### Added
 
-- added a new ghost (#6767) - @lajbel
-===============================================================================
-[DO IT IF YOU DON'T WANT A LAJBEL VISIT AT NIGHT] -->
+- # added a new ghost (#6767) - @lajbel
+  [DO IT IF YOU DON'T WANT A LAJBEL VISIT AT NIGHT] -->
 
 ## [unreleased]
 
@@ -64,6 +63,8 @@ So your change should look like:
   (#1074) - @imaginarny, @mflerackers
 - Fixed broadphase objects cleared on scene switch including those with `stay()`
   (#1077) - @imaginarny, @mflerackers
+- Fixed `TimerController.timeLeft` returning elapsed time instead of remaining
+  time (#1082) - @nojaf
 
 ### Added
 

--- a/src/ecs/components/misc/timer.ts
+++ b/src/ecs/components/misc/timer.ts
@@ -116,10 +116,10 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
             });
             return {
                 get timeLeft() {
-                    return t;
+                    return time - t;
                 },
                 set timeLeft(val: number) {
-                    t = val;
+                    t = time - val;
                 },
                 get paused() {
                     return ev.paused;


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

`timeLeft` is returning elapsed I believe, so I return the delta instead.

Fixes https://github.com/kaplayjs/kaplay/issues/1081

## Summary

- [x] Changeloged
