### PR TITLE
fix: finish tween only once and clamp time to duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ So your change should look like:
   `obj.pos.x += 1` work again (#1109) - @ErikGXDev
 - Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus
   (#1101) - @Stanko
+- Fixed `finish()` being able to complete an already finished tween, and
+  prevented `timeLeft` from going negative and `currentTime` from exceeding the
+  duration (#1117) - @imaginarny
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/ecs/components/misc/timer.ts
+++ b/src/ecs/components/misc/timer.ts
@@ -1,7 +1,7 @@
 import { KEvent } from "../../../events/events";
+import { clamp } from "../../../math/clamp";
 import { easings } from "../../../math/easings";
 import { lerp, type LerpValue } from "../../../math/lerp";
-import { Vec2 } from "../../../math/Vec2";
 import { _k } from "../../../shared";
 import type { Comp, GameObj } from "../../../types";
 
@@ -163,6 +163,7 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
             setValue: (value: V) => void,
             easeFunc = easings.linear,
         ) {
+            let finished = false;
             let curTime = 0;
             if (typeof (from as any).clone == "function") {
                 from = (from as any).clone() as V;
@@ -176,24 +177,28 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
                 curTime += _k.app.dt();
                 const t = Math.min(curTime / duration, 1);
                 setValue(lerp(from, to, easeFunc(t)));
-                if (t === 1) {
-                    ev.cancel();
-                    setValue(to);
-                    onEndEvents.forEach((action) => action());
-                }
+                if (t === 1) finish();
             });
+            const finish = () => {
+                if (finished) return;
+                finished = true;
+                ev.cancel();
+                setValue(to);
+                curTime = duration;
+                onEndEvents.forEach((action) => action());
+            };
             return {
                 get currentTime() {
                     return curTime;
                 },
                 set currentTime(val) {
-                    curTime = val;
+                    curTime = clamp(val, 0, duration);
                 },
                 get timeLeft() {
                     return duration - curTime;
                 },
                 set timeLeft(val: number) {
-                    curTime = duration - val;
+                    curTime = clamp(duration - val, 0, duration);
                 },
                 get paused() {
                     return ev.paused;
@@ -211,11 +216,7 @@ export function timer(maxLoopsPerFrame: number = 1000): TimerComp {
                 cancel() {
                     ev.cancel();
                 },
-                finish() {
-                    ev.cancel();
-                    setValue(to);
-                    onEndEvents.forEach((action) => action());
-                },
+                finish,
             };
         },
     };


### PR DESCRIPTION
It fixes two issues based on a previous report on DC. If tween has finished and you call `finish()` at the same time or again after, it will set to `to` value and run all `onEnd` functions again. Even if it has already finished. Second issue comes from a workaround, having to check beforehand the `timeLeft` value, which instead of being `0` was a negative number. So finish code was unified and ensured it will only run once, with no need to check `timeLeft`, and the time values were clamped to the tween duration.

## Summary

Fixed `finish()` being able to complete an already finished tween, and prevented `timeLeft` from going negative and `currentTime` from exceeding the duration.

- [x] Changeloged
