### PR TITLE
fix: detect mouse release outside canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,8 @@ So your change should look like:
 - Added a `repack: false` option to `loadSpite()` and a repack parameter to
   `loadSpriteAtlas()`, for faster loading if you're packing stuff at build-time
   (#1063) - @dragoncoder047
-- Added `loop` parameter and `onEnd` event to the video component (#1129) - @Stanko
+- Added `loop` parameter and `onEnd` event to the video component (#1129) -
+  @Stanko
 
 ### Changed
 
@@ -96,7 +97,8 @@ So your change should look like:
   @dragoncoder047
 - Added padding around edges of spritesheet to prevent stretch if uv ends up out
   of bounds (#1076) - @dragoncoder047
-- **(!)** Renamed video `mute` parameter to `muted` to match the native API (#1129) - @Stanko
+- **(!)** Renamed video `mute` parameter to `muted` to match the native API
+  (#1129) - @Stanko
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ So your change should look like:
   `obj.pos.x += 1` work again (#1109) - @ErikGXDev
 - Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus
   (#1101) - @Stanko
+- Fixed `onMouseRelease` not being registered outside the canvas (#1113) -
+  @imaginarny
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1085,6 +1085,14 @@ export const initApp = (
         });
     };
 
+    canvasEvents.pointerdown = (e) => {
+        state.canvas.setPointerCapture(e.pointerId);
+    };
+
+    canvasEvents.pointerup = (e) => {
+        state.canvas.releasePointerCapture(e.pointerId);
+    };
+
     const PREVENT_DEFAULT_KEYS = new Set([
         " ",
         "ArrowLeft",

--- a/tests/playtests/mouseCapture.js
+++ b/tests/playtests/mouseCapture.js
@@ -1,0 +1,21 @@
+/**
+ * @file Mouse capture
+ * @description Test mouse release outside of the canvas
+ * @minver 4000.0
+ */
+
+kaplay({
+    width: 600,
+    height: 400,
+    logTime: Infinity,
+});
+
+debug.log(`Steps:
+
+1. Hold mouse down on the canvas
+2. Release it outside the canvas
+
+Release event should be registered.`);
+
+onMouseDown(() => debug.log("↓ holding"));
+onMouseRelease(() => debug.warn("↑ released"));


### PR DESCRIPTION
Captures pointer events outside the canvas that originated on the canvas.
Check the issue on [KAPLAYGROUND](https://play.kaplayjs.com/?code=eJxVjrFOw0AQRPv7ilEqW4qsgFAKo1BRQEEDfEAObnO3wtmLfOtYEaJNH%2BUP8yU5W4mA7XZnZt982U1jd8W3QZ6enYYa89lsOu6B2AetcXc9NNG%2F85pqPMuKhXU3NT%2FlvTGOPjpfZbVYviltUm3MTYWn2DisY5cILvaCKNBA%2BLSytcncVnilhmxWWRE7Tezor8FcZdqSKDhBoqIlz0mpJVctB3SUl4HwmAFFUWLxgN8yk9P%2BiJBbsPhJmd0X8%2BXxP39vWxkCh0wYVTcmzs28XT8%3D&version=4000.0.0-alpha.27.1), same as in the included playtest that is now fixed.

## Summary

Fixed `onMouseRelease` not being registered outside the canvas

- [x] Changeloged
