### PR TITLE
fix: make pos, skew and scale use a proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ So your change should look like:
   time (#1082) - @nojaf
 - Fixed mouse coordinates not being calculated properly when canvas is resized
   by CSS and wasn't rendered at its natural size (#1096) - @Stanko
-- Modified `pos`, `skew` and `scale` components to make operations like `+=` or `-=` work again - @ErikGXDev
+- Modified `pos`, `skew` and `scale` components to make operations like `obj.pos.x += 1` work again (#1109) - @ErikGXDev
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ So your change should look like:
   time (#1082) - @nojaf
 - Fixed mouse coordinates not being calculated properly when canvas is resized
   by CSS and wasn't rendered at its natural size (#1096) - @Stanko
+- Modified `pos`, `skew` and `scale` components to make operations like `+=` or `-=` work again - @ErikGXDev
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ So your change should look like:
   time (#1082) - @nojaf
 - Fixed mouse coordinates not being calculated properly when canvas is resized
   by CSS and wasn't rendered at its natural size (#1096) - @Stanko
-- Modified `pos`, `skew` and `scale` components to make operations like `obj.pos.x += 1` work again (#1109) - @ErikGXDev
+- Modified `pos`, `skew` and `scale` components to make operations like
+  `obj.pos.x += 1` work again (#1109) - @ErikGXDev
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/ecs/components/transform/pos.ts
+++ b/src/ecs/components/transform/pos.ts
@@ -117,8 +117,7 @@ export function pos(...args: Vec2Args): PosComp {
                 const self = this;
                 posProxy = new Proxy(_pos, {
                     set(target, prop, value) {
-                        _pos[prop as keyof Vec2] = value;
-                        target[prop as keyof Vec2] = value;
+                        Reflect.set(target, prop, value);
                         (self as any as InternalGameObjRaw)._transformVersion =
                             nextTransformVersion();
                         return true;

--- a/src/ecs/components/transform/pos.ts
+++ b/src/ecs/components/transform/pos.ts
@@ -102,7 +102,7 @@ export interface PosComp extends Comp {
 
 export function pos(...args: Vec2Args): PosComp {
     const _pos = vec2(...args);
-    const _posReadOnly = vec2(...args);
+    let posProxy: Vec2 | null = null;
 
     return {
         id: "pos",
@@ -113,13 +113,23 @@ export function pos(...args: Vec2Args): PosComp {
         },
 
         get pos(): Vec2 {
-            return _posReadOnly;
+            if (!posProxy) {
+                const self = this;
+                posProxy = new Proxy(_pos, {
+                    set(target, prop, value) {
+                        _pos[prop as keyof Vec2] = value;
+                        target[prop as keyof Vec2] = value;
+                        (self as any as InternalGameObjRaw)._transformVersion =
+                            nextTransformVersion();
+                        return true;
+                    },
+                });
+            }
+            return posProxy;
         },
         set pos(value: Vec2) {
             _pos.x = value.x;
             _pos.y = value.y;
-            _posReadOnly.x = value.x;
-            _posReadOnly.y = value.y;
             (this as any as InternalGameObjRaw)._transformVersion =
                 nextTransformVersion();
         },
@@ -136,9 +146,7 @@ export function pos(...args: Vec2Args): PosComp {
         // move to a destination, with optional speed
         // Address all ts ignores
         moveTo(...args) {
-            if (
-                typeof args[0] === "number" && typeof args[1] === "number"
-            ) {
+            if (typeof args[0] === "number" && typeof args[1] === "number") {
                 // @ts-ignore Use overload functions here?
                 return this.moveTo(vec2(args[0], args[1]), args[2]);
             }
@@ -185,25 +193,19 @@ export function pos(...args: Vec2Args): PosComp {
         // Transform a screen point (relative to the camera) to a local point (relative to this)
         set screenPos(pos: Vec2) {
             const obj = this as unknown as GameObj<PosComp>;
-            this.worldPos = isFixed(obj)
-                ? pos
-                : toWorld(pos);
+            this.worldPos = isFixed(obj) ? pos : toWorld(pos);
         },
 
         get screenPos() {
             const obj = this as unknown as GameObj<PosComp>;
             const pos = obj.worldPos;
-            return isFixed(obj)
-                ? pos
-                : toScreen(pos);
+            return isFixed(obj) ? pos : toScreen(pos);
         },
 
         // Transform a local point (relative to this) to a screen point (relative to the camera)
         toScreen(this: GameObj<PosComp | FixedComp>, pos: Vec2): Vec2 {
             pos = this.toWorld(pos);
-            return isFixed(this)
-                ? pos
-                : toScreen(pos);
+            return isFixed(this) ? pos : toScreen(pos);
         },
 
         // Transform a screen point (relative to the camera) to a local point (relative to this)

--- a/src/ecs/components/transform/scale.ts
+++ b/src/ecs/components/transform/scale.ts
@@ -67,21 +67,20 @@ export function scale(...args: Vec2Args): ScaleComp {
     const _scale = vec2(...args);
     let scaleProxy: Vec2 | null = null;
 
-
     return {
         id: "scale",
 
         get scale(): Vec2 {
             if (!scaleProxy) {
-              const self = this;
-              scaleProxy = new Proxy(_scale, {
-                set(target, prop, value) {
-                  Reflect.set(target, prop, value);
-                  (self as any as InternalGameObjRaw)._transformVersion =
-                    nextTransformVersion();
-                  return true;
-                },
-              });
+                const self = this;
+                scaleProxy = new Proxy(_scale, {
+                    set(target, prop, value) {
+                        Reflect.set(target, prop, value);
+                        (self as any as InternalGameObjRaw)._transformVersion =
+                            nextTransformVersion();
+                        return true;
+                    },
+                });
             }
             return scaleProxy;
         },

--- a/src/ecs/components/transform/scale.ts
+++ b/src/ecs/components/transform/scale.ts
@@ -65,13 +65,25 @@ export function scale(...args: Vec2Args): ScaleComp {
     }
 
     const _scale = vec2(...args);
-    const _scaleReadOnly = vec2(...args);
+    let scaleProxy: Vec2 | null = null;
+
 
     return {
         id: "scale",
 
         get scale(): Vec2 {
-            return _scaleReadOnly;
+            if (!scaleProxy) {
+              const self = this;
+              scaleProxy = new Proxy(_scale, {
+                set(target, prop, value) {
+                  Reflect.set(target, prop, value);
+                  (self as any as InternalGameObjRaw)._transformVersion =
+                    nextTransformVersion();
+                  return true;
+                },
+              });
+            }
+            return scaleProxy;
         },
         set scale(value: Vec2) {
             if (value instanceof Vec2 === false) {
@@ -81,8 +93,6 @@ export function scale(...args: Vec2Args): ScaleComp {
             }
             _scale.x = value.x;
             _scale.y = value.y;
-            _scaleReadOnly.x = value.x;
-            _scaleReadOnly.y = value.y;
             (this as any as InternalGameObjRaw)._transformVersion =
                 nextTransformVersion();
         },

--- a/src/ecs/components/transform/skew.ts
+++ b/src/ecs/components/transform/skew.ts
@@ -41,13 +41,24 @@ export function skew(...args: Vec2Args): SkewComp {
     }
 
     const _skew = vec2(...args);
-    const _skewReadOnly = vec2(...args);
+    let skewProxy: Vec2 | null = null;
 
     return {
         id: "skew",
 
         get skew(): Vec2 {
-            return _skewReadOnly;
+            if (!skewProxy) {
+              const self = this;
+              skewProxy = new Proxy(_skew, {
+                set(target, prop, value) {
+                  Reflect.set(target, prop, value);
+                  (self as any as InternalGameObjRaw)._transformVersion =
+                    nextTransformVersion();
+                  return true;
+                },
+              });
+            }
+            return skewProxy;
         },
         set skew(value: Vec2) {
             if (value instanceof Vec2 === false) {
@@ -57,8 +68,6 @@ export function skew(...args: Vec2Args): SkewComp {
             }
             _skew.x = value.x;
             _skew.y = value.y;
-            _skewReadOnly.x = value.x;
-            _skewReadOnly.y = value.y;
             (this as any as InternalGameObjRaw)._transformVersion =
                 nextTransformVersion();
         },

--- a/src/ecs/components/transform/skew.ts
+++ b/src/ecs/components/transform/skew.ts
@@ -48,15 +48,15 @@ export function skew(...args: Vec2Args): SkewComp {
 
         get skew(): Vec2 {
             if (!skewProxy) {
-              const self = this;
-              skewProxy = new Proxy(_skew, {
-                set(target, prop, value) {
-                  Reflect.set(target, prop, value);
-                  (self as any as InternalGameObjRaw)._transformVersion =
-                    nextTransformVersion();
-                  return true;
-                },
-              });
+                const self = this;
+                skewProxy = new Proxy(_skew, {
+                    set(target, prop, value) {
+                        Reflect.set(target, prop, value);
+                        (self as any as InternalGameObjRaw)._transformVersion =
+                            nextTransformVersion();
+                        return true;
+                    },
+                });
             }
             return skewProxy;
         },

--- a/tests/playtests/bouncingBeans.js
+++ b/tests/playtests/bouncingBeans.js
@@ -1,0 +1,59 @@
+/**
+ * @file Bouncing beans using proxied pos
+ * @description After making pos use a proxy PR #1109
+ * @minver 4000.0.0-alpha.28
+ */
+
+kaplay({
+    width: 1000,
+    height: 800,
+    font: "happy-o",
+});
+
+loadBitmapFont("happy-o", "/crew/happy-o.png", 36, 45);
+loadBean();
+
+// Try to find the highest number of objects your PC can handle at your stable
+// monitor refresh rate for the best FPS drop observation
+const OBJ_COUNT = 1000;
+
+onLoad(() => {
+    for (let i = 0; i < OBJ_COUNT; i++) {
+        const bean = add([
+            sprite("bean"),
+            pos(randi(0, width() - 64), randi(0, height() - 64)),
+            { dir: vec2((randi() * 2 - 1) * 45, (randi() * 2 - 1) * 45) },
+        ]);
+
+        bean.onUpdate(() => {
+            if (bean.pos.x <= 0 || bean.pos.x + bean.width >= width()) {
+                bean.dir.x *= -1;
+            }
+            if (bean.pos.y <= 0 || bean.pos.y + bean.height >= height()) {
+                bean.dir.y *= -1;
+            }
+
+            bean.pos.x += bean.dir.x * dt();
+            bean.pos.y += bean.dir.y * dt();
+
+            // Comparable alternatives
+            // bean.move(bean.dir);
+            // bean.moveBy(bean.dir.x * dt(), bean.dir.y * dt());
+            // bean.pos = bean.pos.add(bean.dir.scale(dt()));
+            // bean.pos = bean.pos.add(bean.dir.x * dt(), bean.dir.y * dt());
+
+            if (i === 0) debug.log(bean.pos);
+        });
+    }
+
+    add([
+        pos(10, 10),
+        text("fps"),
+        z(10000),
+        {
+            update() {
+                this.text = `fps: ${debug.fps().toFixed(2)}`;
+            },
+        },
+    ]);
+});


### PR DESCRIPTION
To make code like `obj.pos.x += 10` work, I have rewritten the pos component to use a proxy, which enables this. This was not possible before.
