### PR TITLE
feat: preventDefault debug, buttons api, and input captured keys

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,8 @@ Replace this text with an overview describing the changes included in this PR.
 
 ## Changelog
 
-Write the changelog according to our [changelog guide](https://github.com/kaplayjs/kaplay/wiki/Changelogging).
+Write the changelog according to our
+[changelog guide](https://github.com/kaplayjs/kaplay/wiki/Changelogging).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,8 @@ So your change should look like:
 - Added a `repack: false` option to `loadSpite()` and a repack parameter to
   `loadSpriteAtlas()`, for faster loading if you're packing stuff at build-time
   (#1063) - @dragoncoder047
-- Added `loop` parameter and `onEnd` event to the video component (#1129) - @Stanko
+- Added `loop` parameter and `onEnd` event to the video component (#1129) -
+  @Stanko
 
 ### Changed
 
@@ -96,7 +97,8 @@ So your change should look like:
   @dragoncoder047
 - Added padding around edges of spritesheet to prevent stretch if uv ends up out
   of bounds (#1076) - @dragoncoder047
-- **(!)** Renamed video `mute` parameter to `muted` to match the native API (#1129) - @Stanko
+- **(!)** Renamed video `mute` parameter to `muted` to match the native API
+  (#1129) - @Stanko
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ So your change should look like:
   (#1097) - @Stanko
 - **(!)** `new RNG()` and `setRNG()` now use config objects instead of the
   string/custom rng parameter (#1097) - @Stanko
+- Debug keys, keys defined with the Buttons API, and keyboard input captured by
+  e.g. focused `textInput` now use `preventDefault()` (#1114) - @imaginarny
 
 ### Fixed
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1142,6 +1142,7 @@ export const initApp = (
 
         if (
             PREVENT_DEFAULT_KEYS.has(k)
+            || _k.game.inputCapturedBy.size > 0
             || shouldPreventButtons(
                 state.buttonHandler.byKey.committers.get(k),
             )

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1086,34 +1086,34 @@ export const initApp = (
         });
     };
 
-    const PREVENT_DEFAULT_KEYS = new Set([
-        " ",
-        "ArrowLeft",
-        "ArrowRight",
-        "ArrowUp",
-        "ArrowDown",
-        "Tab",
-        "/",
-        ...(opt.debug !== false
-            ? [
-                opt.debugKey || "F1",
-                "F2",
-                "F7",
-                "F8",
-                "F9",
-                "F10",
-            ]
-            : []),
-    ]);
-
-    // translate these key names to a simpler version
-    const KEY_ALIAS = {
+    // translate key names to kaplay keys
+    const KEY_ALIAS: Record<KeyboardEvent["key"], Key> = {
         "ArrowLeft": "left",
         "ArrowRight": "right",
         "ArrowUp": "up",
         "ArrowDown": "down",
         " ": "space",
     };
+
+    const PREVENT_DEFAULT_KEYS = new Set<Key>([
+        "left",
+        "right",
+        "up",
+        "down",
+        "space",
+        "tab",
+        "/",
+        ...(opt.debug !== false
+            ? [
+                opt.debugKey || "f1",
+                "f2",
+                "f7",
+                "f8",
+                "f9",
+                "f10",
+            ]
+            : []),
+    ]);
 
     const shouldPreventButtons = (
         committer:

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,6 +1,7 @@
 // App is everything related to canvas, game loop and input
 
 import type {
+    ChordedKey,
     Cursor,
     GameObj,
     KAPLAYOpt,
@@ -1114,6 +1115,25 @@ export const initApp = (
         " ": "space",
     };
 
+    const shouldPreventButtons = (
+        committer:
+            | { check: Set<ChordedKey>; btns: Map<string, ChordedKey[]> }
+            | undefined,
+    ) => {
+        if (!committer?.btns?.size) {
+            return false;
+        }
+        else if (committer.check.size === 0) {
+            return true;
+        }
+
+        for (const k of state.keyState.down) {
+            if (committer.check.has(k)) return true;
+        }
+
+        return false;
+    };
+
     canvasEvents.keydown = (e) => {
         state.capsOn = e.getModifierState("CapsLock");
 
@@ -1122,8 +1142,12 @@ export const initApp = (
 
         if (
             PREVENT_DEFAULT_KEYS.has(k)
-            || state.buttonHandler.byKey.committers.get(k)?.btns?.size
-            || state.buttonHandler.byKeyCode.committers.get(e.code)?.btns?.size
+            || shouldPreventButtons(
+                state.buttonHandler.byKey.committers.get(k),
+            )
+            || shouldPreventButtons(
+                state.buttonHandler.byKeyCode.committers.get(e.code),
+            )
         ) {
             e.preventDefault();
         }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1115,20 +1115,20 @@ export const initApp = (
             : []),
     ]);
 
-    const shouldPreventButtons = (
-        committer:
-            | { check: Set<ChordedKey>; btns: Map<string, ChordedKey[]> }
-            | undefined,
-    ) => {
-        if (!committer?.btns?.size) {
-            return false;
-        }
-        else if (committer.check.size === 0) {
-            return true;
-        }
+    const shouldPreventButtons = (key: Key, by: "byKey" | "byKeyCode") => {
+        const committer = state.buttonHandler[by].committers.get(key);
+        if (!committer) return false;
 
-        for (const k of state.keyState.down) {
-            if (committer.check.has(k)) return true;
+        btns: for (const mods of committer.btns.values()) {
+            for (const mod of committer.check) {
+                if (
+                    (state.keyState.down.has(mod) || mod === key)
+                        !== mods.includes(mod)
+                ) {
+                    continue btns;
+                }
+            }
+            return true;
         }
 
         return false;
@@ -1143,12 +1143,8 @@ export const initApp = (
         if (
             PREVENT_DEFAULT_KEYS.has(k)
             || _k.game.inputCapturedBy.size > 0
-            || shouldPreventButtons(
-                state.buttonHandler.byKey.committers.get(k),
-            )
-            || shouldPreventButtons(
-                state.buttonHandler.byKeyCode.committers.get(e.code),
-            )
+            || shouldPreventButtons(k, "byKey")
+            || shouldPreventButtons(e.code, "byKeyCode")
         ) {
             e.preventDefault();
         }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,6 +1,7 @@
 // App is everything related to canvas, game loop and input
 
 import type {
+    ChordedKey,
     Cursor,
     GameObj,
     KAPLAYOpt,
@@ -1114,13 +1115,32 @@ export const initApp = (
         " ": "space",
     };
 
+    const shouldPreventButtons = (check: Set<ChordedKey> | undefined) => {
+        if (!check) return false;
+        if (check.size === 0) return true;
+
+        for (const key of check) {
+            if (state.keyState.down.has(key)) return true;
+        }
+
+        return false;
+    };
+
     canvasEvents.keydown = (e) => {
         state.capsOn = e.getModifierState("CapsLock");
 
         const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
             || e.key.toLowerCase();
 
-        if (PREVENT_DEFAULT_KEYS.has(k)) {
+        if (
+            PREVENT_DEFAULT_KEYS.has(k)
+            || shouldPreventButtons(
+                state.buttonHandler.byKey.committers.get(k)?.check,
+            )
+            || shouldPreventButtons(
+                state.buttonHandler.byKeyCode.committers.get(e.code)?.check,
+            )
+        ) {
             e.preventDefault();
         }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,7 +1,6 @@
 // App is everything related to canvas, game loop and input
 
 import type {
-    ChordedKey,
     Cursor,
     GameObj,
     KAPLAYOpt,
@@ -1115,17 +1114,6 @@ export const initApp = (
         " ": "space",
     };
 
-    const shouldPreventButtons = (check: Set<ChordedKey> | undefined) => {
-        if (!check) return false;
-        if (check.size === 0) return true;
-
-        for (const key of check) {
-            if (state.keyState.down.has(key)) return true;
-        }
-
-        return false;
-    };
-
     canvasEvents.keydown = (e) => {
         state.capsOn = e.getModifierState("CapsLock");
 
@@ -1134,12 +1122,8 @@ export const initApp = (
 
         if (
             PREVENT_DEFAULT_KEYS.has(k)
-            || shouldPreventButtons(
-                state.buttonHandler.byKey.committers.get(k)?.check,
-            )
-            || shouldPreventButtons(
-                state.buttonHandler.byKeyCode.committers.get(e.code)?.check,
-            )
+            || state.buttonHandler.byKey.committers.get(k)?.btns?.size
+            || state.buttonHandler.byKeyCode.committers.get(e.code)?.btns?.size
         ) {
             e.preventDefault();
         }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1092,6 +1092,17 @@ export const initApp = (
         "ArrowUp",
         "ArrowDown",
         "Tab",
+        "/",
+        ...(opt.debug !== false
+            ? [
+                opt.debugKey || "F1",
+                "F2",
+                "F7",
+                "F8",
+                "F9",
+                "F10",
+            ]
+            : []),
     ]);
 
     // translate these key names to a simpler version
@@ -1106,12 +1117,14 @@ export const initApp = (
     canvasEvents.keydown = (e) => {
         state.capsOn = e.getModifierState("CapsLock");
 
-        if (PREVENT_DEFAULT_KEYS.has(e.key)) {
+        const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
+            || e.key.toLowerCase();
+
+        if (PREVENT_DEFAULT_KEYS.has(k)) {
             e.preventDefault();
         }
+
         state.events.onOnce("input", () => {
-            const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
-                || e.key.toLowerCase();
             const code = e.code;
 
             if (k === undefined) throw new Error(`Unknown key: ${e.key}`);

--- a/src/ecs/components/misc/textInput.ts
+++ b/src/ecs/components/misc/textInput.ts
@@ -66,7 +66,12 @@ export function textInput(
         set hasFocus(newValue) {
             if (hasFocus === newValue) return;
             hasFocus = newValue;
+
+            _k.game.inputCapturedBy[hasFocus ? "add" : "delete"](
+                this as any as GameObj,
+            );
             (this as any as GameObj).trigger(hasFocus ? "focus" : "blur");
+
             if (hasFocus) {
                 origText = this.typedText;
                 _k.game.allTextInputs.forEach(i => {
@@ -88,6 +93,8 @@ export function textInput(
                 this.text = this.typedText.replace(/([\[\\])/g, "\\$1");
                 this.trigger("input");
             };
+
+            if (this.hasFocus) _k.game.inputCapturedBy.add(this);
 
             charEv = _k.app.onCharInput((character) => {
                 if (
@@ -115,7 +122,9 @@ export function textInput(
         destroy(this: GameObj<TextInputComp>) {
             charEv.cancel();
             backEv.cancel();
+
             _k.game.allTextInputs.delete(this);
+            _k.game.inputCapturedBy.delete(this);
         },
         focus() {
             this.hasFocus = true;

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -18,7 +18,7 @@ import { type KEventController, KEventHandler } from "../events/events";
 import { Mat23, Rect } from "../math/math";
 import { RNG, type RNGConfig } from "../math/random";
 import { Vec2 } from "../math/Vec2";
-import type { GameObj } from "../types";
+import type { GameObj, GameObjID } from "../types";
 import type { SceneDef, SceneState } from "./scenes";
 
 /**
@@ -120,6 +120,10 @@ export type Game = {
      */
     allTextInputs: Set<GameObj>;
     /**
+     * Objects or identifiers currently capturing input, e.g. a textInput obj.
+     */
+    inputCapturedBy: Set<GameObj | GameObjID | string>;
+    /**
      * Deprecated functions we already warned about.
      */
     warned: Set<string>;
@@ -209,6 +213,7 @@ export const createGame = (
         crashed: false,
         areaCount: 0,
         allTextInputs: new Set<GameObj>(),
+        inputCapturedBy: new Set(),
         defRNG: new RNG(rngConfig),
         warned: new Set<string>(),
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,6 @@ export type Key =
         | "alt"
         | "meta"
         | "space"
-        | " "
         | "left"
         | "right"
         | "up"

--- a/tests/playtests/preventButtons.js
+++ b/tests/playtests/preventButtons.js
@@ -1,0 +1,91 @@
+/**
+ * @file Prevent Buttons
+ * @description Bound buttons use preventDefault()
+ * @minver 4000.0
+ */
+
+kaplay({
+    background: "black",
+    buttons: {
+        "save": {
+            keyboard: "control+s",
+        },
+        "find": {
+            keyboard: "control+f",
+        },
+    },
+    pixelDensity: Math.min(devicePixelRatio, 2),
+    texFilter: "linear",
+});
+
+const README = `
+Bound buttons prevent default actions:
+${
+    Object.entries(getButtons())
+        .map(([k, v]) => `- ${k} (${v.keyboard})`)
+        .join("\n")
+}
+
+Other automatically prevented keys:
+- if debug is allowed, keys like F1 (chrome help page)
+- when inputs are captured, like focused input
+    - focus & try pressing (control+r)
+      (just "r" is typed instead of reloading the page)
+`.trim();
+
+const txt = add([
+    pos(32),
+    text(README, { size: 18, lineSpacing: 12 }),
+]);
+
+onButtonPress(btn => debug.log(`${btn} pressed`));
+
+add([
+    {
+        draw() {
+            drawRect({
+                pos: vec2(-8, -6),
+                width: (this.width || 10) + 16,
+                height: (this.height || 18) + 12,
+                color: rgb("#222222"),
+                radius: 8,
+                outline: this?.hasFocus
+                    ? {
+                        width: 2,
+                        color: WHITE,
+                    }
+                    : false,
+            });
+        },
+    },
+    pos(txt.pos.add(0, txt.height + 36)),
+    text("Click to focus...", { size: 18, lineSpacing: 12 }),
+    textInput(false),
+    area(),
+    {
+        placeHolder: "",
+        add() {
+            this.placeHolder = this.text;
+
+            this.onClick(() => {
+                if (this.hasFocus) return;
+                this.hasFocus = true;
+
+                const mc = onMousePress(() => {
+                    if (this.isClicked()) return;
+                    this.hasFocus = false;
+                    kc?.cancel();
+                    return cancel();
+                });
+
+                const kc = onKeyPress(["escape", "enter"], () => {
+                    this.hasFocus = false;
+                    mc?.cancel();
+                    return cancel();
+                });
+            });
+
+            this.onInput(() => this.text = this.text || this.placeHolder);
+        },
+    },
+]);


### PR DESCRIPTION
Default debug inspect mode `F1` key will not open the help page in Chrome anymore.. Bound keys with Buttons API are prevented too, using the same logic as chorded keys. So e.g. bound `control+s` wouldn't trigger save file dialog. Captured keys, e.g. with focused textInput, are using `preventDefault()` as well.

## Summary

Debug keys, keys defined with the Buttons API, and keyboard input captured by e.g. focused `textInput` now use `preventDefault()`.

- [x] Changeloged
