### PR TITLE
fix: resolve gamepad mappings by multi-tier matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,9 @@ So your change should look like:
   (#1112) - @imaginarny
 - Added a mapping for DualShock 4 gamepads, and a `controllerName` field on
   `KGamepad` for identifying the recognized controller model (#1119) - @CEREBR4L
-- Added a `type` field to `KGamepad` (`"playstation"`, `"xbox"`, `"switch"`, or
-  `undefined`) for picking button-glyph assets based on controller family
-  (#1119) - @CEREBR4L
+- Added a `type` field to `KGamepad` (`"ps4"`, `"ps5"`, `"playstation"`,
+  `"xbox"`, `"switch"`, a custom string, or `undefined`) for picking
+  button-glyph assets based on controller family (#1119) - @CEREBR4L
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ So your change should look like:
   (#1112) - @imaginarny
 - Added a mapping for DualShock 4 gamepads, and a `controllerName` field on
   `KGamepad` for identifying the recognized controller model (#1119) - @CEREBR4L
+- Added a `type` field to `KGamepad` (`"playstation"`, `"xbox"`, `"switch"`, or
+  `undefined`) for picking button-glyph assets based on controller family
+  (#1119) - @CEREBR4L
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ So your change should look like:
 - Added Alea as random generator (#1097) - @Stanko
 - Added `nextFrame()` helper function to defer/run a function on the next frame
   (#1112) - @imaginarny
-- Added a mapping for DualShock 4 gamepads, and a `controllerName` field on
-  `KGamepad` for identifying the recognized controller model (#1119) - @CEREBR4L
+- Added a mapping for DualShock 4 gamepads, and a `name` field on `KGamepad` for
+  identifying the recognized controller model (#1119) - @CEREBR4L
 - Added a `type` field to `KGamepad` (`"ps4"`, `"ps5"`, `"playstation"`,
   `"xbox"`, `"switch"`, a custom string, or `undefined`) for picking
   button-glyph assets based on controller family (#1119) - @CEREBR4L

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ So your change should look like:
 - Added Alea as random generator (#1097) - @Stanko
 - Added `nextFrame()` helper function to defer/run a function on the next frame
   (#1112) - @imaginarny
+- Added a mapping for DualShock 4 gamepads, and a `controllerName` field on
+  `KGamepad` for identifying the recognized controller model (#1119) - @CEREBR4L
 
 ### Changed
 
@@ -67,6 +69,9 @@ So your change should look like:
   `obj.pos.x += 1` work again (#1109) - @ErikGXDev
 - Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus
   (#1101) - @Stanko
+- Fixed gamepad button mappings (e.g. DualSense touchpad) breaking when the
+  browser's reported `Gamepad.id` format changes, by matching on vendor/product
+  id and controller name instead of the raw id string (#1119) - @CEREBR4L
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,6 +3,7 @@
 import type {
     Cursor,
     GameObj,
+    GamepadDef,
     KAPLAYOpt,
     Key,
     KGamepad,
@@ -34,6 +35,7 @@ import {
     releaseButton,
     setButton,
 } from "./buttons";
+import { resolveGamepadMap } from "./gamepadId";
 import {
     ButtonProcessor,
     type ButtonsDef,
@@ -59,7 +61,7 @@ export class ButtonState<T = string, A = never> {
     }
     process(state: AppState) {
         if (this._downEv !== null) {
-            this.down.forEach(b => {
+            this.down.forEach((b) => {
                 state.events.trigger(this._downEv as any, b, this._arg);
             });
         }
@@ -140,7 +142,7 @@ class FPSCounter {
         }
     }
     calculate() {
-        return this.fps = this.curNSamples / this.accumulator;
+        return (this.fps = this.curNSamples / this.accumulator);
     }
     ago(ago: number) {
         return this.history.at(this.i - ago - 1);
@@ -224,6 +226,9 @@ export const initAppState = (opt: {
         ),
         mergedGamepadState: new GamepadState(null),
         gamepadStates: new Map<number, GamepadState>(),
+        // resolved button map per gamepad index, computed once on connect
+        // rather than re-resolved from the raw id string every frame
+        gamepadMaps: new Map<number, GamepadDef>(),
         lastInputDevice: null as "mouse" | "keyboard" | "gamepad" | null,
         // unified input state
         gamepads: [] as KGamepad[],
@@ -263,8 +268,7 @@ export const initApp = (
 
     function updateCanvasScale() {
         const pd = opt.pixelDensity || 1;
-        state.canvasScaleX = state.canvas.width / pd
-            / state.canvas.offsetWidth;
+        state.canvasScaleX = state.canvas.width / pd / state.canvas.offsetWidth;
         state.canvasScaleY = state.canvas.height / pd
             / state.canvas.offsetHeight;
     }
@@ -307,7 +311,7 @@ export const initApp = (
 
     function screenshotToBlob(): Promise<Blob> {
         return new Promise<Blob>((resolve, reject) => {
-            state.canvas.toBlob(b => {
+            state.canvas.toBlob((b) => {
                 if (b !== null) resolve(b);
                 else reject(new Error("failed to make blob"));
             });
@@ -366,9 +370,11 @@ export const initApp = (
     }
 
     function isFullscreen(): boolean {
-        return document.fullscreenElement === state.canvas
+        return (
+            document.fullscreenElement === state.canvas
             // @ts-ignore
-            || document.webkitFullscreenElement === state.canvas;
+            || document.webkitFullscreenElement === state.canvas
+        );
     }
 
     const isFocused = () => {
@@ -470,7 +476,7 @@ export const initApp = (
     }
 
     function isTouchscreen() {
-        return ("ontouchstart" in window) || navigator.maxTouchPoints > 0;
+        return "ontouchstart" in window || navigator.maxTouchPoints > 0;
     }
 
     function mousePos(): Vec2 {
@@ -551,9 +557,7 @@ export const initApp = (
             );
     }
 
-    function getGamepadAnalogButton(
-        btn: KGamepadButton,
-    ): number {
+    function getGamepadAnalogButton(btn: KGamepadButton): number {
         return state.mergedGamepadState.analogState.get(btn) ?? 0;
     }
 
@@ -580,75 +584,99 @@ export const initApp = (
     }
 
     // input callbacks
-    const onKeyDown = overload2((action: (key: Key) => void) => {
-        return state.events.on("keyDown", action);
-    }, (key: Key | Key[], action: (key: Key) => void) => {
-        return state.events.on(
-            "keyDown",
-            (k) => isEqOrIncludes(key, k) && action(k),
-        );
-    });
+    const onKeyDown = overload2(
+        (action: (key: Key) => void) => {
+            return state.events.on("keyDown", action);
+        },
+        (key: Key | Key[], action: (key: Key) => void) => {
+            return state.events.on(
+                "keyDown",
+                (k) => isEqOrIncludes(key, k) && action(k),
+            );
+        },
+    );
 
     // key pressed is equal to the key by the user
-    const onKeyPress = overload2((action: (key: Key) => void) => {
-        return state.events.on("keyPress", (k) => action(k));
-    }, (key: Key | Key[], action: (key: Key) => void) => {
-        return state.events.on(
-            "keyPress",
-            (k) => isEqOrIncludes(key, k) && action(k),
-        );
-    });
+    const onKeyPress = overload2(
+        (action: (key: Key) => void) => {
+            return state.events.on("keyPress", (k) => action(k));
+        },
+        (key: Key | Key[], action: (key: Key) => void) => {
+            return state.events.on(
+                "keyPress",
+                (k) => isEqOrIncludes(key, k) && action(k),
+            );
+        },
+    );
 
-    const onKeyPressRepeat = overload2((action: (key: Key) => void) => {
-        return state.events.on("keyPressRepeat", action);
-    }, (key: Key | Key[], action: (key: Key) => void) => {
-        return state.events.on(
-            "keyPressRepeat",
-            (k) => isEqOrIncludes(key, k) && action(k),
-        );
-    });
+    const onKeyPressRepeat = overload2(
+        (action: (key: Key) => void) => {
+            return state.events.on("keyPressRepeat", action);
+        },
+        (key: Key | Key[], action: (key: Key) => void) => {
+            return state.events.on(
+                "keyPressRepeat",
+                (k) => isEqOrIncludes(key, k) && action(k),
+            );
+        },
+    );
 
-    const onKeyRelease = overload2((action: (key: Key) => void) => {
-        return state.events.on("keyRelease", action);
-    }, (key: Key | Key[], action: (key: Key) => void) => {
-        return state.events.on(
-            "keyRelease",
-            (k) => isEqOrIncludes(key, k) && action(k),
-        );
-    });
+    const onKeyRelease = overload2(
+        (action: (key: Key) => void) => {
+            return state.events.on("keyRelease", action);
+        },
+        (key: Key | Key[], action: (key: Key) => void) => {
+            return state.events.on(
+                "keyRelease",
+                (k) => isEqOrIncludes(key, k) && action(k),
+            );
+        },
+    );
 
-    const onMouseDown = overload2((action: (m: MouseButton) => void) => {
-        return state.events.on("mouseDown", (m) => action(m));
-    }, (
-        mouse: MouseButton | MouseButton[],
-        action: (m: MouseButton) => void,
-    ) => {
-        return state.events.on(
-            "mouseDown",
-            (m) => isEqOrIncludes(mouse, m) && action(m),
-        );
-    });
+    const onMouseDown = overload2(
+        (action: (m: MouseButton) => void) => {
+            return state.events.on("mouseDown", (m) => action(m));
+        },
+        (
+            mouse: MouseButton | MouseButton[],
+            action: (m: MouseButton) => void,
+        ) => {
+            return state.events.on(
+                "mouseDown",
+                (m) => isEqOrIncludes(mouse, m) && action(m),
+            );
+        },
+    );
 
-    const onMousePress = overload2((action: (m: MouseButton) => void) => {
-        return state.events.on("mousePress", (m) => action(m));
-    }, (
-        mouse: MouseButton | MouseButton[],
-        action: (m: MouseButton) => void,
-    ) => {
-        return state.events.on(
-            "mousePress",
-            (m) => isEqOrIncludes(mouse, m) && action(m),
-        );
-    });
+    const onMousePress = overload2(
+        (action: (m: MouseButton) => void) => {
+            return state.events.on("mousePress", (m) => action(m));
+        },
+        (
+            mouse: MouseButton | MouseButton[],
+            action: (m: MouseButton) => void,
+        ) => {
+            return state.events.on(
+                "mousePress",
+                (m) => isEqOrIncludes(mouse, m) && action(m),
+            );
+        },
+    );
 
-    const onMouseRelease = overload2((action: (m: MouseButton) => void) => {
-        return state.events.on("mouseRelease", (m) => action(m));
-    }, (
-        mouse: MouseButton | MouseButton[],
-        action: (m: MouseButton) => void,
-    ) => {
-        return state.events.on("mouseRelease", (m) => m === mouse && action(m));
-    });
+    const onMouseRelease = overload2(
+        (action: (m: MouseButton) => void) => {
+            return state.events.on("mouseRelease", (m) => action(m));
+        },
+        (
+            mouse: MouseButton | MouseButton[],
+            action: (m: MouseButton) => void,
+        ) => {
+            return state.events.on(
+                "mouseRelease",
+                (m) => m === mouse && action(m),
+            );
+        },
+    );
 
     function onMouseMove(f: (pos: Vec2, dpos: Vec2) => void): KEventController {
         return state.events.on(
@@ -779,32 +807,41 @@ export const initApp = (
         return [...state.gamepads];
     }
 
-    const onButtonPress = overload2((action: (btn: string) => void) => {
-        return state.events.on("buttonPress", (b) => action(b));
-    }, (btn: string | string, action: (btn: string) => void) => {
-        return state.events.on(
-            "buttonPress",
-            (b) => isEqOrIncludes(btn, b) && action(b),
-        );
-    });
+    const onButtonPress = overload2(
+        (action: (btn: string) => void) => {
+            return state.events.on("buttonPress", (b) => action(b));
+        },
+        (btn: string | string, action: (btn: string) => void) => {
+            return state.events.on(
+                "buttonPress",
+                (b) => isEqOrIncludes(btn, b) && action(b),
+            );
+        },
+    );
 
-    const onButtonDown = overload2((action: (btn: string) => void) => {
-        return state.events.on("buttonDown", (b) => action(b));
-    }, (btn: string | string, action: (btn: string) => void) => {
-        return state.events.on(
-            "buttonDown",
-            (b) => isEqOrIncludes(btn, b) && action(b),
-        );
-    });
+    const onButtonDown = overload2(
+        (action: (btn: string) => void) => {
+            return state.events.on("buttonDown", (b) => action(b));
+        },
+        (btn: string | string, action: (btn: string) => void) => {
+            return state.events.on(
+                "buttonDown",
+                (b) => isEqOrIncludes(btn, b) && action(b),
+            );
+        },
+    );
 
-    const onButtonRelease = overload2((action: (btn: string) => void) => {
-        return state.events.on("buttonRelease", (b) => action(b));
-    }, (btn: string | string, action: (btn: string) => void) => {
-        return state.events.on(
-            "buttonRelease",
-            (b) => isEqOrIncludes(btn, b) && action(b),
-        );
-    });
+    const onButtonRelease = overload2(
+        (action: (btn: string) => void) => {
+            return state.events.on("buttonRelease", (b) => action(b));
+        },
+        (btn: string | string, action: (btn: string) => void) => {
+            return state.events.on(
+                "buttonRelease",
+                (b) => isEqOrIncludes(btn, b) && action(b),
+            );
+        },
+    );
 
     const getLastInputDeviceType = () => {
         return state.lastInputDevice;
@@ -847,30 +884,51 @@ export const initApp = (
     }
 
     function registerGamepad(browserGamepad: Gamepad) {
+        // Custom maps (opt.gamepads) stay keyed by literal id for backwards
+        // compatibility; see gamepadId.ts for the vendor:product resolution.
+        const { map: gamepadMap, controllerName } = resolveGamepadMap(
+            browserGamepad.id,
+            GP_MAP,
+            opt.gamepads,
+        );
+
         const gamepad: KGamepad = {
             index: browserGamepad.index,
+            controllerName,
             isPressed: (btn: KGamepadButton) => {
-                return state.gamepadStates.get(browserGamepad.index)
-                    ?.buttonState
-                    .pressed.has(btn) || false;
+                return (
+                    state.gamepadStates
+                        .get(browserGamepad.index)
+                        ?.buttonState.pressed.has(btn) || false
+                );
             },
             isDown: (btn: KGamepadButton) => {
-                return state.gamepadStates.get(browserGamepad.index)
-                    ?.buttonState
-                    .down.has(btn) || false;
+                return (
+                    state.gamepadStates
+                        .get(browserGamepad.index)
+                        ?.buttonState.down.has(btn) || false
+                );
             },
             isReleased: (btn: KGamepadButton) => {
-                return state.gamepadStates.get(browserGamepad.index)
-                    ?.buttonState
-                    .released.has(btn) || false;
+                return (
+                    state.gamepadStates
+                        .get(browserGamepad.index)
+                        ?.buttonState.released.has(btn) || false
+                );
             },
             getStick: (stick: KGamepadStick) => {
-                return state.gamepadStates.get(browserGamepad.index)?.stickState
-                    .get(stick) || vec2();
+                return (
+                    state.gamepadStates
+                        .get(browserGamepad.index)
+                        ?.stickState.get(stick) || vec2()
+                );
             },
             getAnalog: (button: KGamepadButton) => {
-                return state.gamepadStates.get(browserGamepad.index)
-                    ?.analogState.get(button) ?? 0;
+                return (
+                    state.gamepadStates
+                        .get(browserGamepad.index)
+                        ?.analogState.get(button) ?? 0
+                );
             },
         };
 
@@ -880,6 +938,7 @@ export const initApp = (
             browserGamepad.index,
             new GamepadState(gamepad),
         );
+        state.gamepadMaps.set(browserGamepad.index, gamepadMap);
 
         return gamepad;
     }
@@ -889,15 +948,14 @@ export const initApp = (
             g.index !== gamepad.index
         );
         state.gamepadStates.delete(gamepad.index);
+        state.gamepadMaps.delete(gamepad.index);
     }
 
     // TODO: Clean up this function
     function processGamepad() {
         for (const browserGamepad of navigator.getGamepads()) {
             if (
-                browserGamepad && !state.gamepadStates.has(
-                    browserGamepad.index,
-                )
+                browserGamepad && !state.gamepadStates.has(browserGamepad.index)
             ) {
                 registerGamepad(browserGamepad);
             }
@@ -907,9 +965,8 @@ export const initApp = (
             const browserGamepad = navigator.getGamepads()[gamepad.index];
             if (!browserGamepad) continue;
 
-            const customMap = opt.gamepads ?? {};
-            const map = customMap[browserGamepad.id]
-                || GP_MAP[browserGamepad.id] || GP_MAP["default"];
+            const map = state.gamepadMaps.get(gamepad.index)
+                ?? GP_MAP["default"];
             const gamepadState = state.gamepadStates.get(gamepad.index);
             if (!gamepadState) continue;
 
@@ -1035,13 +1092,13 @@ export const initApp = (
             const rc = cw / ch;
             if (rw > rc) {
                 const ratio = wh / ch;
-                const offset = (ww - (cw * ratio)) / 2;
+                const offset = (ww - cw * ratio) / 2;
                 mousePos.x = map(e.offsetX - offset, 0, cw * ratio, 0, cw);
                 mousePos.y = map(e.offsetY, 0, ch * ratio, 0, ch);
             }
             else {
                 const ratio = ww / cw;
-                const offset = (wh - (ch * ratio)) / 2;
+                const offset = (wh - ch * ratio) / 2;
                 mousePos.x = map(e.offsetX, 0, cw * ratio, 0, cw);
                 mousePos.y = map(e.offsetY - offset, 0, ch * ratio, 0, ch);
             }
@@ -1096,10 +1153,10 @@ export const initApp = (
 
     // translate these key names to a simpler version
     const KEY_ALIAS = {
-        "ArrowLeft": "left",
-        "ArrowRight": "right",
-        "ArrowUp": "up",
-        "ArrowDown": "down",
+        ArrowLeft: "left",
+        ArrowRight: "right",
+        ArrowUp: "up",
+        ArrowDown: "down",
         " ": "space",
     };
 
@@ -1110,7 +1167,7 @@ export const initApp = (
             e.preventDefault();
         }
         state.events.onOnce("input", () => {
-            const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
+            const k: Key = (KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key)
                 || e.key.toLowerCase();
             const code = e.code;
 
@@ -1136,7 +1193,7 @@ export const initApp = (
 
     canvasEvents.keyup = (e) => {
         state.events.onOnce("input", () => {
-            const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
+            const k: Key = (KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key)
                 || e.key.toLowerCase();
             const code = e.code;
 
@@ -1170,10 +1227,7 @@ export const initApp = (
                 state.events.trigger(
                     "touchStart",
                     canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
+                        new Vec2(t.clientX - box.x, t.clientY - box.y),
                     ),
                     t,
                 );
@@ -1204,10 +1258,7 @@ export const initApp = (
                 state.events.trigger(
                     "touchMove",
                     canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
+                        new Vec2(t.clientX - box.x, t.clientY - box.y),
                     ),
                     t,
                 );
@@ -1236,10 +1287,7 @@ export const initApp = (
                 state.events.trigger(
                     "touchEnd",
                     canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
+                        new Vec2(t.clientX - box.x, t.clientY - box.y),
                     ),
                     t,
                 );
@@ -1266,10 +1314,7 @@ export const initApp = (
                 state.events.trigger(
                     "touchEnd",
                     canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
+                        new Vec2(t.clientX - box.x, t.clientY - box.y),
                     ),
                     t,
                 );
@@ -1313,8 +1358,9 @@ export const initApp = (
     };
 
     winEvents.gamepaddisconnected = (e) => {
-        const kbGamepad =
-            getGamepads().filter((g) => g.index === e.gamepad.index)[0];
+        const kbGamepad = getGamepads().filter(
+            (g) => g.index === e.gamepad.index,
+        )[0];
         removeGamepad(e.gamepad);
         state.events.onOnce("input", () => {
             state.events.trigger("gamepadDisconnect", kbGamepad);
@@ -1348,7 +1394,9 @@ export const initApp = (
             if (
                 state.lastWidth === state.canvas.offsetWidth
                 && state.lastHeight === state.canvas.offsetHeight
-            ) return;
+            ) {
+                return;
+            }
             state.lastWidth = state.canvas.offsetWidth;
             state.lastHeight = state.canvas.offsetHeight;
             updateCanvasScale();

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -859,12 +859,12 @@ export const initApp = (
             GP_MAP,
             opt.gamepads,
         );
-        const { map: gamepadMap, controllerName } = gamepadResolution;
+        const { map: gamepadMap, name } = gamepadResolution;
         const type = detectGamepadType(gamepadResolution);
 
         const gamepad: KGamepad = {
             index: browserGamepad.index,
-            controllerName,
+            name,
             type,
             isPressed: (btn: KGamepadButton) => {
                 return state.gamepadStates.get(browserGamepad.index)

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -35,7 +35,7 @@ import {
     releaseButton,
     setButton,
 } from "./buttons";
-import { resolveGamepadMap } from "./gamepadId";
+import { detectGamepadType, resolveGamepadMap } from "./gamepadId";
 import {
     ButtonProcessor,
     type ButtonsDef,
@@ -854,15 +854,18 @@ export const initApp = (
     function registerGamepad(browserGamepad: Gamepad) {
         // Custom maps (opt.gamepads) stay keyed by literal id for backwards
         // compatibility; see gamepadId.ts for the vendor:product resolution.
-        const { map: gamepadMap, controllerName } = resolveGamepadMap(
+        const gamepadResolution = resolveGamepadMap(
             browserGamepad.id,
             GP_MAP,
             opt.gamepads,
         );
+        const { map: gamepadMap, controllerName } = gamepadResolution;
+        const type = detectGamepadType(gamepadResolution);
 
         const gamepad: KGamepad = {
             index: browserGamepad.index,
             controllerName,
+            type,
             isPressed: (btn: KGamepadButton) => {
                 return state.gamepadStates.get(browserGamepad.index)
                     ?.buttonState

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -61,7 +61,7 @@ export class ButtonState<T = string, A = never> {
     }
     process(state: AppState) {
         if (this._downEv !== null) {
-            this.down.forEach((b) => {
+            this.down.forEach(b => {
                 state.events.trigger(this._downEv as any, b, this._arg);
             });
         }
@@ -142,7 +142,7 @@ class FPSCounter {
         }
     }
     calculate() {
-        return (this.fps = this.curNSamples / this.accumulator);
+        return this.fps = this.curNSamples / this.accumulator;
     }
     ago(ago: number) {
         return this.history.at(this.i - ago - 1);
@@ -268,7 +268,8 @@ export const initApp = (
 
     function updateCanvasScale() {
         const pd = opt.pixelDensity || 1;
-        state.canvasScaleX = state.canvas.width / pd / state.canvas.offsetWidth;
+        state.canvasScaleX = state.canvas.width / pd
+            / state.canvas.offsetWidth;
         state.canvasScaleY = state.canvas.height / pd
             / state.canvas.offsetHeight;
     }
@@ -311,7 +312,7 @@ export const initApp = (
 
     function screenshotToBlob(): Promise<Blob> {
         return new Promise<Blob>((resolve, reject) => {
-            state.canvas.toBlob((b) => {
+            state.canvas.toBlob(b => {
                 if (b !== null) resolve(b);
                 else reject(new Error("failed to make blob"));
             });
@@ -370,11 +371,9 @@ export const initApp = (
     }
 
     function isFullscreen(): boolean {
-        return (
-            document.fullscreenElement === state.canvas
+        return document.fullscreenElement === state.canvas
             // @ts-ignore
-            || document.webkitFullscreenElement === state.canvas
-        );
+            || document.webkitFullscreenElement === state.canvas;
     }
 
     const isFocused = () => {
@@ -476,7 +475,7 @@ export const initApp = (
     }
 
     function isTouchscreen() {
-        return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+        return ("ontouchstart" in window) || navigator.maxTouchPoints > 0;
     }
 
     function mousePos(): Vec2 {
@@ -557,7 +556,9 @@ export const initApp = (
             );
     }
 
-    function getGamepadAnalogButton(btn: KGamepadButton): number {
+    function getGamepadAnalogButton(
+        btn: KGamepadButton,
+    ): number {
         return state.mergedGamepadState.analogState.get(btn) ?? 0;
     }
 
@@ -584,99 +585,75 @@ export const initApp = (
     }
 
     // input callbacks
-    const onKeyDown = overload2(
-        (action: (key: Key) => void) => {
-            return state.events.on("keyDown", action);
-        },
-        (key: Key | Key[], action: (key: Key) => void) => {
-            return state.events.on(
-                "keyDown",
-                (k) => isEqOrIncludes(key, k) && action(k),
-            );
-        },
-    );
+    const onKeyDown = overload2((action: (key: Key) => void) => {
+        return state.events.on("keyDown", action);
+    }, (key: Key | Key[], action: (key: Key) => void) => {
+        return state.events.on(
+            "keyDown",
+            (k) => isEqOrIncludes(key, k) && action(k),
+        );
+    });
 
     // key pressed is equal to the key by the user
-    const onKeyPress = overload2(
-        (action: (key: Key) => void) => {
-            return state.events.on("keyPress", (k) => action(k));
-        },
-        (key: Key | Key[], action: (key: Key) => void) => {
-            return state.events.on(
-                "keyPress",
-                (k) => isEqOrIncludes(key, k) && action(k),
-            );
-        },
-    );
+    const onKeyPress = overload2((action: (key: Key) => void) => {
+        return state.events.on("keyPress", (k) => action(k));
+    }, (key: Key | Key[], action: (key: Key) => void) => {
+        return state.events.on(
+            "keyPress",
+            (k) => isEqOrIncludes(key, k) && action(k),
+        );
+    });
 
-    const onKeyPressRepeat = overload2(
-        (action: (key: Key) => void) => {
-            return state.events.on("keyPressRepeat", action);
-        },
-        (key: Key | Key[], action: (key: Key) => void) => {
-            return state.events.on(
-                "keyPressRepeat",
-                (k) => isEqOrIncludes(key, k) && action(k),
-            );
-        },
-    );
+    const onKeyPressRepeat = overload2((action: (key: Key) => void) => {
+        return state.events.on("keyPressRepeat", action);
+    }, (key: Key | Key[], action: (key: Key) => void) => {
+        return state.events.on(
+            "keyPressRepeat",
+            (k) => isEqOrIncludes(key, k) && action(k),
+        );
+    });
 
-    const onKeyRelease = overload2(
-        (action: (key: Key) => void) => {
-            return state.events.on("keyRelease", action);
-        },
-        (key: Key | Key[], action: (key: Key) => void) => {
-            return state.events.on(
-                "keyRelease",
-                (k) => isEqOrIncludes(key, k) && action(k),
-            );
-        },
-    );
+    const onKeyRelease = overload2((action: (key: Key) => void) => {
+        return state.events.on("keyRelease", action);
+    }, (key: Key | Key[], action: (key: Key) => void) => {
+        return state.events.on(
+            "keyRelease",
+            (k) => isEqOrIncludes(key, k) && action(k),
+        );
+    });
 
-    const onMouseDown = overload2(
-        (action: (m: MouseButton) => void) => {
-            return state.events.on("mouseDown", (m) => action(m));
-        },
-        (
-            mouse: MouseButton | MouseButton[],
-            action: (m: MouseButton) => void,
-        ) => {
-            return state.events.on(
-                "mouseDown",
-                (m) => isEqOrIncludes(mouse, m) && action(m),
-            );
-        },
-    );
+    const onMouseDown = overload2((action: (m: MouseButton) => void) => {
+        return state.events.on("mouseDown", (m) => action(m));
+    }, (
+        mouse: MouseButton | MouseButton[],
+        action: (m: MouseButton) => void,
+    ) => {
+        return state.events.on(
+            "mouseDown",
+            (m) => isEqOrIncludes(mouse, m) && action(m),
+        );
+    });
 
-    const onMousePress = overload2(
-        (action: (m: MouseButton) => void) => {
-            return state.events.on("mousePress", (m) => action(m));
-        },
-        (
-            mouse: MouseButton | MouseButton[],
-            action: (m: MouseButton) => void,
-        ) => {
-            return state.events.on(
-                "mousePress",
-                (m) => isEqOrIncludes(mouse, m) && action(m),
-            );
-        },
-    );
+    const onMousePress = overload2((action: (m: MouseButton) => void) => {
+        return state.events.on("mousePress", (m) => action(m));
+    }, (
+        mouse: MouseButton | MouseButton[],
+        action: (m: MouseButton) => void,
+    ) => {
+        return state.events.on(
+            "mousePress",
+            (m) => isEqOrIncludes(mouse, m) && action(m),
+        );
+    });
 
-    const onMouseRelease = overload2(
-        (action: (m: MouseButton) => void) => {
-            return state.events.on("mouseRelease", (m) => action(m));
-        },
-        (
-            mouse: MouseButton | MouseButton[],
-            action: (m: MouseButton) => void,
-        ) => {
-            return state.events.on(
-                "mouseRelease",
-                (m) => m === mouse && action(m),
-            );
-        },
-    );
+    const onMouseRelease = overload2((action: (m: MouseButton) => void) => {
+        return state.events.on("mouseRelease", (m) => action(m));
+    }, (
+        mouse: MouseButton | MouseButton[],
+        action: (m: MouseButton) => void,
+    ) => {
+        return state.events.on("mouseRelease", (m) => m === mouse && action(m));
+    });
 
     function onMouseMove(f: (pos: Vec2, dpos: Vec2) => void): KEventController {
         return state.events.on(
@@ -807,41 +784,32 @@ export const initApp = (
         return [...state.gamepads];
     }
 
-    const onButtonPress = overload2(
-        (action: (btn: string) => void) => {
-            return state.events.on("buttonPress", (b) => action(b));
-        },
-        (btn: string | string, action: (btn: string) => void) => {
-            return state.events.on(
-                "buttonPress",
-                (b) => isEqOrIncludes(btn, b) && action(b),
-            );
-        },
-    );
+    const onButtonPress = overload2((action: (btn: string) => void) => {
+        return state.events.on("buttonPress", (b) => action(b));
+    }, (btn: string | string, action: (btn: string) => void) => {
+        return state.events.on(
+            "buttonPress",
+            (b) => isEqOrIncludes(btn, b) && action(b),
+        );
+    });
 
-    const onButtonDown = overload2(
-        (action: (btn: string) => void) => {
-            return state.events.on("buttonDown", (b) => action(b));
-        },
-        (btn: string | string, action: (btn: string) => void) => {
-            return state.events.on(
-                "buttonDown",
-                (b) => isEqOrIncludes(btn, b) && action(b),
-            );
-        },
-    );
+    const onButtonDown = overload2((action: (btn: string) => void) => {
+        return state.events.on("buttonDown", (b) => action(b));
+    }, (btn: string | string, action: (btn: string) => void) => {
+        return state.events.on(
+            "buttonDown",
+            (b) => isEqOrIncludes(btn, b) && action(b),
+        );
+    });
 
-    const onButtonRelease = overload2(
-        (action: (btn: string) => void) => {
-            return state.events.on("buttonRelease", (b) => action(b));
-        },
-        (btn: string | string, action: (btn: string) => void) => {
-            return state.events.on(
-                "buttonRelease",
-                (b) => isEqOrIncludes(btn, b) && action(b),
-            );
-        },
-    );
+    const onButtonRelease = overload2((action: (btn: string) => void) => {
+        return state.events.on("buttonRelease", (b) => action(b));
+    }, (btn: string | string, action: (btn: string) => void) => {
+        return state.events.on(
+            "buttonRelease",
+            (b) => isEqOrIncludes(btn, b) && action(b),
+        );
+    });
 
     const getLastInputDeviceType = () => {
         return state.lastInputDevice;
@@ -896,39 +864,27 @@ export const initApp = (
             index: browserGamepad.index,
             controllerName,
             isPressed: (btn: KGamepadButton) => {
-                return (
-                    state.gamepadStates
-                        .get(browserGamepad.index)
-                        ?.buttonState.pressed.has(btn) || false
-                );
+                return state.gamepadStates.get(browserGamepad.index)
+                    ?.buttonState
+                    .pressed.has(btn) || false;
             },
             isDown: (btn: KGamepadButton) => {
-                return (
-                    state.gamepadStates
-                        .get(browserGamepad.index)
-                        ?.buttonState.down.has(btn) || false
-                );
+                return state.gamepadStates.get(browserGamepad.index)
+                    ?.buttonState
+                    .down.has(btn) || false;
             },
             isReleased: (btn: KGamepadButton) => {
-                return (
-                    state.gamepadStates
-                        .get(browserGamepad.index)
-                        ?.buttonState.released.has(btn) || false
-                );
+                return state.gamepadStates.get(browserGamepad.index)
+                    ?.buttonState
+                    .released.has(btn) || false;
             },
             getStick: (stick: KGamepadStick) => {
-                return (
-                    state.gamepadStates
-                        .get(browserGamepad.index)
-                        ?.stickState.get(stick) || vec2()
-                );
+                return state.gamepadStates.get(browserGamepad.index)?.stickState
+                    .get(stick) || vec2();
             },
             getAnalog: (button: KGamepadButton) => {
-                return (
-                    state.gamepadStates
-                        .get(browserGamepad.index)
-                        ?.analogState.get(button) ?? 0
-                );
+                return state.gamepadStates.get(browserGamepad.index)
+                    ?.analogState.get(button) ?? 0;
             },
         };
 
@@ -955,7 +911,9 @@ export const initApp = (
     function processGamepad() {
         for (const browserGamepad of navigator.getGamepads()) {
             if (
-                browserGamepad && !state.gamepadStates.has(browserGamepad.index)
+                browserGamepad && !state.gamepadStates.has(
+                    browserGamepad.index,
+                )
             ) {
                 registerGamepad(browserGamepad);
             }
@@ -1092,13 +1050,13 @@ export const initApp = (
             const rc = cw / ch;
             if (rw > rc) {
                 const ratio = wh / ch;
-                const offset = (ww - cw * ratio) / 2;
+                const offset = (ww - (cw * ratio)) / 2;
                 mousePos.x = map(e.offsetX - offset, 0, cw * ratio, 0, cw);
                 mousePos.y = map(e.offsetY, 0, ch * ratio, 0, ch);
             }
             else {
                 const ratio = ww / cw;
-                const offset = (wh - ch * ratio) / 2;
+                const offset = (wh - (ch * ratio)) / 2;
                 mousePos.x = map(e.offsetX, 0, cw * ratio, 0, cw);
                 mousePos.y = map(e.offsetY - offset, 0, ch * ratio, 0, ch);
             }
@@ -1153,10 +1111,10 @@ export const initApp = (
 
     // translate these key names to a simpler version
     const KEY_ALIAS = {
-        ArrowLeft: "left",
-        ArrowRight: "right",
-        ArrowUp: "up",
-        ArrowDown: "down",
+        "ArrowLeft": "left",
+        "ArrowRight": "right",
+        "ArrowUp": "up",
+        "ArrowDown": "down",
         " ": "space",
     };
 
@@ -1167,7 +1125,7 @@ export const initApp = (
             e.preventDefault();
         }
         state.events.onOnce("input", () => {
-            const k: Key = (KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key)
+            const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
                 || e.key.toLowerCase();
             const code = e.code;
 
@@ -1193,7 +1151,7 @@ export const initApp = (
 
     canvasEvents.keyup = (e) => {
         state.events.onOnce("input", () => {
-            const k: Key = (KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key)
+            const k: Key = KEY_ALIAS[e.key as keyof typeof KEY_ALIAS] as Key
                 || e.key.toLowerCase();
             const code = e.code;
 
@@ -1227,7 +1185,10 @@ export const initApp = (
                 state.events.trigger(
                     "touchStart",
                     canvasToViewport(
-                        new Vec2(t.clientX - box.x, t.clientY - box.y),
+                        new Vec2(
+                            t.clientX - box.x,
+                            t.clientY - box.y,
+                        ),
                     ),
                     t,
                 );
@@ -1258,7 +1219,10 @@ export const initApp = (
                 state.events.trigger(
                     "touchMove",
                     canvasToViewport(
-                        new Vec2(t.clientX - box.x, t.clientY - box.y),
+                        new Vec2(
+                            t.clientX - box.x,
+                            t.clientY - box.y,
+                        ),
                     ),
                     t,
                 );
@@ -1287,7 +1251,10 @@ export const initApp = (
                 state.events.trigger(
                     "touchEnd",
                     canvasToViewport(
-                        new Vec2(t.clientX - box.x, t.clientY - box.y),
+                        new Vec2(
+                            t.clientX - box.x,
+                            t.clientY - box.y,
+                        ),
                     ),
                     t,
                 );
@@ -1314,7 +1281,10 @@ export const initApp = (
                 state.events.trigger(
                     "touchEnd",
                     canvasToViewport(
-                        new Vec2(t.clientX - box.x, t.clientY - box.y),
+                        new Vec2(
+                            t.clientX - box.x,
+                            t.clientY - box.y,
+                        ),
                     ),
                     t,
                 );
@@ -1358,9 +1328,8 @@ export const initApp = (
     };
 
     winEvents.gamepaddisconnected = (e) => {
-        const kbGamepad = getGamepads().filter(
-            (g) => g.index === e.gamepad.index,
-        )[0];
+        const kbGamepad =
+            getGamepads().filter((g) => g.index === e.gamepad.index)[0];
         removeGamepad(e.gamepad);
         state.events.onOnce("input", () => {
             state.events.trigger("gamepadDisconnect", kbGamepad);
@@ -1394,9 +1363,7 @@ export const initApp = (
             if (
                 state.lastWidth === state.canvas.offsetWidth
                 && state.lastHeight === state.canvas.offsetHeight
-            ) {
-                return;
-            }
+            ) return;
             state.lastWidth = state.canvas.offsetWidth;
             state.lastHeight = state.canvas.offsetHeight;
             updateCanvasScale();

--- a/src/app/gamepadId.ts
+++ b/src/app/gamepadId.ts
@@ -62,7 +62,9 @@ export function resolveGamepadMap(
 }
 
 // Vendor-only fallback for controllers with no `type` in the table (e.g.
-// Xbox, which already works under "default" and isn't in GP_MAP).
+// Xbox, which already works under "default" and isn't in GP_MAP). Sony maps
+// to the generic "playstation" here rather than ps4/ps5 - 054c alone doesn't
+// say which generation, and a usable "it's a PlayStation pad" beats undefined.
 const VENDOR_ONLY_TYPE: Record<string, GamepadType> = {
     "054c": "playstation", // Sony
     "045e": "xbox", // Microsoft
@@ -71,7 +73,8 @@ const VENDOR_ONLY_TYPE: Record<string, GamepadType> = {
 
 // Resolves a controller family from an already-resolved gamepad map, so it
 // gets the same name-fallback recovery as `controllerName`. Priority:
-// resolved map's `type` > vendor-only fallback > undefined.
+// resolved map's exact `type` (ps4/ps5) > vendor-only fallback (playstation)
+// > undefined.
 export function detectGamepadType(
     { map, vidPid }: Pick<GamepadMapResolution, "map" | "vidPid">,
 ): GamepadType | undefined {

--- a/src/app/gamepadId.ts
+++ b/src/app/gamepadId.ts
@@ -42,7 +42,7 @@ function matchByName(
 export type GamepadMapResolution = {
     map: GamepadDef;
     vidPid: string | null;
-    controllerName: string;
+    name: string;
 };
 
 // Resolves the GamepadDef for a raw Gamepad.id. Pure function (no DOM
@@ -58,7 +58,7 @@ export function resolveGamepadMap(
         ?? (vidPid ? builtins[vidPid] : undefined)
         ?? matchByName(id, builtins)
         ?? builtins["default"];
-    return { map, vidPid, controllerName: map.name ?? "Standard Gamepad" };
+    return { map, vidPid, name: map.name ?? "Standard Gamepad" };
 }
 
 // Vendor-only fallback for controllers with no `type` in the table (e.g.
@@ -72,7 +72,7 @@ const VENDOR_ONLY_TYPE: Record<string, GamepadType> = {
 };
 
 // Resolves a controller family from an already-resolved gamepad map, so it
-// gets the same name-fallback recovery as `controllerName`. Priority:
+// gets the same name-fallback recovery as `name`. Priority:
 // resolved map's exact `type` (ps4/ps5) > vendor-only fallback (playstation)
 // > undefined.
 export function detectGamepadType(

--- a/src/app/gamepadId.ts
+++ b/src/app/gamepadId.ts
@@ -1,0 +1,62 @@
+import type { GamepadDef } from "../types";
+
+// Gamepad.id isn't standardized by spec, and its format has changed across
+// browser versions (PRs #867 & #1110), so we match on vendor:product hex
+// when present rather than the raw id string.
+// https://w3c.github.io/gamepad/#dom-gamepad-id
+// https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/id
+
+// Chrome/Chromium/Opera: "<name> ([STANDARD GAMEPAD ]Vendor: xxxx Product: yyyy)"
+const CHROME_VID_PID =
+    /vendor:\s*([0-9a-f]{1,4})\D+product:\s*([0-9a-f]{1,4})/i;
+// Firefox/Safari: "xxxx-yyyy-<name>"
+const DASH_VID_PID = /^([0-9a-f]{1,4})-([0-9a-f]{1,4})-/i;
+
+// Extracts a "vendor:product" key from a Gamepad.id, or null if the browser
+// didn't expose one (Safari name-only ids, Chrome XInput devices, etc).
+export function parseGamepadVidPid(id: string): string | null {
+    const match = id.match(CHROME_VID_PID) ?? id.match(DASH_VID_PID);
+    if (!match) return null;
+    const vendor = match[1].toLowerCase().padStart(4, "0");
+    const product = match[2].toLowerCase().padStart(4, "0");
+    return `${vendor}:${product}`;
+}
+
+// Fallback for when vendor/product is stripped entirely. Only safe for
+// controllers whose name text is itself distinctive - not used for e.g.
+// DualShock 4, whose reported name is just the generic "Wireless Controller".
+function matchByName(
+    id: string,
+    builtins: Record<string, GamepadDef>,
+): GamepadDef | undefined {
+    const lowerId = id.toLowerCase();
+    for (const key in builtins) {
+        const entry = builtins[key];
+        if (entry.matchNames?.some(name => lowerId.includes(name))) {
+            return entry;
+        }
+    }
+    return undefined;
+}
+
+export type GamepadMapResolution = {
+    map: GamepadDef;
+    vidPid: string | null;
+    controllerName: string;
+};
+
+// Resolves the GamepadDef for a raw Gamepad.id. Pure function (no DOM
+// dependency), so it's directly unit-testable. Priority: exact match in
+// customMap > vendor:product match > name-substring fallback > "default".
+export function resolveGamepadMap(
+    id: string,
+    builtins: Record<string, GamepadDef>,
+    customMap: Record<string, GamepadDef> = {},
+): GamepadMapResolution {
+    const vidPid = parseGamepadVidPid(id);
+    const map = customMap[id]
+        ?? (vidPid ? builtins[vidPid] : undefined)
+        ?? matchByName(id, builtins)
+        ?? builtins["default"];
+    return { map, vidPid, controllerName: map.name ?? "Standard Gamepad" };
+}

--- a/src/app/gamepadId.ts
+++ b/src/app/gamepadId.ts
@@ -1,4 +1,4 @@
-import type { GamepadDef } from "../types";
+import type { GamepadDef, GamepadType } from "../types";
 
 // Gamepad.id isn't standardized by spec, and its format has changed across
 // browser versions (PRs #867 & #1110), so we match on vendor:product hex
@@ -59,4 +59,25 @@ export function resolveGamepadMap(
         ?? matchByName(id, builtins)
         ?? builtins["default"];
     return { map, vidPid, controllerName: map.name ?? "Standard Gamepad" };
+}
+
+// Vendor-only fallback for controllers with no `type` in the table (e.g.
+// Xbox, which already works under "default" and isn't in GP_MAP).
+const VENDOR_ONLY_TYPE: Record<string, GamepadType> = {
+    "054c": "playstation", // Sony
+    "045e": "xbox", // Microsoft
+    "057e": "switch", // Nintendo
+};
+
+// Resolves a controller family from an already-resolved gamepad map, so it
+// gets the same name-fallback recovery as `controllerName`. Priority:
+// resolved map's `type` > vendor-only fallback > undefined.
+export function detectGamepadType(
+    { map, vidPid }: Pick<GamepadMapResolution, "map" | "vidPid">,
+): GamepadType | undefined {
+    if (map.type) return map.type;
+    if (!vidPid) return undefined;
+
+    const [vendor] = vidPid.split(":");
+    return VENDOR_ONLY_TYPE[vendor];
 }

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -8,6 +8,7 @@ Constants should be SNAKE_CASE
 */
 
 import GAMEPAD_MAP from "../data/gamepad.json" assert { type: "json" };
+import type { GamepadDef } from "../types";
 
 // some default charsets for loading bitmap fonts
 export const ASCII_CHARS =
@@ -49,6 +50,6 @@ export const DEF_JUMP_FORCE = 640;
 export const MAX_VEL = 65536;
 export const EVENT_CANCEL_SYMBOL = Symbol.for("kaplay.cancel");
 
-export const GP_MAP = GAMEPAD_MAP as unknown as Record<string, string>;
+export const GP_MAP = GAMEPAD_MAP as unknown as Record<string, GamepadDef>;
 
 export const MAX_TRIES = 20;

--- a/src/data/gamepad.json
+++ b/src/data/gamepad.json
@@ -1,6 +1,7 @@
 {
   "057e:200e": {
     "name": "Joy-Con L+R",
+    "type": "switch",
     "matchNames": ["joy-con l+r"],
     "buttons": {
       "0": "south",
@@ -29,6 +30,7 @@
   },
   "057e:2006": {
     "name": "Joy-Con (L)",
+    "type": "switch",
     "matchNames": ["joy-con (l)"],
     "buttons": {
       "0": "south",
@@ -47,6 +49,7 @@
   },
   "057e:2007": {
     "name": "Joy-Con (R)",
+    "type": "switch",
     "matchNames": ["joy-con (r)"],
     "buttons": {
       "0": "south",
@@ -65,6 +68,7 @@
   },
   "057e:2009": {
     "name": "Switch Pro Controller",
+    "type": "switch",
     "matchNames": ["pro controller"],
     "buttons": {
       "0": "south",
@@ -93,6 +97,7 @@
   },
   "054c:0ce6": {
     "name": "DualSense",
+    "type": "playstation",
     "matchNames": ["dualsense"],
     "buttons": {
       "0": "south",
@@ -121,6 +126,7 @@
   },
   "054c:05c4": {
     "name": "DualShock 4",
+    "type": "playstation",
     "buttons": {
       "0": "south",
       "1": "east",
@@ -148,6 +154,7 @@
   },
   "054c:09cc": {
     "name": "DualShock 4",
+    "type": "playstation",
     "buttons": {
       "0": "south",
       "1": "east",

--- a/src/data/gamepad.json
+++ b/src/data/gamepad.json
@@ -1,5 +1,7 @@
 {
-  "Joy-Con L+R (STANDARD GAMEPAD Vendor: 057e Product: 200e)": {
+  "057e:200e": {
+    "name": "Joy-Con L+R",
+    "matchNames": ["joy-con l+r"],
     "buttons": {
       "0": "south",
       "1": "east",
@@ -25,7 +27,9 @@
       "right": { "x": 2, "y": 3 }
     }
   },
-  "Joy-Con (L) (STANDARD GAMEPAD Vendor: 057e Product: 2006)": {
+  "057e:2006": {
+    "name": "Joy-Con (L)",
+    "matchNames": ["joy-con (l)"],
     "buttons": {
       "0": "south",
       "1": "east",
@@ -41,7 +45,9 @@
       "left": { "x": 0, "y": 1 }
     }
   },
-  "Joy-Con (R) (STANDARD GAMEPAD Vendor: 057e Product: 2007)": {
+  "057e:2007": {
+    "name": "Joy-Con (R)",
+    "matchNames": ["joy-con (r)"],
     "buttons": {
       "0": "south",
       "1": "east",
@@ -57,7 +63,9 @@
       "left": { "x": 0, "y": 1 }
     }
   },
-  "Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)": {
+  "057e:2009": {
+    "name": "Switch Pro Controller",
+    "matchNames": ["pro controller"],
     "buttons": {
       "0": "south",
       "1": "east",
@@ -83,7 +91,63 @@
       "right": { "x": 2, "y": 3 }
     }
   },
-  "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)": {
+  "054c:0ce6": {
+    "name": "DualSense",
+    "matchNames": ["dualsense"],
+    "buttons": {
+      "0": "south",
+      "1": "east",
+      "2": "west",
+      "3": "north",
+      "4": "lshoulder",
+      "5": "rshoulder",
+      "6": "ltrigger",
+      "7": "rtrigger",
+      "8": "select",
+      "9": "start",
+      "10": "lstick",
+      "11": "rstick",
+      "12": "dpad-up",
+      "13": "dpad-down",
+      "14": "dpad-left",
+      "15": "dpad-right",
+      "16": "home",
+      "17": "touchpad"
+    },
+    "sticks": {
+      "left": { "x": 0, "y": 1 },
+      "right": { "x": 2, "y": 3 }
+    }
+  },
+  "054c:05c4": {
+    "name": "DualShock 4",
+    "buttons": {
+      "0": "south",
+      "1": "east",
+      "2": "west",
+      "3": "north",
+      "4": "lshoulder",
+      "5": "rshoulder",
+      "6": "ltrigger",
+      "7": "rtrigger",
+      "8": "select",
+      "9": "start",
+      "10": "lstick",
+      "11": "rstick",
+      "12": "dpad-up",
+      "13": "dpad-down",
+      "14": "dpad-left",
+      "15": "dpad-right",
+      "16": "home",
+      "17": "touchpad"
+    },
+    "sticks": {
+      "left": { "x": 0, "y": 1 },
+      "right": { "x": 2, "y": 3 }
+    }
+  },
+  "054c:09cc": {
+    "name": "DualShock 4",
     "buttons": {
       "0": "south",
       "1": "east",
@@ -110,6 +174,7 @@
     }
   },
   "default": {
+    "name": "Standard Gamepad",
     "buttons": {
       "0": "south",
       "1": "east",

--- a/src/data/gamepad.json
+++ b/src/data/gamepad.json
@@ -97,7 +97,7 @@
   },
   "054c:0ce6": {
     "name": "DualSense",
-    "type": "playstation",
+    "type": "ps5",
     "matchNames": ["dualsense"],
     "buttons": {
       "0": "south",
@@ -126,7 +126,7 @@
   },
   "054c:05c4": {
     "name": "DualShock 4",
-    "type": "playstation",
+    "type": "ps4",
     "buttons": {
       "0": "south",
       "1": "east",
@@ -154,7 +154,7 @@
   },
   "054c:09cc": {
     "name": "DualShock 4",
-    "type": "playstation",
+    "type": "ps4",
     "buttons": {
       "0": "south",
       "1": "east",

--- a/src/types.ts
+++ b/src/types.ts
@@ -247,7 +247,7 @@ export type KGamepad = {
      * A human-readable label for the recognized controller, e.g. "DualSense",
      * or "Standard Gamepad" if unrecognized. For display/debugging only.
      */
-    controllerName: string;
+    name: string;
     /** The recognized controller family, for picking button-glyph assets. */
     type: GamepadType | undefined;
     /** If certain button is pressed. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,10 +197,8 @@ export type ChordedKGamepadButton =
 export type KGamepadStick = "left" | "right";
 
 /**
- * A machine-readable controller family, for picking button-glyph assets.
- * Not a closed set - custom `GamepadDef`s (via `KAPLAYOpt.gamepads`) can use
- * any string here, e.g. `"steam"` for a Steam Controller mapping KAPLAY
- * doesn't ship a built-in for.
+ * Controller type, useful for accurate button-glyph assets.
+ * Can be extended with custom gamepad definitions.
  *
  * @group Input
  * @subgroup Gamepad

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,7 +205,13 @@ export type KGamepadStick = "left" | "right";
  * @group Input
  * @subgroup Gamepad
  */
-export type GamepadType = "playstation" | "xbox" | "switch" | (string & {});
+export type GamepadType =
+    | "ps4"
+    | "ps5"
+    | "playstation"
+    | "xbox"
+    | "switch"
+    | (string & {});
 
 /**
  * A gamepad definition. Used in {@link KAPLAYOpt `KAPLAYOpt`}

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,14 @@ export type ChordedKGamepadButton =
 export type KGamepadStick = "left" | "right";
 
 /**
+ * A machine-readable controller family, for picking button-glyph assets.
+ *
+ * @group Input
+ * @subgroup Gamepad
+ */
+export type GamepadType = "playstation" | "xbox" | "switch";
+
+/**
  * A gamepad definition. Used in {@link KAPLAYOpt `KAPLAYOpt`}
  *
  * @group Input
@@ -211,6 +219,8 @@ export type GamepadDef = {
      * names distinctive enough to not misidentify unrelated hardware.
      */
     matchNames?: string[];
+    /** The controller family this definition belongs to, if known. */
+    type?: GamepadType;
     buttons: Record<string, KGamepadButton>;
     sticks: Partial<Record<KGamepadStick, { x: number; y: number }>>;
 };
@@ -229,6 +239,8 @@ export type KGamepad = {
      * or "Standard Gamepad" if unrecognized. For display/debugging only.
      */
     controllerName: string;
+    /** The recognized controller family, for picking button-glyph assets. */
+    type: GamepadType | undefined;
     /** If certain button is pressed. */
     isPressed(b: KGamepadButton): boolean;
     /** If certain button is held down. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,14 @@ export type KGamepadStick = "left" | "right";
  * @subgroup Gamepad
  */
 export type GamepadDef = {
+    /** A human-readable label for this controller model, e.g. "DualSense". */
+    name?: string;
+    /**
+     * Lowercase name substrings used as a last-resort fallback match when
+     * vendor/product can't be parsed from `Gamepad.id`. Only set this for
+     * names distinctive enough to not misidentify unrelated hardware.
+     */
+    matchNames?: string[];
     buttons: Record<string, KGamepadButton>;
     sticks: Partial<Record<KGamepadStick, { x: number; y: number }>>;
 };
@@ -216,6 +224,11 @@ export type GamepadDef = {
 export type KGamepad = {
     /** The order of the gamepad in the gamepad list. */
     index: number;
+    /**
+     * A human-readable label for the recognized controller, e.g. "DualSense",
+     * or "Standard Gamepad" if unrecognized. For display/debugging only.
+     */
+    controllerName: string;
     /** If certain button is pressed. */
     isPressed(b: KGamepadButton): boolean;
     /** If certain button is held down. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,11 +198,14 @@ export type KGamepadStick = "left" | "right";
 
 /**
  * A machine-readable controller family, for picking button-glyph assets.
+ * Not a closed set - custom `GamepadDef`s (via `KAPLAYOpt.gamepads`) can use
+ * any string here, e.g. `"steam"` for a Steam Controller mapping KAPLAY
+ * doesn't ship a built-in for.
  *
  * @group Input
  * @subgroup Gamepad
  */
-export type GamepadType = "playstation" | "xbox" | "switch";
+export type GamepadType = "playstation" | "xbox" | "switch" | (string & {});
 
 /**
  * A gamepad definition. Used in {@link KAPLAYOpt `KAPLAYOpt`}

--- a/tests/auto/gamepadId.spec.ts
+++ b/tests/auto/gamepadId.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { parseGamepadVidPid, resolveGamepadMap } from "../../src/app/gamepadId";
+import {
+    detectGamepadType,
+    parseGamepadVidPid,
+    resolveGamepadMap,
+} from "../../src/app/gamepadId";
 import { GP_MAP } from "../../src/constants/general";
 
 describe("parseGamepadVidPid", () => {
@@ -204,5 +208,51 @@ describe("resolveGamepadMap (custom opt.gamepads override)", () => {
             customMap,
         );
         expect(controllerName).toBe("DualSense");
+    });
+});
+
+describe("detectGamepadType", () => {
+    function typeOf(id: string) {
+        return detectGamepadType(resolveGamepadMap(id, GP_MAP));
+    }
+
+    test("DualSense resolves via the built-in table's type field", () => {
+        expect(
+            typeOf(
+                "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
+            ),
+        ).toBe("playstation");
+    });
+
+    test("Switch Pro Controller resolves via the built-in table's type field", () => {
+        expect(
+            typeOf(
+                "Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)",
+            ),
+        ).toBe("switch");
+    });
+
+    test("Xbox pad isn't in the built-in table, but still resolves via vendor-only fallback", () => {
+        expect(
+            typeOf(
+                "Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 0b12)",
+            ),
+        ).toBe("xbox");
+    });
+
+    test("DualSense with vendor/product stripped still resolves, via the same name fallback that recovers controllerName", () => {
+        expect(
+            typeOf("DualSense Wireless Controller (STANDARD GAMEPAD)"),
+        ).toBe("playstation");
+    });
+
+    test("unknown vendor returns undefined, doesn't guess", () => {
+        expect(
+            typeOf("Generic   USB Joystick (Vendor: 0079 Product: 0006)"),
+        ).toBeUndefined();
+    });
+
+    test("no vendor/product and no distinctive name (DualShock 4 over Android) returns undefined", () => {
+        expect(typeOf("Wireless Controller")).toBeUndefined();
     });
 });

--- a/tests/auto/gamepadId.spec.ts
+++ b/tests/auto/gamepadId.spec.ts
@@ -59,7 +59,7 @@ describe("parseGamepadVidPid", () => {
 type Fixture = {
     description: string;
     id: string;
-    expectedControllerName: string;
+    expectedName: string;
     expectButton?: [index: string, button: string | undefined];
 };
 
@@ -67,102 +67,102 @@ const FIXTURES: Fixture[] = [
     {
         description: "DualSense, Chrome, old id format (w/ Vendor/Product)",
         id: "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
-        expectedControllerName: "DualSense",
+        expectedName: "DualSense",
         expectButton: ["17", "touchpad"],
     },
     {
         description:
             "DualSense, Chrome, current id (#867 - Vendor/Product dropped, recovered via name fallback)",
         id: "DualSense Wireless Controller (STANDARD GAMEPAD)",
-        expectedControllerName: "DualSense",
+        expectedName: "DualSense",
         expectButton: ["17", "touchpad"],
     },
     {
         description: "DualSense, Firefox/Safari dash id format",
         id: "054c-0ce6-DualSense Wireless Controller",
-        expectedControllerName: "DualSense",
+        expectedName: "DualSense",
         expectButton: ["17", "touchpad"],
     },
     {
         description:
             "DualShock 4, Vendor/Product stripped (Android Chrome) - NOT recovered, name is too generic to guess safely",
         id: "Wireless Controller",
-        expectedControllerName: "Standard Gamepad",
+        expectedName: "Standard Gamepad",
         expectButton: ["17", undefined],
     },
     {
         description: "DualShock 4, Chrome, PID 05c4",
         id: "Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 05c4)",
-        expectedControllerName: "DualShock 4",
+        expectedName: "DualShock 4",
         expectButton: ["17", "touchpad"],
     },
     {
         description: "DualShock 4, Chrome, PID 09cc (later hardware revision)",
         id: "Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)",
-        expectedControllerName: "DualShock 4",
+        expectedName: "DualShock 4",
         expectButton: ["17", "touchpad"],
     },
     {
         description: "Switch Pro Controller, Chrome, with STANDARD GAMEPAD tag",
         id: "Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)",
-        expectedControllerName: "Switch Pro Controller",
+        expectedName: "Switch Pro Controller",
         expectButton: ["17", "capture"],
     },
     {
         description:
             "Switch Pro Controller, Chrome, without STANDARD GAMEPAD tag",
         id: "Pro Controller (Vendor: 057e Product: 2009)",
-        expectedControllerName: "Switch Pro Controller",
+        expectedName: "Switch Pro Controller",
         expectButton: ["17", "capture"],
     },
     {
         description: "Joy-Con (L)",
         id: "Joy-Con (L) (STANDARD GAMEPAD Vendor: 057e Product: 2006)",
-        expectedControllerName: "Joy-Con (L)",
+        expectedName: "Joy-Con (L)",
     },
     {
         description: "Joy-Con (R)",
         id: "Joy-Con (R) (STANDARD GAMEPAD Vendor: 057e Product: 2007)",
-        expectedControllerName: "Joy-Con (R)",
+        expectedName: "Joy-Con (R)",
     },
     {
         description: "Joy-Con L+R combined",
         id: "Joy-Con L+R (STANDARD GAMEPAD Vendor: 057e Product: 200e)",
-        expectedControllerName: "Joy-Con L+R",
+        expectedName: "Joy-Con L+R",
         expectButton: ["17", "capture"],
     },
     {
         description:
             "Xbox Series X|S (USB) - not in our table, default covers it fully",
         id: "Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 0b12)",
-        expectedControllerName: "Standard Gamepad",
+        expectedName: "Standard Gamepad",
     },
     {
         description: "Xbox Wireless Controller over Bluetooth",
         id: "Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 02fd)",
-        expectedControllerName: "Standard Gamepad",
+        expectedName: "Standard Gamepad",
     },
     {
         description:
             "Xbox 360 via XInput - Chrome exposes no vendor/product for these",
         id: "Xbox 360 Controller (XInput STANDARD GAMEPAD)",
-        expectedControllerName: "Standard Gamepad",
+        expectedName: "Standard Gamepad",
     },
     {
         description: "Generic/\"knockoff\" USB gamepad (DragonRise chipset)",
         id: "Generic   USB Joystick (Vendor: 0079 Product: 0006)",
-        expectedControllerName: "Standard Gamepad",
+        expectedName: "Standard Gamepad",
     },
 ];
 
 describe("resolveGamepadMap (built-in table)", () => {
     for (const fixture of FIXTURES) {
         test(fixture.description, () => {
-            const { map, controllerName } = resolveGamepadMap(
+            const { map, name } = resolveGamepadMap(
                 fixture.id,
                 GP_MAP,
             );
-            expect(controllerName).toBe(fixture.expectedControllerName);
+            expect(name).toBe(fixture.expectedName);
             if (fixture.expectButton) {
                 const [index, expected] = fixture.expectButton;
                 expect(map.buttons[index]).toBe(expected);
@@ -183,12 +183,12 @@ describe("resolveGamepadMap (custom opt.gamepads override)", () => {
             },
         };
 
-        const { map, controllerName } = resolveGamepadMap(
+        const { map, name } = resolveGamepadMap(
             id,
             GP_MAP,
             customMap,
         );
-        expect(controllerName).toBe("My Custom DualSense Remap");
+        expect(name).toBe("My Custom DualSense Remap");
         expect(map.buttons["0"]).toBe("north");
     });
 
@@ -202,12 +202,12 @@ describe("resolveGamepadMap (custom opt.gamepads override)", () => {
             },
         };
 
-        const { controllerName } = resolveGamepadMap(
+        const { name } = resolveGamepadMap(
             "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
             GP_MAP,
             customMap,
         );
-        expect(controllerName).toBe("DualSense");
+        expect(name).toBe("DualSense");
     });
 });
 
@@ -248,7 +248,7 @@ describe("detectGamepadType", () => {
         ).toBe("xbox");
     });
 
-    test("DualSense with vendor/product stripped still resolves, via the same name fallback that recovers controllerName", () => {
+    test("DualSense with vendor/product stripped still resolves, via the same name-fallback that resolveGamepadMap uses", () => {
         expect(
             typeOf("DualSense Wireless Controller (STANDARD GAMEPAD)"),
         ).toBe("ps5");

--- a/tests/auto/gamepadId.spec.ts
+++ b/tests/auto/gamepadId.spec.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "vitest";
+import { parseGamepadVidPid, resolveGamepadMap } from "../../src/app/gamepadId";
+import { GP_MAP } from "../../src/constants/general";
+
+describe("parseGamepadVidPid", () => {
+    test("parses Chrome id with STANDARD GAMEPAD tag", () => {
+        expect(
+            parseGamepadVidPid(
+                "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
+            ),
+        ).toBe("054c:0ce6");
+    });
+
+    test("parses Chrome id without STANDARD GAMEPAD tag", () => {
+        expect(
+            parseGamepadVidPid("Pro Controller (Vendor: 057e Product: 2009)"),
+        )
+            .toBe("057e:2009");
+    });
+
+    test("returns null for the changed DualSense id that dropped Vendor/Product", () => {
+        expect(
+            parseGamepadVidPid(
+                "DualSense Wireless Controller (STANDARD GAMEPAD)",
+            ),
+        ).toBeNull();
+    });
+
+    test("returns null for Chrome XInput ids (no vendor/product exposed)", () => {
+        expect(
+            parseGamepadVidPid("Xbox 360 Controller (XInput STANDARD GAMEPAD)"),
+        )
+            .toBeNull();
+    });
+
+    test("parses Firefox/Safari dash-delimited ids", () => {
+        expect(parseGamepadVidPid("054c-0ce6-Wireless Controller")).toBe(
+            "054c:0ce6",
+        );
+    });
+
+    test("zero-pads short hex segments to 4 digits", () => {
+        expect(parseGamepadVidPid("46d-c216-Logitech Dual Action")).toBe(
+            "046d:c216",
+        );
+    });
+
+    test("returns null for name-only ids", () => {
+        expect(parseGamepadVidPid("DualSense Wireless Controller")).toBeNull();
+    });
+});
+
+// Real Gamepad.id strings (Chrome/Firefox), vendor:product pairs cross-checked
+// against SDL_GameControllerDB. Add your own here if you test real hardware.
+type Fixture = {
+    description: string;
+    id: string;
+    expectedControllerName: string;
+    expectButton?: [index: string, button: string | undefined];
+};
+
+const FIXTURES: Fixture[] = [
+    {
+        description: "DualSense, Chrome, old id format (w/ Vendor/Product)",
+        id: "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
+        expectedControllerName: "DualSense",
+        expectButton: ["17", "touchpad"],
+    },
+    {
+        description:
+            "DualSense, Chrome, current id (#867 - Vendor/Product dropped, recovered via name fallback)",
+        id: "DualSense Wireless Controller (STANDARD GAMEPAD)",
+        expectedControllerName: "DualSense",
+        expectButton: ["17", "touchpad"],
+    },
+    {
+        description: "DualSense, Firefox/Safari dash id format",
+        id: "054c-0ce6-DualSense Wireless Controller",
+        expectedControllerName: "DualSense",
+        expectButton: ["17", "touchpad"],
+    },
+    {
+        description:
+            "DualShock 4, Vendor/Product stripped (Android Chrome) - NOT recovered, name is too generic to guess safely",
+        id: "Wireless Controller",
+        expectedControllerName: "Standard Gamepad",
+        expectButton: ["17", undefined],
+    },
+    {
+        description: "DualShock 4, Chrome, PID 05c4",
+        id: "Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 05c4)",
+        expectedControllerName: "DualShock 4",
+        expectButton: ["17", "touchpad"],
+    },
+    {
+        description: "DualShock 4, Chrome, PID 09cc (later hardware revision)",
+        id: "Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)",
+        expectedControllerName: "DualShock 4",
+        expectButton: ["17", "touchpad"],
+    },
+    {
+        description: "Switch Pro Controller, Chrome, with STANDARD GAMEPAD tag",
+        id: "Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)",
+        expectedControllerName: "Switch Pro Controller",
+        expectButton: ["17", "capture"],
+    },
+    {
+        description:
+            "Switch Pro Controller, Chrome, without STANDARD GAMEPAD tag",
+        id: "Pro Controller (Vendor: 057e Product: 2009)",
+        expectedControllerName: "Switch Pro Controller",
+        expectButton: ["17", "capture"],
+    },
+    {
+        description: "Joy-Con (L)",
+        id: "Joy-Con (L) (STANDARD GAMEPAD Vendor: 057e Product: 2006)",
+        expectedControllerName: "Joy-Con (L)",
+    },
+    {
+        description: "Joy-Con (R)",
+        id: "Joy-Con (R) (STANDARD GAMEPAD Vendor: 057e Product: 2007)",
+        expectedControllerName: "Joy-Con (R)",
+    },
+    {
+        description: "Joy-Con L+R combined",
+        id: "Joy-Con L+R (STANDARD GAMEPAD Vendor: 057e Product: 200e)",
+        expectedControllerName: "Joy-Con L+R",
+        expectButton: ["17", "capture"],
+    },
+    {
+        description:
+            "Xbox Series X|S (USB) - not in our table, default covers it fully",
+        id: "Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 0b12)",
+        expectedControllerName: "Standard Gamepad",
+    },
+    {
+        description: "Xbox Wireless Controller over Bluetooth",
+        id: "Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 02fd)",
+        expectedControllerName: "Standard Gamepad",
+    },
+    {
+        description:
+            "Xbox 360 via XInput - Chrome exposes no vendor/product for these",
+        id: "Xbox 360 Controller (XInput STANDARD GAMEPAD)",
+        expectedControllerName: "Standard Gamepad",
+    },
+    {
+        description: "Generic/\"knockoff\" USB gamepad (DragonRise chipset)",
+        id: "Generic   USB Joystick (Vendor: 0079 Product: 0006)",
+        expectedControllerName: "Standard Gamepad",
+    },
+];
+
+describe("resolveGamepadMap (built-in table)", () => {
+    for (const fixture of FIXTURES) {
+        test(fixture.description, () => {
+            const { map, controllerName } = resolveGamepadMap(
+                fixture.id,
+                GP_MAP,
+            );
+            expect(controllerName).toBe(fixture.expectedControllerName);
+            if (fixture.expectButton) {
+                const [index, expected] = fixture.expectButton;
+                expect(map.buttons[index]).toBe(expected);
+            }
+        });
+    }
+});
+
+describe("resolveGamepadMap (custom opt.gamepads override)", () => {
+    test("a user-supplied map keyed by the literal id wins over the built-in table", () => {
+        const id =
+            "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)";
+        const customMap = {
+            [id]: {
+                name: "My Custom DualSense Remap",
+                buttons: { "0": "north" as const },
+                sticks: {},
+            },
+        };
+
+        const { map, controllerName } = resolveGamepadMap(
+            id,
+            GP_MAP,
+            customMap,
+        );
+        expect(controllerName).toBe("My Custom DualSense Remap");
+        expect(map.buttons["0"]).toBe("north");
+    });
+
+    test("a user override for one id doesn't affect resolution of other ids", () => {
+        const overriddenId = "Some Weird Pad (Vendor: ffff Product: ffff)";
+        const customMap = {
+            [overriddenId]: {
+                name: "Weird Pad",
+                buttons: {},
+                sticks: {},
+            },
+        };
+
+        const { controllerName } = resolveGamepadMap(
+            "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
+            GP_MAP,
+            customMap,
+        );
+        expect(controllerName).toBe("DualSense");
+    });
+});

--- a/tests/auto/gamepadId.spec.ts
+++ b/tests/auto/gamepadId.spec.ts
@@ -216,12 +216,20 @@ describe("detectGamepadType", () => {
         return detectGamepadType(resolveGamepadMap(id, GP_MAP));
     }
 
-    test("DualSense resolves via the built-in table's type field", () => {
+    test("DualSense resolves to ps5 via the built-in table's type field", () => {
         expect(
             typeOf(
                 "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)",
             ),
-        ).toBe("playstation");
+        ).toBe("ps5");
+    });
+
+    test("DualShock 4 resolves to ps4 via the built-in table's type field", () => {
+        expect(
+            typeOf(
+                "Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 05c4)",
+            ),
+        ).toBe("ps4");
     });
 
     test("Switch Pro Controller resolves via the built-in table's type field", () => {
@@ -243,6 +251,14 @@ describe("detectGamepadType", () => {
     test("DualSense with vendor/product stripped still resolves, via the same name fallback that recovers controllerName", () => {
         expect(
             typeOf("DualSense Wireless Controller (STANDARD GAMEPAD)"),
+        ).toBe("ps5");
+    });
+
+    test("Sony vendor id with an unrecognized product falls back to generic playstation instead of guessing ps4 vs ps5", () => {
+        expect(
+            typeOf(
+                "Some Future Sony Pad (STANDARD GAMEPAD Vendor: 054c Product: ffff)",
+            ),
         ).toBe("playstation");
     });
 

--- a/tests/playtests/gamepadControllerName.js
+++ b/tests/playtests/gamepadControllerName.js
@@ -45,7 +45,7 @@ let currentGamepad = null;
 let lastButtonPress = "";
 
 function showConnected(gp) {
-    banner.text = `${gp.controllerName} connected! (type: ${
+    banner.text = `${gp.name} connected! (type: ${
         gp.type ?? "unknown"
     })`;
     currentGamepad = gp;
@@ -88,7 +88,7 @@ if (existing) showConnected(existing);
 
 onGamepadConnect((gp) => {
     showConnected(gp);
-    showToast(`${gp.controllerName} connected`, rgb(0, 255, 0));
+    showToast(`${gp.name} connected`, rgb(0, 255, 0));
 });
 
 onGamepadDisconnect((gp) => {
@@ -97,11 +97,11 @@ onGamepadDisconnect((gp) => {
     currentGamepad = null;
     lastButtonPress = "";
     panel.text = "";
-    showToast(`${gp.controllerName} disconnected`, rgb(255, 0, 0));
+    showToast(`${gp.name} disconnected`, rgb(255, 0, 0));
 });
 
 onGamepadButtonPress((btn, gp) => {
-    lastButtonPress = `${gp.controllerName}: ${btn}`;
+    lastButtonPress = `${gp.name}: ${btn}`;
 });
 
 onButtonPress("test", () => {

--- a/tests/playtests/gamepadControllerName.js
+++ b/tests/playtests/gamepadControllerName.js
@@ -45,7 +45,9 @@ let currentGamepad = null;
 let lastButtonPress = "";
 
 function showConnected(gp) {
-    banner.text = `${gp.controllerName} connected!`;
+    banner.text = `${gp.controllerName} connected! (type: ${
+        gp.type ?? "unknown"
+    })`;
     currentGamepad = gp;
 }
 

--- a/tests/playtests/gamepadControllerName.js
+++ b/tests/playtests/gamepadControllerName.js
@@ -1,0 +1,134 @@
+kaplay({
+    background: [20, 20, 20],
+    buttons: {
+        test: { gamepad: "south" },
+    },
+});
+
+const GAMEPAD_BUTTONS = [
+    "north",
+    "east",
+    "south",
+    "west",
+    "ltrigger",
+    "rtrigger",
+    "lshoulder",
+    "rshoulder",
+    "select",
+    "start",
+    "lstick",
+    "rstick",
+    "dpad-up",
+    "dpad-right",
+    "dpad-down",
+    "dpad-left",
+    "home",
+    "capture",
+    "touchpad",
+];
+
+const banner = add([
+    text("Plug in a controller, or press a button if it's already connected.", {
+        width: width() - 80,
+        align: "center",
+    }),
+    pos(center()),
+    anchor("center"),
+]);
+
+const panel = add([
+    text("", { size: 18 }),
+    pos(20, 20),
+]);
+
+let currentGamepad = null;
+let lastButtonPress = "";
+
+function showConnected(gp) {
+    banner.text = `${gp.controllerName} connected!`;
+    currentGamepad = gp;
+}
+
+let toastBox = null;
+let toastText = null;
+
+function showToast(msg, textColor) {
+    toastBox?.destroy();
+    toastText?.destroy();
+
+    const toastPos = vec2(width() / 2, 60);
+    toastBox = add([
+        rect(360, 50, { radius: 8 }),
+        pos(toastPos),
+        anchor("center"),
+        color(30, 30, 30),
+        opacity(0.85),
+        lifespan(0.7, { fade: 0.3 }),
+        z(100),
+    ]);
+    toastText = add([
+        text(msg, { size: 20, align: "center", width: 340 }),
+        pos(toastPos),
+        anchor("center"),
+        color(textColor),
+        opacity(1),
+        lifespan(0.7, { fade: 0.3 }),
+        z(101),
+    ]);
+}
+
+// Browsers withhold gamepad detection until the user interacts with it
+// (button press / stick move) for fingerprinting-privacy reasons, so a
+// controller already plugged in before this page loaded may not show up
+// here yet - that's the Gamepad API's own gating, not a bug in KAPLAY.
+const existing = getGamepads()[0];
+if (existing) showConnected(existing);
+
+onGamepadConnect((gp) => {
+    showConnected(gp);
+    showToast(`${gp.controllerName} connected`, rgb(0, 255, 0));
+});
+
+onGamepadDisconnect((gp) => {
+    banner.text =
+        "Plug in a controller, or press a button if it's already connected.";
+    currentGamepad = null;
+    lastButtonPress = "";
+    panel.text = "";
+    showToast(`${gp.controllerName} disconnected`, rgb(255, 0, 0));
+});
+
+onGamepadButtonPress((btn, gp) => {
+    lastButtonPress = `${gp.controllerName}: ${btn}`;
+});
+
+onButtonPress("test", () => {
+    showToast("\"test\" binding fired!", rgb(255, 255, 0));
+});
+
+function fmtVec(v) {
+    return `(${v.x.toFixed(2)}, ${v.y.toFixed(2)})`;
+}
+
+onUpdate(() => {
+    if (!currentGamepad) return;
+
+    const downInstance = GAMEPAD_BUTTONS.filter((b) =>
+        currentGamepad.isDown(b)
+    );
+    const downGlobal = GAMEPAD_BUTTONS.filter((b) => isGamepadButtonDown(b));
+
+    panel.text = [
+        `last button: ${lastButtonPress}`,
+        `stick L   instance: ${fmtVec(currentGamepad.getStick("left"))}`
+        + `  global: ${fmtVec(getGamepadStick("left"))}`,
+        `stick R   instance: ${fmtVec(currentGamepad.getStick("right"))}`
+        + `  global: ${fmtVec(getGamepadStick("right"))}`,
+        `trigger L instance: ${currentGamepad.getAnalog("ltrigger").toFixed(2)}`
+        + `  global: ${getGamepadAnalogButton("ltrigger").toFixed(2)}`,
+        `trigger R instance: ${currentGamepad.getAnalog("rtrigger").toFixed(2)}`
+        + `  global: ${getGamepadAnalogButton("rtrigger").toFixed(2)}`,
+        `down instance: ${downInstance.join(", ")}`,
+        `down global:   ${downGlobal.join(", ")}`,
+    ].join("\n");
+});


### PR DESCRIPTION

<!--
Check our contributing guide:
https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md
-->

## Please describe what issue(s) this PR fixes.

Fixes #1110.

`Gamepad.id` isn't standardized by the Gamepad API spec - its exact text is whatever the browser decides to report, and it's not guaranteed to stay the same between browser versions. Chrome's id for the DualSense used to include `Vendor: 054c Product: 0ce6`, and no longer does, which is why the mapping added in #867 stopped matching and the touchpad button went back to `undefined`. The underlying issue isn't specific to DualSense though - we were matching gamepads by comparing the *entire* id string, which breaks any time a browser changes wording/tagging/casing anywhere in that string, for any controller, not just this one.

## Summary

- [x] Changeloged

Re-keyed the built-in gamepad table to match on the vendor:product hex pair (parsed out of `id`) instead of the raw id string, since that's the one part of the id that's actually stable across the kind of text-format changes that caused this bug. Custom controller maps passed via `kaplay({ gamepads: {...} })` are untouched and still keyed by the literal id string, so this isn't a breaking change for anyone already using that option.

For the specific case in this issue - Chrome now omits vendor/product from the DualSense id entirely, so there's nothing left to parse - added a second, more conservative fallback: a substring match against the controller's own reported name, but only for controllers where that name text is actually distinctive enough to trust (`"DualSense"` is safe to match on; DualShock 4's reported name is just the generic `"Wireless Controller"`, which plenty of unrelated pads also report, so that one's deliberately not included). This is what actually recovers the touchpad button for the id in this issue.

While in there, also added DualShock 4 (`054c:05c4` / `054c:09cc`) as a built-in mapping - same touchpad-beyond-standard-range situation as DualSense, and it wasn't covered before at all.

Also surfaced a `controllerName` field on `KGamepad` (e.g. `"DualSense"`, `"Standard Gamepad"` if unrecognized) - display/debugging only, doesn't affect matching, but makes it possible to write tests (and games) against a readable label instead of the vendor:product hex.

### Testing

Added `tests/auto/gamepadId.spec.ts` - the id-parsing and matching logic is pure (no DOM/browser dependency), so it's covered directly with real `Gamepad.id` strings observed across Chrome/Firefox for DualSense, DualShock 4, Switch Pro Controller, Joy-Con, and a few controllers that are deliberately *not* in the built-in table (Xbox, a generic/knockoff pad) to confirm those still degrade to the default mapping instead of misidentifying as something they're not. Vendor:product pairs cross-checked against [SDL_GameControllerDB](https://github.com/mdqinc/SDL_GameControllerDB) to make sure none of it was guessed.

Also added tests/playtests/gamepadControllerName.js, a manual playtest for the parts of this that need a real gamepad in a real browser (can't be asserted in CI). Shows the resolved controllerName, and a debug panel that pairs the per-gamepad instance API (gp.isDown(), gp.getStick(), gp.getAnalog()) against the equivalent global functions (isGamepadButtonDown(), getGamepadStick(), getGamepadAnalogButton()) side by side so any mismatch is visually obvious, plus a buttons: {...} binding wired to a gamepad button to confirm the higher-level binding system resolves correctly too, not just the raw per-device events. Manually verified against a DualSense, a DualShock 4, and two Xbox-family pads (one official, one generic/knockoff). Lack hardware for further physical testing unfortunately. 

EDIT: For clarity claude llm was used to assist in this work, but the ideas, structure, and most of the code for implementation was mine. Testing used it more heavily but still reviewed. All changes have been reviewed and I can explain how this feature works in detail if needed. It is not "vibe coded" but LLM assisted.  