### PR TITLE
docs: add testing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,12 +45,19 @@ Normally the definitions of components, types, interfaces (i.e: `SpriteComp`,
 Your best option is use **ctrl + click** on the type to go to the definition and
 see the JSDoc comments. Other option is to use the search feature of your IDE.
 
+## Testing
+
+See [TESTING.md](TESTING.md) for what we test, where each kind of test goes, and
+when it's fine to skip one. Tests aren't required for every PR, if you skip one,
+a short reason in the PR is enough.
+
 ## Commiting your changes
 
 1. Follow our [conventional commits](#conventional-commits-guide) format. You
    can see how seeing the commit history.
 2. `pnpm run check` to check TypeScript.
 3. `pnpm run fmt` to format.
+4. `pnpm run test` and `pnpm run test:vite` to run the test suites.
 
 ## Conventional Commits Guide
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,52 @@
+# Testing KAPLAY
+
+A lot of KAPLAY is rendering, timing and feel, the kind of thing a script can't
+judge as right or wrong. So there isn't one conventional test suite, just a few
+tools for different jobs. This doc covers what exists, where each one goes, and
+when it's fine to skip.
+
+## What we have
+
+1. `pnpm run test:vite` runs Vitest.
+   - `tests/auto/*.spec.ts`: unit tests for pure logic only, no DOM, no canvas,
+     no timing. Math (`Vec2`, `Mat23`, `Color`), RNG, parsing, chord matching
+     logic.
+   - `tests/types/*.test-d.ts`: type-level tests (`vitest --typecheck`) for the
+     public type surface, plugin typing, `core/taf.ts` generics.
+2. `pnpm run test` runs a Puppeteer smoke test (`scripts/test.ts`). It opens
+   every file in `examples/*.js` and `tests/playtests/*.js` tagged `@test` in a
+   real browser for ~20 frames with synthetic input, and fails only if something
+   throws. It doesn't check correctness, just crashes.
+3. Manual: `pnpm dev` and look at it. This is the normal way to check anything
+   visual, not a shortcut for when you skipped writing a real test.
+
+## Where to add a test
+
+- Pure function bug (math, RNG, parsing, chord matching logic): extend a
+  `tests/auto/*.spec.ts`.
+- Type surface or generics (plugins, `core/taf.ts`, component option types):
+  extend a `tests/types/*.test-d.ts`.
+- Runtime bug or feature (a component, input, physics): add a
+  `tests/playtests/<name>.js` repro named after the bug, like `984.js`,
+  `area_add_race.js` or `sprite_anim_onend_restart.js`. Only add `@test` to it
+  if the failure can be expressed as a thrown error under synthetic input. Most
+  playtests aren't tagged, they're just there for `pnpm dev` checks later.
+- Editing an `examples/*.js` file that's tagged `@test`: don't break it under
+  synthetic input, and check it with `pnpm dev` before pushing.
+
+## When to skip a test
+
+Tests aren't required for every PR. Visual or feel changes (easing, particles, a
+shader) usually don't have anything worth asserting, "looks right" doesn't
+throw. If you skip a test, say why in the PR, one line like "visual change,
+verified with pnpm dev" is enough.
+
+## Before you push
+
+- `pnpm run check`
+- `pnpm run fmt`
+- `pnpm run test`
+- `pnpm run test:vite`
+
+CI runs format check, build, check, test and test:vite in that order, and all of
+them need to pass before merging to master.


### PR DESCRIPTION
<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

Not tied to a specific issue. Testing isn't documented anywhere right now,
`CONTRIBUTING.md` doesn't mention it at all, so it's a guess for anyone
contributing whether a change needs a vitest spec, a playtest, or nothing.
I ran into that gap myself while trying to get more involved here, and
figured writing down what's actually going on (a few different tools for
different situations, most `tests/playtests` files aren't even tagged
`@test` on purpose, etc.) would give everyone, myself included, the same
shared understanding instead of each contributor re-deriving it on their own.

## Summary

- Added `TESTING.md`: the three test tiers, where each kind of fix goes, and
  when it's fine to skip a test.
- Linked it from `CONTRIBUTING.md`, and added `pnpm run test` / `test:vite`
  to the pre-push checklist.

One thing I want to float rather than just decide: the doc suggests saying
why you're skipping a test, even if it's just "visual change, verified with
`pnpm dev`". Open to cutting that if it's not something you want to
normalize. As does quietly add the stupulation all PRs should at least 
address testing.

Also aware #1116 is reworking testing too (Playwright, `tests/e2e`, a new PR
template with reviewer-side test checkboxes). This doc will need a follow-up
once that lands, or I'm happy folding it into that PR instead if you'd
rather not have two testing changes in flight at once.

- [ ] Changeloged
