### PR TITLE
fix: align styled-text style positions with grapheme clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ So your change should look like:
   e.g. focused `textInput` now use `preventDefault()` (#1114) - @imaginarny
 - Updated `drawSprite()` to allow slice9'ed sprites, and so now the `sprite()`
   component just calls `drawSprite()` (#1036) - @dragoncoder047
+- `StyledTextInfo` now carries the rendered text's grapheme clusters as a
+  `runes` array, and `compileStyledText()` takes an optional `locale`
+  parameter, so `formatText()` no longer segments the same string twice
+  (#1115) - @mahirhir
 
 ### Fixed
 
@@ -98,6 +102,8 @@ So your change should look like:
   duration (#1117) - @imaginarny
 - Fixed triangulate by updating the convexity of nearby vertices after removing
   a concave vertex during ear cutting (#1134) - @mflerackers
+- Fixed styled text (`[tag]...[/tag]`) style positions desyncing after an
+  emoji, ZWJ sequence or astral character (#1115) - @mahirhir
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -6696,14 +6696,15 @@ export interface KAPLAYCtx {
     formatText(options: DrawTextOpt): FormattedText;
     /**
      * Parses the text that has formatting tags, and returns the unstyled text
-     * (the actual characters that will be displayed) as well as which styles are
-     * active on each character.
+     * (the actual characters that will be displayed, both as a string and as
+     * an array of grapheme clusters) as well as which styles are active on
+     * each character.
      *
      * @since v4000
      * @group Rendering
      * @subgroup Text
      */
-    compileStyledText(text: any): StyledTextInfo;
+    compileStyledText(text: any, locale?: string): StyledTextInfo;
     /**
      * Create a canvas to draw stuff offscreen.
      *

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -6,7 +6,7 @@ import { Color, rgb } from "../math/color";
 import { vec2 } from "../math/math";
 import { _k } from "../shared";
 import type { Outline } from "../types";
-import { firstRune, runes } from "../utils/runes";
+import { firstRune } from "../utils/runes";
 import { alignPt } from "./anchor";
 import type { FormattedChar, FormattedText } from "./draw/drawFormattedText";
 import type { CharTransform, DrawTextOpt } from "./draw/drawText";
@@ -31,6 +31,13 @@ export type FontAtlas = {
 export type StyledTextInfo = {
     charStyleMap: Record<number, [string, string][]>;
     text: string;
+    /**
+     * The rendered text split into grapheme clusters, in render order.
+     * charStyleMap keys index into this array. Carrying it here lets
+     * formatText() reuse the segmentation compileStyledText() already did
+     * instead of running runes() over the same string a second time.
+     */
+    runes: string[];
 };
 
 function applyCharTransform(fchar: FormattedChar, tr: CharTransform) {
@@ -56,23 +63,23 @@ function applyCharTransform(fchar: FormattedChar, tr: CharTransform) {
     if (tr.opacity != null) fchar.opacity *= tr.opacity;
 }
 
-export function compileStyledText(txt: any): StyledTextInfo {
+export function compileStyledText(txt: any, locale?: string): StyledTextInfo {
     const charStyleMap = {} as Record<number, [string, string][]>;
+    const renderRunes: string[] = [];
     let renderText = "";
     let styleStack: [string, string][] = [];
     // Normalize to NFC and walk grapheme clusters instead of UTF-16 code units,
-    // so style positions stay aligned with formatText(), which iterates the
-    // rendered text via runes(). Keying by renderText.length would desync every
-    // style after an emoji, ZWJ sequence or astral char (e.g. CJK Extension B).
+    // so style positions stay aligned with formatText(), which walks the same
+    // grapheme array. Keying by renderText.length would desync every style
+    // after an emoji, ZWJ sequence or astral char (e.g. CJK Extension B).
     let text = String(txt).normalize("NFC");
-    let charIndex = 0;
 
     const emit = (ch: string) => {
         if (styleStack.length > 0) {
-            charStyleMap[charIndex] = styleStack.slice();
+            charStyleMap[renderRunes.length] = styleStack.slice();
         }
         renderText += ch;
-        charIndex++;
+        renderRunes.push(ch);
     };
 
     while (text !== "") {
@@ -80,7 +87,7 @@ export function compileStyledText(txt: any): StyledTextInfo {
             if (text.length === 1) {
                 throw new Error("Styled text error: \\ at end of string");
             }
-            const escaped = firstRune(text.slice(1));
+            const escaped = firstRune(text.slice(1), locale);
             emit(escaped);
             text = text.slice(1 + escaped.length);
             continue;
@@ -116,7 +123,7 @@ export function compileStyledText(txt: any): StyledTextInfo {
             text = text.slice(m.length);
             continue;
         }
-        const grapheme = firstRune(text);
+        const grapheme = firstRune(text, locale);
         emit(grapheme);
         text = text.slice(grapheme.length);
     }
@@ -130,6 +137,7 @@ export function compileStyledText(txt: any): StyledTextInfo {
     return {
         charStyleMap,
         text: renderText,
+        runes: renderRunes,
     };
 }
 
@@ -316,8 +324,10 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         };
     }
 
-    const { charStyleMap, text } = compileStyledText(opt.text + "");
-    const chars = runes(text, opt.locale);
+    const { charStyleMap, text, runes: chars } = compileStyledText(
+        opt.text + "",
+        opt.locale,
+    );
 
     const fontAtlas = font instanceof FontData || typeof font === "string"
         ? (() => {

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -6,7 +6,7 @@ import { Color, rgb } from "../math/color";
 import { vec2 } from "../math/math";
 import { _k } from "../shared";
 import type { Outline } from "../types";
-import { runes } from "../utils/runes";
+import { firstRune, runes } from "../utils/runes";
 import { alignPt } from "./anchor";
 import type { FormattedChar, FormattedText } from "./draw/drawFormattedText";
 import type { CharTransform, DrawTextOpt } from "./draw/drawText";
@@ -80,7 +80,7 @@ export function compileStyledText(txt: any): StyledTextInfo {
             if (text.length === 1) {
                 throw new Error("Styled text error: \\ at end of string");
             }
-            const [escaped] = runes(text.slice(1));
+            const escaped = firstRune(text.slice(1));
             emit(escaped);
             text = text.slice(1 + escaped.length);
             continue;
@@ -116,7 +116,7 @@ export function compileStyledText(txt: any): StyledTextInfo {
             text = text.slice(m.length);
             continue;
         }
-        const [grapheme] = runes(text);
+        const grapheme = firstRune(text);
         emit(grapheme);
         text = text.slice(grapheme.length);
     }

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -60,13 +60,19 @@ export function compileStyledText(txt: any): StyledTextInfo {
     const charStyleMap = {} as Record<number, [string, string][]>;
     let renderText = "";
     let styleStack: [string, string][] = [];
-    let text = String(txt);
+    // Normalize to NFC and walk grapheme clusters instead of UTF-16 code units,
+    // so style positions stay aligned with formatText(), which iterates the
+    // rendered text via runes(). Keying by renderText.length would desync every
+    // style after an emoji, ZWJ sequence or astral char (e.g. CJK Extension B).
+    let text = String(txt).normalize("NFC");
+    let charIndex = 0;
 
     const emit = (ch: string) => {
         if (styleStack.length > 0) {
-            charStyleMap[renderText.length] = styleStack.slice();
+            charStyleMap[charIndex] = styleStack.slice();
         }
         renderText += ch;
+        charIndex++;
     };
 
     while (text !== "") {
@@ -74,8 +80,9 @@ export function compileStyledText(txt: any): StyledTextInfo {
             if (text.length === 1) {
                 throw new Error("Styled text error: \\ at end of string");
             }
-            emit(text[1]);
-            text = text.slice(2);
+            const [escaped] = runes(text.slice(1));
+            emit(escaped);
+            text = text.slice(1 + escaped.length);
             continue;
         }
         if (text[0] === "[") {
@@ -109,8 +116,9 @@ export function compileStyledText(txt: any): StyledTextInfo {
             text = text.slice(m.length);
             continue;
         }
-        emit(text[0]);
-        text = text.slice(1);
+        const [grapheme] = runes(text);
+        emit(grapheme);
+        text = text.slice(grapheme.length);
     }
 
     if (styleStack.length > 0) {

--- a/src/utils/runes.ts
+++ b/src/utils/runes.ts
@@ -94,6 +94,37 @@ export function runes(string: string, locale?: string): string[] {
 }
 
 /**
+ * Get the first grapheme cluster of a string without splitting the rest of it.
+ * Equivalent to runes(string, locale)[0], but stops after the first cluster so
+ * callers that consume one grapheme per iteration stay O(n) overall instead of
+ * O(n^2).
+ *
+ * @param string - The string to read the first grapheme cluster from
+ * @param locale - Optional locale for locale-aware segmentation
+ *
+ * @returns The first grapheme cluster, or "" for an empty string
+ */
+export function firstRune(string: string, locale?: string): string {
+    if (typeof string !== "string") {
+        throw new TypeError("string cannot be undefined or null");
+    }
+
+    // Use Intl.Segmenter if available (Chrome 87+, Safari 14.1+, Firefox 125+)
+    if (typeof Intl !== "undefined" && Intl.Segmenter) {
+        // Normalize to NFC for consistent representation of combining characters
+        const normalized = string.normalize("NFC");
+        const segmenter = getSegmenter(locale);
+        for (const { segment } of segmenter.segment(normalized)) {
+            return segment;
+        }
+        return "";
+    }
+
+    // Fallback to legacy implementation for older browsers
+    return runesLegacy(string)[0] ?? "";
+}
+
+/**
  * Legacy grapheme cluster splitting implementation.
  * Used as fallback for browsers without Intl.Segmenter support.
  */

--- a/tests/auto/styledText.spec.ts
+++ b/tests/auto/styledText.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "vitest";
+import { compileStyledText } from "../../src/gfx/formatText";
+import { runes } from "../../src/utils/runes";
+
+// compileStyledText() should key charStyleMap by grapheme index, the same way
+// formatText() walks the rendered text via runes(). Keying by UTF-16 code unit
+// desyncs every style after an emoji, ZWJ sequence or astral character.
+
+// the styled graphemes of `input`, resolved through the same runes() indexing
+// that formatText() uses to apply styles
+function styledGraphemes(input: string): (string | undefined)[] {
+    const { charStyleMap, text } = compileStyledText(input);
+    const graphemes = runes(text);
+    return Object.keys(charStyleMap)
+        .map(Number)
+        .sort((a, b) => a - b)
+        .map(i => graphemes[i]);
+}
+
+test("compileStyledText keeps ASCII style indices unchanged", () => {
+    const { charStyleMap } = compileStyledText("a[c]b[/c]c");
+    expect(charStyleMap).toEqual({ 1: [["c", undefined]] });
+});
+
+test("compileStyledText aligns styles after an emoji", () => {
+    expect(styledGraphemes("\u{1F600}[c]x[/c]")).toEqual(["x"]);
+});
+
+test("compileStyledText aligns styles after an astral CJK character", () => {
+    // U+20BB7 (a CJK Extension B ideograph) is a surrogate pair, so .length
+    // counts it as two code units
+    expect(styledGraphemes("\u{20BB7}[c]a[/c]")).toEqual(["a"]);
+});
+
+test("compileStyledText aligns styles after a ZWJ emoji sequence", () => {
+    const family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+    expect(styledGraphemes(`${family}[c]z[/c]`)).toEqual(["z"]);
+});
+
+test("compileStyledText maps every style key to a real grapheme", () => {
+    const { charStyleMap, text } = compileStyledText("[c]\u{1F600}b[/c]");
+    const graphemes = runes(text);
+    for (const key of Object.keys(charStyleMap).map(Number)) {
+        expect(graphemes[key]).toBeDefined();
+    }
+    expect(styledGraphemes("[c]\u{1F600}b[/c]")).toEqual(["\u{1F600}", "b"]);
+});

--- a/tests/auto/styledText.spec.ts
+++ b/tests/auto/styledText.spec.ts
@@ -3,18 +3,17 @@ import { compileStyledText } from "../../src/gfx/formatText";
 import { runes } from "../../src/utils/runes";
 
 // compileStyledText() should key charStyleMap by grapheme index, the same way
-// formatText() walks the rendered text via runes(). Keying by UTF-16 code unit
-// desyncs every style after an emoji, ZWJ sequence or astral character.
+// formatText() walks the rendered text. Keying by UTF-16 code unit desyncs
+// every style after an emoji, ZWJ sequence or astral character.
 
-// the styled graphemes of `input`, resolved through the same runes() indexing
-// that formatText() uses to apply styles
+// the styled graphemes of `input`, resolved through the same rune array
+// that formatText() consumes to apply styles
 function styledGraphemes(input: string): (string | undefined)[] {
-    const { charStyleMap, text } = compileStyledText(input);
-    const graphemes = runes(text);
+    const { charStyleMap, runes } = compileStyledText(input);
     return Object.keys(charStyleMap)
         .map(Number)
         .sort((a, b) => a - b)
-        .map(i => graphemes[i]);
+        .map(i => runes[i]);
 }
 
 test("compileStyledText keeps ASCII style indices unchanged", () => {
@@ -38,10 +37,27 @@ test("compileStyledText aligns styles after a ZWJ emoji sequence", () => {
 });
 
 test("compileStyledText maps every style key to a real grapheme", () => {
-    const { charStyleMap, text } = compileStyledText("[c]\u{1F600}b[/c]");
-    const graphemes = runes(text);
+    const { charStyleMap, runes: segmented } = compileStyledText(
+        "[c]\u{1F600}b[/c]",
+    );
     for (const key of Object.keys(charStyleMap).map(Number)) {
-        expect(graphemes[key]).toBeDefined();
+        expect(segmented[key]).toBeDefined();
     }
     expect(styledGraphemes("[c]\u{1F600}b[/c]")).toEqual(["\u{1F600}", "b"]);
+});
+
+test("compileStyledText returns the rune array formatText consumes", () => {
+    const family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+    const input = `a[c]\u{1F600}[/c]\\[x] ${family}b`;
+    const { text, runes: segmented } = compileStyledText(input);
+    // the array must match what a second runes() pass over the rendered text
+    // would produce, so formatText can consume it without segmenting again
+    expect(segmented).toEqual(runes(text));
+    expect(segmented.join("")).toBe(text);
+});
+
+test("compileStyledText keeps escaped characters as single runes", () => {
+    const { text, runes: segmented } = compileStyledText("\\[c]\\\\x");
+    expect(text).toBe("[c]\\x");
+    expect(segmented).toEqual(["[", "c", "]", "\\", "x"]);
 });


### PR DESCRIPTION
`compileStyledText` builds `charStyleMap` keyed by `renderText.length`, i.e. UTF-16 code units, while emitting the text one code unit at a time. `formatText` then splits the rendered text with `runes()` and applies styles with `charStyleMap[cursor]`, where `cursor` is a grapheme index.

For plain ASCII those two indexings match, but they drift apart as soon as the text contains a character that is more than one code unit: an emoji, a ZWJ sequence, a skin-tone or flag sequence, or an astral-plane CJK ideograph (CJK Extension B, e.g. names written with 𠮷). After such a character every following style is shifted, so it lands on the wrong grapheme or is dropped.

A couple of concrete cases:

- `😀[c]x[/c]` keys the style at `2`, but `runes("😀x")` puts `x` at grapheme index `1`, so the style is lost.
- `[c]😀b[/c]` produces keys `{0,1,2}` for a string `runes()` sees as two graphemes.

The fix makes `compileStyledText` walk grapheme clusters with the same `runes()` helper `formatText` already uses, keying `charStyleMap` by grapheme index. The input is normalized to NFC up front (which `runes()` does internally too) so the slice lengths stay consistent. Escapes (`\x`) now also consume a whole grapheme rather than a single code unit.

Added `tests/auto/styledText.spec.ts` covering ASCII (unchanged), an emoji, an astral CJK character, and a ZWJ family sequence.
