### PR TITLE
feat: add nextFrame helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ So your change should look like:
 - Added xorshift32 as random generator (#1057) - @mflerackers
 - **(examples)** Added a new `gacha` example! (#1057) - @imaginarny
 - Added Alea as random generator (#1097) - @Stanko
+- Added `nextFrame()` helper function to defer/run a function on the next frame
+  (#1112) - @imaginarny
 
 ### Changed
 

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -262,6 +262,7 @@ export const createContext = (
     const destroyAll = game.root.removeAll.bind(game.root);
     const get = game.root.get.bind(game.root);
     const wait = game.root.wait.bind(game.root);
+    const nextFrame = game.root.nextFrame.bind(game.root);
     const loop = game.root.loop.bind(game.root);
     const query = game.root.query.bind(game.root);
     const tween = game.root.tween.bind(game.root);
@@ -494,6 +495,7 @@ export const createContext = (
         // timer
         loop,
         wait,
+        nextFrame,
         // audio
         play,
         setVolume: setVolume,

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -5414,6 +5414,59 @@ export interface KAPLAYCtx {
      */
     wait(n: number, action?: () => void): TimerController;
     /**
+     * Defer/run the function on the next frame.
+     *
+     * @param action - The function to run.
+     *
+     * @example Passing a callback
+     * ```js
+     * nextFrame(() => {})
+     * ```
+     * @example It returns a PromiseLike that can be used with await
+     * ```js
+     * await nextFrame()
+     * ```
+     * @example Use cases
+     * ```js
+     * // Typical use case is to unpause a game after all listeners in the current frame
+     * // have run, otherwise you would unpause and register input events too early
+     * nextFrame(() => {
+     *     gameObj.paused = false
+     * })
+     *
+     * // Or registering an event listener inside of the same event listener
+     * onKeyPress("space", () => {
+     *     // outside, the object would be added in the same frame when the space key is
+     *     // processed, so you would see "ohhi" message on the first space key press
+     *     nextFrame(() => {
+     *         const obj = add([])
+     *         obj.onKeyPress("space", () => debug.log("ohhi"))
+     *     })
+     *     return cancel()
+     * })
+     *
+     * // Or accessing info that is not available in the current event loop
+     * // like getting the next tiles array in the addLevel tiles config
+     * "=": () => [
+     *     sprite("grass"),
+     *     {
+     *         add() {
+     *             // outside it would be empty, since it runs when the tile is added
+     *             nextFrame(() => {
+     *                 // here it will work since the whole level is processed now
+     *                 console.log(this.getLevel().getAt(this.tilePos.add(1, 0)))
+     *             })
+     *         },
+     *     },
+     * ],
+     * ```
+     *
+     * @returns A timer controller.
+     * @since v4000.0
+     * @group Timer
+     */
+    nextFrame(action?: () => void): TimerController;
+    /**
      * Run the function every n seconds.
      *
      * @param n - The time to wait in seconds.

--- a/src/ecs/components/misc/timer.ts
+++ b/src/ecs/components/misc/timer.ts
@@ -152,6 +152,7 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
             this: GameObj<TimerComp>,
             action?: () => void,
         ): TimerController {
+            // will run only once
             return this.loop(0, action ?? (() => {}), 1, true);
         },
         tween<V extends LerpValue>(

--- a/src/ecs/components/misc/timer.ts
+++ b/src/ecs/components/misc/timer.ts
@@ -61,6 +61,10 @@ export interface TimerComp extends Comp {
      */
     wait(time: number, action?: () => void): TimerController;
     /**
+     * Run the callback on the next frame.
+     */
+    nextFrame(action?: () => void): TimerController;
+    /**
      * Run the callback every n seconds.
      *
      * If waitFirst is false (the default), the function will
@@ -143,6 +147,12 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
             action?: () => void,
         ): TimerController {
             return this.loop(time, action ?? (() => {}), 1, true);
+        },
+        nextFrame(
+            this: GameObj<TimerComp>,
+            action?: () => void,
+        ): TimerController {
+            return this.loop(0, action ?? (() => {}), 1, true);
         },
         tween<V extends LerpValue>(
             this: GameObj<TimerComp>,

--- a/tests/playtests/nextFrame.js
+++ b/tests/playtests/nextFrame.js
@@ -1,0 +1,32 @@
+/**
+ * @file nextFrame
+ * @description Defer fn to the next frame, same as wait(0)
+ * @minver 4000.0
+ */
+
+kaplay({ logTime: Infinity });
+
+debug.log("Second and consecutive clicks or key presses should say ohhi");
+
+// without nextFrame, the object would be added in the same frame when events
+// are processed, so you would see "ohhi" message on the first space key press
+
+onKeyPress(() => {
+    nextFrame(() => {
+        const obj = add([]);
+        obj.onKeyPress(() => {
+            debug.log("ohhi");
+        });
+    });
+    return cancel();
+});
+
+onMousePress(() => {
+    nextFrame(() => {
+        const obj = add([]);
+        obj.onMousePress(() => {
+            debug.log("ohhi");
+        });
+    });
+    return cancel();
+});


### PR DESCRIPTION
The `nextFrame(() => {})` is basically the `wait(0, () => {})`. Recently, a few more use cases have emerged when deferring to the next frame would make sense or is required. This alternative function makes its use more obvious rather than seemingly hacky `wait(0)`. Some of those are documented in types/JSDoc.

Playtest prevents the one where if you register an event in the same event listener, it would get triggered immediately, since it's added to the listeners stack before the current frame/loop finishes processing those listeners.

## Summary

Adds `nextFrame()` helper function to defer/run a function on the next frame.

- [x] Changeloged
