### PR TITLE
fix: refresh packer for direct referenced sprites resolving

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+allowBuilds:
+  dprint: true
+  esbuild: true
+  puppeteer: true
 overrides:
   axios@>=1.0.0 <1.15.0: '>=1.15.0'
   basic-ftp@<=5.2.1: '>=5.2.2'

--- a/src/assets/sprite.ts
+++ b/src/assets/sprite.ts
@@ -243,6 +243,9 @@ export function resolveSprite(
     //     return Asset.loaded(src);
     // }
     else if (src instanceof Asset) {
+        // might be sometimes unnecessary here but if we're getting the sprite data directly
+        // then obviously we might be wanting to draw it.
+        _k.k.onLoad(() => _k.assets.packer.syncIfPending());
         return src;
     }
     else {

--- a/src/gfx/TexPacker.ts
+++ b/src/gfx/TexPacker.ts
@@ -264,7 +264,7 @@ export class TexPacker {
         packer._used.set(-1, {
             rect: new Rect(new Vec2(width - 1, height - 1), 1, 1),
             tex: tex,
-            used: 0,
+            used: UsedCorner.BOTTOMLEFT | UsedCorner.TOPRIGHT, // it's bottom right so nothing can go right or below it
         });
         return {
             tex,

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -230,6 +230,7 @@ function updateFontAtlas(font: FontData | string, ch: string) {
         const img = c2d.getImageData(0, 0, w, h);
 
         atlas.font.map[ch] = _k.assets.packer.add(img, atlas.font.filter);
+        _k.assets.packer.syncIfPending();
 
         atlas.maxHeight = Math.max(atlas.maxHeight, h);
     }
@@ -471,8 +472,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         }
         th += thisLineHeight;
     }
-
-    _k.assets.packer.syncIfPending();
 
     return {
         width: tw,

--- a/tests/auto/texturesync.spec.ts
+++ b/tests/auto/texturesync.spec.ts
@@ -1,0 +1,33 @@
+import { beforeAll, describe, expect, test } from "vitest";
+
+describe("Components validation in add()", async () => {
+    beforeAll(async () => {
+        await page.addScriptTag({ path: "dist/kaplay.js" });
+    });
+
+    test(
+        "direct sprite referencing should force a texture flush",
+        async () => {
+            async function fn() {
+                return page.evaluate(() => {
+                    const k = kaplay();
+                    return new Promise(resolve => {
+                        // hacky since we can't use spyOn mocking
+                        var called = false;
+                        k._k.assets.packer.syncIfPending = function() {
+                            called = true;
+                        };
+
+                        const bean = k.loadBean();
+                        k.add([k.sprite(bean)]);
+
+                        k.onLoad(() => resolve(called));
+                    });
+                });
+            }
+
+            await expect(fn()).resolves.toBeTruthy();
+        },
+        20000,
+    );
+});


### PR DESCRIPTION
also some trivial optimizations


this is so trivial it probably doesn't even need changelog since it was fine in a27 so the bug will be fixed by the next release if this is merged before then