### PR TITLE
feat: add perspective function to mat4, fix: make Vec3 visible to user

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -221,6 +221,7 @@ import {
     testRectRect,
     triangulate,
     vec2,
+    vec3,
     wave,
 } from "../math/math";
 import { buildConnectivityMap, floodFill } from "../math/navigation";
@@ -235,6 +236,7 @@ import { chance, rand, randi, randSeed, RNG, setRNG } from "../math/random";
 import { insertionSort } from "../math/sort";
 import { makeQuadtree, Quadtree } from "../math/spatial/quadtree";
 import { Vec2 } from "../math/Vec2";
+import { Vec3 } from "../math/vec3";
 import { BlendMode, type KAPLAYPlugin } from "../types";
 import {
     download,
@@ -512,6 +514,7 @@ export const createContext = (
         Polygon,
         Collision,
         Vec2,
+        Vec3,
         Color,
         Mat2,
         Mat4,
@@ -532,6 +535,7 @@ export const createContext = (
         randi,
         randSeed,
         vec2,
+        vec3,
         rgb,
         hsl2rgb,
         quad,

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -167,6 +167,7 @@ import type { NavMesh } from "../math/navigationmesh";
 import type { RandomGenerator, RNG, RNGConfig, RNGSeed } from "../math/random";
 import type { Quadtree, ResizingQuadtree } from "../math/spatial/quadtree";
 import type { Vec2 } from "../math/Vec2";
+import type { Vec3 } from "../math/vec3";
 import {
     type Anchor,
     type BlendMode,
@@ -5057,6 +5058,32 @@ export interface KAPLAYCtx {
     vec2(xy: number): Vec2;
     vec2(): Vec2;
     /**
+     * Create a 3D vector.
+     *
+     * @example
+     * ```js
+     * // { x: 0, y: 0, z: 0 }
+     * vec3()
+     *
+     * // { x: 10, y: 10, z: 10 }
+     * vec3(10)
+     *
+     * // { x: 80, y: 100, z: 120 }
+     * vec3(80, 100, 120)
+     *
+     * // move to 150 degrees direction with by length 10
+     * player.pos = pos.add(Vec2.fromAngle(150).scale(10))
+     * ```
+     *
+     * @returns The vector.
+     * @since v2000.0
+     * @group Math
+     */
+    vec3(x: number, y: number, z: number): Vec3;
+    vec3(p: Vec3): Vec3;
+    vec3(xyz: number): Vec3;
+    vec3(): Vec3;
+    /**
      * Create a color from RGB values (0 - 255).
      *
      * @param r - The red value.
@@ -5885,6 +5912,14 @@ export interface KAPLAYCtx {
      * @subgroup Vectors
      */
     Vec2: typeof Vec2;
+    /**
+     * A 3D vector.
+     *
+     * @since v2000.0
+     * @group Math
+     * @subgroup Vectors
+     */
+    Vec3: typeof Vec3;
     /**
      * A color.
      *

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -5070,9 +5070,6 @@ export interface KAPLAYCtx {
      *
      * // { x: 80, y: 100, z: 120 }
      * vec3(80, 100, 120)
-     *
-     * // move to 150 degrees direction with by length 10
-     * player.pos = pos.add(Vec2.fromAngle(150).scale(10))
      * ```
      *
      * @returns The vector.

--- a/src/math/Mat4.ts
+++ b/src/math/Mat4.ts
@@ -321,6 +321,41 @@ export class Mat4 {
         return new Mat4(out);
     }
 
+    static perspective(
+        fov: number,
+        aspect: number,
+        near: number = 0.1,
+        far: number = 1000,
+    ): Mat4 {
+        if (aspect === 0) return new Mat4();
+        if (near <= 0 || far <= near) return new Mat4();
+
+        const f = 1.0 / Math.tan(deg2rad(fov) / 2);
+        const rangeInv = 1.0 / (near - far);
+
+        return new Mat4([
+            f / aspect,
+            0,
+            0,
+            0,
+
+            0,
+            f,
+            0,
+            0,
+
+            0,
+            0,
+            (far + near) * rangeInv,
+            -1,
+
+            0,
+            0,
+            2 * far * near * rangeInv,
+            0,
+        ]);
+    }
+
     clone(): Mat4 {
         return new Mat4([...this.m]);
     }

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -24,7 +24,7 @@ export type Vec2Args =
     | [];
 
 /**
- * Possible arguments for a Vec2.
+ * Possible arguments for a Vec3.
  *
  * @group Math
  * @subgroup Vectors

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -8,6 +8,7 @@ import { traceRegion } from "./getImageOutline";
 import { lerp, type LerpValue } from "./lerp";
 import { rand, RNG } from "./random";
 import { Vec2 } from "./Vec2";
+import { Vec3 } from "./vec3";
 
 /**
  * Possible arguments for a Vec2.
@@ -20,6 +21,19 @@ export type Vec2Args =
     | [number]
     | [Vec2]
     | [number | Vec2]
+    | [];
+
+/**
+ * Possible arguments for a Vec2.
+ *
+ * @group Math
+ * @subgroup Vectors
+ */
+export type Vec3Args =
+    | [number, number, number]
+    | [number]
+    | [Vec3]
+    | [number | Vec3]
     | [];
 
 export function deg2rad(deg: number): number {
@@ -70,6 +84,20 @@ export function vec2(...args: Vec2Args): Vec2 {
     }
     // @ts-ignore
     return new Vec2(...args);
+}
+
+export function vec3(...args: Vec3Args): Vec3 {
+    if (args.length === 1) {
+        if (args[0] instanceof Vec3) {
+            return new Vec3(args[0].x, args[0].y, args[0].z);
+        }
+        else if (Array.isArray(args[0]) && args[0].length === 3) {
+            return new Vec3(...args[0]);
+        }
+    }
+
+    // @ts-ignore
+    return new Vec3(...args);
 }
 
 /**

--- a/src/math/vec3.ts
+++ b/src/math/vec3.ts
@@ -18,7 +18,7 @@ export class Vec3 {
     static ZERO = new Vec3(0, 0, 0);
     static ONE = new Vec3(1, 1, 1);
 
-    constructor(x: number, y: number, z: number) {
+    constructor(x: number = 0, y: number = x, z: number = x) {
         this.x = x;
         this.y = y;
         this.z = z;


### PR DESCRIPTION
## Please describe what issue(s) this PR fixes.

Added a perspective function in Mat4 for anyone willing to experiment with it, and made the Vec3 class available to everyone who needs it for a project.

## Summary

- `perspective()` function in Mat4
- Vec3 visible to projects