### PR TITLE
fix: button release on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ So your change should look like:
   by CSS and wasn't rendered at its natural size (#1096) - @Stanko
 - Modified `pos`, `skew` and `scale` components to make operations like
   `obj.pos.x += 1` work again (#1109) - @ErikGXDev
+- Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus (#1101) - @Stanko
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@ So your change should look like:
   by CSS and wasn't rendered at its natural size (#1096) - @Stanko
 - Modified `pos`, `skew` and `scale` components to make operations like
   `obj.pos.x += 1` work again (#1109) - @ErikGXDev
-- Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus (#1101) - @Stanko
+- Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus
+  (#1101) - @Stanko
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -89,6 +89,11 @@ export class ButtonState<T = string, A = never> {
             state.events.trigger(this._releaseEv as any, btn, this._arg);
         }
     }
+    releaseAll(state: AppState) {
+        for (const btn of this.down) {
+            this.release(btn, state);
+        }
+    }
 }
 
 class GamepadState {
@@ -978,7 +983,38 @@ export const initApp = (
     const docEvents: EventList<DocumentEventMap> = {};
     const winEvents: EventList<WindowEventMap> = {};
 
+    let releaseHeldInputsQueued = false;
+
+    function releaseHeldInputs() {
+        state.buttonHandler.releaseKeyboardMouse(state);
+        state.keyState.releaseAll(state);
+        state.mouseState.releaseAll(state);
+    }
+
+    function queueReleaseHeldInputs() {
+        if (releaseHeldInputsQueued) {
+            return;
+        }
+        releaseHeldInputsQueued = true;
+        state.events.onOnce("input", () => {
+            releaseHeldInputsQueued = false;
+            releaseHeldInputs();
+        });
+    }
+
+    function releaseHeldInputsOnFocusLoss() {
+        // Release all inputs immediately when blur/hide happens, 
+        // and then queue it to to catch any queued events on the next input tick,
+        // that wouldn't be processed otherwise
+        releaseHeldInputs();
+        queueReleaseHeldInputs();
+    }
+
     const pd = opt.pixelDensity || 1;
+
+    canvasEvents.blur = () => {
+        releaseHeldInputsOnFocusLoss();
+    };
 
     canvasEvents.mousemove = (e) => {
         // 🍝 Here we depend of GFX Context even if initGfx needs initApp for being used
@@ -1259,9 +1295,14 @@ export const initApp = (
             state.events.trigger("show");
         }
         else {
+            releaseHeldInputsOnFocusLoss();
             state.isHidden = true;
             state.events.trigger("hide");
         }
+    };
+
+    winEvents.blur = () => {
+        releaseHeldInputsOnFocusLoss();
     };
 
     winEvents.gamepadconnected = (e) => {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1003,7 +1003,7 @@ export const initApp = (
     }
 
     function releaseHeldInputsOnFocusLoss() {
-        // Release all inputs immediately when blur/hide happens, 
+        // Release all inputs immediately when blur/hide happens,
         // and then queue it to to catch any queued events on the next input tick,
         // that wouldn't be processed otherwise
         releaseHeldInputs();

--- a/src/app/inputBindings.ts
+++ b/src/app/inputBindings.ts
@@ -134,6 +134,15 @@ class ChordedButtonDetector<T extends string = string> {
         }
         return canceledButtons;
     }
+    releaseAll(): string[] {
+        const buttons = [...this.buttonsUsed];
+        this.buttonsUsed.clear();
+        this.mods.forEach((_, mod) => this.mods.set(mod, false));
+        return buttons;
+    }
+    isButtonUsed(button: string): boolean {
+        return this.buttonsUsed.has(button);
+    }
 }
 
 export class ButtonProcessor {
@@ -176,6 +185,16 @@ export class ButtonProcessor {
             this.state.release(button, state);
         }
     }
+    private _releaseKeyboardMouse(buttons: string[], state: AppState) {
+        for (let button of buttons) {
+            if (
+                this.state.down.has(button)
+                && !this.byGamepad.isButtonUsed(button)
+            ) {
+                this.state.release(button, state);
+            }
+        }
+    }
     processKeydown(key: Key, keyCode: string, state: AppState) {
         this._maybePress(this.byKey.handleDown(key), state);
         this._maybePress(this.byKeyCode.handleDown(keyCode), state);
@@ -195,6 +214,16 @@ export class ButtonProcessor {
     }
     processGamepadButtonUp(gb: KGamepadButton, state: AppState) {
         this._maybeRelease(this.byGamepad.handleUp(gb), state);
+    }
+    releaseKeyboardMouse(state: AppState) {
+        this._releaseKeyboardMouse(
+            [
+                ...this.byKey.releaseAll(),
+                ...this.byKeyCode.releaseAll(),
+                ...this.byMouse.releaseAll(),
+            ],
+            state,
+        );
     }
     update() {
         this.state.update();


### PR DESCRIPTION
Relates to #1094 

I would like you folks to take a look before I convert it to a "real" pull request.

I added "release all" buttons for keyboard and mouse. These events can "drop" when focus leaves the canvas. On the other hand gamepad is polling for events so I made sure to skip those (if there are any).