### PR TITLE
perf: optimize text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ So your change should look like:
   (#1097) - @Stanko
 - **(!)** `new RNG()` and `setRNG()` now use config objects instead of the
   string/custom rng parameter (#1097) - @Stanko
+- Improved `text` component performance by separating text transform and
+  formatting, reducing update calls for both dynamic and (especially) static
+  text (#1125) - @imaginarny
 
 ### Fixed
 
@@ -69,6 +72,8 @@ So your change should look like:
   the initial `GameObjRaw.use()` call (e.g. `obj.use(scale(2))`) - @mflerackers
 - Fixed `isKeyDown` and `isButtonDown` getting stuck on game loosing focus
   (#1101) - @Stanko
+- Fixed objects with a `text` component reporting wrong dimensions when scaled
+  using the `scale` component (#1125) - @imaginarny
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -172,7 +172,7 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
     let _width = opt.width ?? 0;
     let _height = 0;
 
-    // obj props that are checked on update and trigger reformat
+    // obj props that are checked on update and trigger transform or reformat
     let _renderProps:
         | RenderProps & Record<"anchor", DrawTextOpt["anchor"]>
         | null = null;
@@ -226,20 +226,24 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         );
     }
 
-    function renderPropsChanged(obj: GameObj<TextComp | any>) {
-        return !_renderProps
-            || obj.color !== _renderProps.color
+    function refreshRenderProps(obj: GameObj<TextComp | any>): 0 | 1 | 2 {
+        if (!_renderProps) {
+            _renderProps = getRenderProps(obj);
+            return 2;
+        }
+
+        const reformat = obj.anchor !== _renderProps.anchor;
+
+        const transform = obj.color !== _renderProps.color
             || obj.opacity !== _renderProps.opacity
-            || obj.anchor !== _renderProps.anchor
             || obj.shader !== _renderProps.shader
             || obj.uniform !== _renderProps.uniform;
-    }
 
-    function refreshRenderProps(obj: GameObj<TextComp | any>) {
-        if (!renderPropsChanged(obj)) return false;
+        if (!reformat && !transform) return 0;
 
         _renderProps = getRenderProps(obj);
-        return true;
+
+        return reformat ? 2 : 1;
     }
 
     function onUpdate(obj: GameObj<TextComp | any>) {
@@ -247,15 +251,14 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
 
         if (Object.values(_proxiedProps).some(isDynamic)) {
             _updateController = obj.onUpdate(() => {
-                update(obj, refreshRenderProps(obj));
+                update(obj, refreshRenderProps(obj) === 2);
             });
         }
         else {
             if (_updateController) update(obj, true);
             _updateController = obj.onUpdate(() => {
-                if (refreshRenderProps(obj)) {
-                    update(obj, true);
-                }
+                const updateType = refreshRenderProps(obj);
+                if (updateType) update(obj, updateType === 2);
             });
         }
     }

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -304,7 +304,10 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         add(this: GameObj<TextComp | any>) {
             objRef = this;
             updateDynamic();
-            _k.k.onLoad(() => update(this, true));
+            _k.k.onLoad(() => {
+                update(this, true);
+                return _k.k.cancel();
+            });
         },
 
         update(this: GameObj<TextComp>) {

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -1,6 +1,5 @@
 import type { BitmapFontData } from "../../../assets/bitmapFont";
 import { DEF_TEXT_SIZE } from "../../../constants/general";
-import type { KEventController } from "../../../events/events";
 import { defineReactiveProps, getRenderProps } from "../../../game/utils";
 import {
     drawFormattedText,
@@ -167,10 +166,10 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
     let objRef: GameObj<TextComp | any> | null = null;
     let theFormattedText: FormattedText;
 
-    let _updateController: KEventController | null = null;
     let _shape: Rect | undefined;
     let _width = opt.width ?? 0;
     let _height = 0;
+    let _isDynamic = false;
 
     // obj props that are checked on update and trigger transform or reformat
     let _renderProps:
@@ -186,17 +185,19 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         letterSpacing: opt.letterSpacing!,
     };
 
-    // dynamic props that optimize onUpdate with transform instead, reformat only if _renderProps changed
+    // dynamic props that update with transform instead, reformat only if _renderProps changed
     const _proxiedProps = {
         textStyles: proxifyProp(opt.styles!),
         textTransform: proxifyProp(opt.transform!),
     };
 
-    function update(
-        obj: GameObj<TextComp | any>,
-        reformat?: boolean,
-        isDynamic = false,
-    ) {
+    function update(obj: GameObj<TextComp | any>, reformat?: boolean) {
+        const updateType = refreshRenderProps(obj);
+        if (!reformat) {
+            if (!_isDynamic && !updateType) return;
+            reformat = updateType === 2;
+        }
+
         const fOpt = {
             ..._renderProps,
             text: obj.text + "",
@@ -213,21 +214,10 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
 
         theFormattedText = reformat
             ? formatText(fOpt)
-            : transformFormattedText(theFormattedText, fOpt, isDynamic);
+            : transformFormattedText(theFormattedText, fOpt, _isDynamic);
 
         if (!opt.width) obj.width = theFormattedText.width;
         obj.height = theFormattedText.height;
-    }
-
-    function isDynamic() {
-        return Object.values(_proxiedProps).some(value => (
-            typeof value === "function"
-            || (
-                value
-                && typeof value === "object"
-                && Object.values(value).some(v => typeof v === "function")
-            )
-        ));
     }
 
     function refreshRenderProps(obj: GameObj<TextComp | any>): 0 | 1 | 2 {
@@ -250,21 +240,18 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         return reformat ? 2 : 1;
     }
 
-    function onUpdate(obj: GameObj<TextComp | any>) {
-        _updateController?.cancel();
+    function updateDynamic() {
+        const prev = _isDynamic;
+        _isDynamic = Object.values(_proxiedProps).some(value => (
+            typeof value === "function"
+            || (
+                value
+                && typeof value === "object"
+                && Object.values(value).some(v => typeof v === "function")
+            )
+        ));
 
-        if (isDynamic()) {
-            _updateController = obj.onUpdate(() => {
-                update(obj, refreshRenderProps(obj) === 2, true);
-            });
-        }
-        else {
-            if (_updateController) update(obj, true);
-            _updateController = obj.onUpdate(() => {
-                const updateType = refreshRenderProps(obj);
-                if (updateType) update(obj, updateType === 2);
-            });
-        }
+        if (prev && !_isDynamic && objRef) update(objRef, true);
     }
 
     function proxifyProp(value: Object | Function) {
@@ -272,7 +259,7 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
             ? new Proxy(value, {
                 set(target, key, val) {
                     Reflect.set(target, key, val);
-                    objRef && onUpdate(objRef);
+                    updateDynamic();
                     return true;
                 },
             })
@@ -315,9 +302,13 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         },
 
         add(this: GameObj<TextComp | any>) {
-            _k.k.onLoad(() => update(this, true));
             objRef = this;
-            onUpdate(this);
+            updateDynamic();
+            _k.k.onLoad(() => update(this, true));
+        },
+
+        update(this: GameObj<TextComp>) {
+            update(this);
         },
 
         draw(this: GameObj<TextComp>) {
@@ -356,11 +347,11 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         },
     });
 
-    // define _proxiedProps as obj props that register onUpdate with transform only
+    // define _proxiedProps as obj props that update with transform only if dynamic
     defineReactiveProps(obj, _proxiedProps, {
         set(prop, value) {
             _proxiedProps[prop] = proxifyProp(value);
-            onUpdate(this as any as GameObj<TextComp>);
+            updateDynamic();
         },
     });
 

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -9,12 +9,13 @@ import {
 import type {
     CharTransform,
     CharTransformFunc,
+    DrawTextOpt,
     TextAlign,
 } from "../../../gfx/draw/drawText";
 import { formatText, transformFormattedText } from "../../../gfx/formatText";
 import { Rect, vec2 } from "../../../math/math";
 import { _k } from "../../../shared";
-import type { Comp, GameObj } from "../../../types";
+import type { Comp, GameObj, RenderProps } from "../../../types";
 import { nextRenderAreaVersion } from "../physics/area";
 
 /**
@@ -163,7 +164,7 @@ export interface TextCompOpt {
 }
 
 export function text(t: string, opt: TextCompOpt = {}): TextComp {
-    let objRef: GameObj<TextComp> | null = null;
+    let objRef: GameObj<TextComp | any> | null = null;
     let theFormattedText: FormattedText;
 
     let _updateController: KEventController | null = null;
@@ -171,7 +172,12 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
     let _width = opt.width ?? 0;
     let _height = 0;
 
-    // props that call formatText update once on set
+    // obj props that are checked on update and trigger reformat
+    let _renderProps:
+        | RenderProps & Record<"anchor", DrawTextOpt["anchor"]>
+        | null = null;
+
+    // props that call update with reformat once on set
     const _props = {
         textSize: opt.size ?? DEF_TEXT_SIZE,
         font: opt.font!,
@@ -180,14 +186,15 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         letterSpacing: opt.letterSpacing!,
     };
 
-    // dynamic props that are checked for continuous onUpdate
+    // dynamic props that optimize onUpdate with transform instead, reformat only if _renderProps changed
     const _proxiedProps = {
-        textStyles: proxify(opt.styles!),
-        textTransform: proxify(opt.transform!),
+        textStyles: proxifyProp(opt.styles!),
+        textTransform: proxifyProp(opt.transform!),
     };
 
     function update(obj: GameObj<TextComp | any>, reformat?: boolean) {
-        const fOpt = Object.assign(getRenderProps(obj), {
+        const fOpt = {
+            ..._renderProps,
             text: obj.text + "",
             size: obj.textSize,
             font: obj.font,
@@ -198,9 +205,9 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
             transform: obj.textTransform,
             styles: obj.textStyles,
             indentAll: opt.indentAll,
-        });
+        };
 
-        theFormattedText = (reformat || !theFormattedText?.renderedText)
+        theFormattedText = reformat
             ? formatText(fOpt)
             : transformFormattedText(theFormattedText, fOpt);
 
@@ -219,18 +226,41 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         );
     }
 
+    function renderPropsChanged(obj: GameObj<TextComp | any>) {
+        return !_renderProps
+            || obj.color !== _renderProps.color
+            || obj.opacity !== _renderProps.opacity
+            || obj.anchor !== _renderProps.anchor
+            || obj.shader !== _renderProps.shader
+            || obj.uniform !== _renderProps.uniform;
+    }
+
+    function refreshRenderProps(obj: GameObj<TextComp | any>) {
+        if (!renderPropsChanged(obj)) return false;
+
+        _renderProps = getRenderProps(obj);
+        return true;
+    }
+
     function onUpdate(obj: GameObj<TextComp | any>) {
+        _updateController?.cancel();
+
         if (Object.values(_proxiedProps).some(isDynamic)) {
-            _updateController ??= obj.onUpdate(() => update(obj));
+            _updateController = obj.onUpdate(() => {
+                update(obj, refreshRenderProps(obj));
+            });
         }
         else {
-            _updateController?.cancel();
-            if (_updateController) update(obj);
-            _updateController = null;
+            if (_updateController) update(obj, true);
+            _updateController = obj.onUpdate(() => {
+                if (refreshRenderProps(obj)) {
+                    update(obj, true);
+                }
+            });
         }
     }
 
-    function proxify(value: Object | Function) {
+    function proxifyProp(value: Object | Function) {
         return value && typeof value === "object"
             ? new Proxy(value, {
                 set(target, key, val) {
@@ -277,11 +307,9 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
             return theFormattedText;
         },
 
-        add(this: GameObj<TextComp>) {
+        add(this: GameObj<TextComp | any>) {
             _k.k.onLoad(() => update(this, true));
-            this.onUse(() => update(this, true));
             objRef = this;
-            update(this, true);
             onUpdate(this);
         },
 
@@ -324,7 +352,7 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
     // define _proxiedProps as obj props that register onUpdate with transform only
     defineReactiveProps(obj, _proxiedProps, {
         set(prop, value) {
-            _proxiedProps[prop] = proxify(value);
+            _proxiedProps[prop] = proxifyProp(value);
             onUpdate(this as any as GameObj<TextComp>);
         },
     });

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -1,6 +1,7 @@
 import type { BitmapFontData } from "../../../assets/bitmapFont";
 import { DEF_TEXT_SIZE } from "../../../constants/general";
-import { getRenderProps } from "../../../game/utils";
+import type { KEventController } from "../../../events/events";
+import { defineReactiveProps, getRenderProps } from "../../../game/utils";
 import {
     drawFormattedText,
     type FormattedText,
@@ -10,7 +11,7 @@ import type {
     CharTransformFunc,
     TextAlign,
 } from "../../../gfx/draw/drawText";
-import { formatText } from "../../../gfx/formatText";
+import { formatText, transformFormattedText } from "../../../gfx/formatText";
 import { Rect, vec2 } from "../../../math/math";
 import { _k } from "../../../shared";
 import type { Comp, GameObj } from "../../../types";
@@ -162,9 +163,31 @@ export interface TextCompOpt {
 }
 
 export function text(t: string, opt: TextCompOpt = {}): TextComp {
+    let objRef: GameObj<TextComp> | null = null;
     let theFormattedText: FormattedText;
-    function update(obj: GameObj<TextComp | any>) {
-        theFormattedText = formatText(Object.assign(getRenderProps(obj), {
+
+    let _updateController: KEventController | null = null;
+    let _shape: Rect | undefined;
+    let _width = opt.width ?? 0;
+    let _height = 0;
+
+    // props that call formatText update once on set
+    const _props = {
+        textSize: opt.size ?? DEF_TEXT_SIZE,
+        font: opt.font!,
+        align: opt.align!,
+        lineSpacing: opt.lineSpacing!,
+        letterSpacing: opt.letterSpacing!,
+    };
+
+    // dynamic props that are checked for continuous onUpdate
+    const _proxiedProps = {
+        textStyles: proxify(opt.styles!),
+        textTransform: proxify(opt.transform!),
+    };
+
+    function update(obj: GameObj<TextComp | any>, reformat?: boolean) {
+        const fOpt = Object.assign(getRenderProps(obj), {
             text: obj.text + "",
             size: obj.textSize,
             font: obj.font,
@@ -175,71 +198,95 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
             transform: obj.textTransform,
             styles: obj.textStyles,
             indentAll: opt.indentAll,
-        }));
+        });
 
-        if (!opt.width) {
-            obj.width = theFormattedText.width / (obj.scale?.x || 1);
-        }
+        theFormattedText = (reformat || !theFormattedText?.renderedText)
+            ? formatText(fOpt)
+            : transformFormattedText(theFormattedText, fOpt);
 
-        obj.height = theFormattedText.height / (obj.scale?.y || 1);
+        if (!opt.width) obj.width = theFormattedText.width;
+        obj.height = theFormattedText.height;
     }
 
-    let _shape: Rect | undefined;
-    let _width = opt.width ?? 0;
-    let _height = 0;
+    function isDynamic(value?: Function | Object) {
+        return (
+            typeof value === "function"
+            || (
+                value
+                && typeof value === "object"
+                && Object.values(value).some(v => typeof v === "function")
+            )
+        );
+    }
 
-    const obj: TextComp = {
+    function onUpdate(obj: GameObj<TextComp | any>) {
+        if (Object.values(_proxiedProps).some(isDynamic)) {
+            _updateController ??= obj.onUpdate(() => update(obj));
+        }
+        else {
+            _updateController?.cancel();
+            if (_updateController) update(obj);
+            _updateController = null;
+        }
+    }
+
+    function proxify(value: Object | Function) {
+        return value && typeof value === "object"
+            ? new Proxy(value, {
+                set(target, key, val) {
+                    Reflect.set(target, key, val);
+                    objRef && onUpdate(objRef);
+                    return true;
+                },
+            })
+            : value;
+    }
+
+    const obj = {
         id: "text",
         set text(nt) {
+            if (t === nt) return;
             t = nt;
-            // @ts-expect-error
-            update(this);
+            update(this as any as GameObj<TextComp>, true);
         },
         get text() {
             return t;
         },
-        textSize: opt.size ?? DEF_TEXT_SIZE,
-        font: opt.font!,
         get width() {
             return _width;
         },
         set width(value) {
-            if (_width != value) {
-                _width = value;
-                if (_shape) _shape.width = value;
-                this._renderAreaVersion = nextRenderAreaVersion();
-            }
+            if (_width === value) return;
+            _width = value;
+            if (_shape) _shape.width = value;
+            this._renderAreaVersion = nextRenderAreaVersion();
+            update(this as any as GameObj<TextComp>, true);
         },
         get height() {
             return _height;
         },
         set height(value) {
-            if (_height != value) {
-                _height = value;
-                if (_shape) _shape.height = value;
-                this._renderAreaVersion = nextRenderAreaVersion();
-            }
+            if (_height === value) return;
+            _height = value;
+            if (_shape) _shape.height = value;
+            this._renderAreaVersion = nextRenderAreaVersion();
+            update(this as any as GameObj<TextComp>, true);
         },
-        align: opt.align!,
-        lineSpacing: opt.lineSpacing!,
-        letterSpacing: opt.letterSpacing!,
-        textTransform: opt.transform!,
-        textStyles: opt.styles!,
 
         formattedText(this: GameObj<TextComp>) {
             return theFormattedText;
         },
 
         add(this: GameObj<TextComp>) {
-            _k.k.onLoad(() => update(this));
+            _k.k.onLoad(() => update(this, true));
+            this.onUse(() => update(this, true));
+            objRef = this;
+            update(this, true);
+            onUpdate(this);
         },
 
         draw(this: GameObj<TextComp>) {
             drawFormattedText(theFormattedText);
-        },
-
-        update(this: GameObj<TextComp>) {
-            update(this);
         },
 
         renderArea() {
@@ -264,10 +311,23 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
                 indentAll: opt.indentAll,
             };
         },
-    };
+    } as TextComp;
 
-    // @ts-expect-error
-    update(obj);
+    // define _props as obj props that call update once with reformat
+    defineReactiveProps(obj, _props, {
+        set(prop, value) {
+            _props[prop] = value;
+            update(this as any as GameObj<TextComp>, true);
+        },
+    });
+
+    // define _proxiedProps as obj props that register onUpdate with transform only
+    defineReactiveProps(obj, _proxiedProps, {
+        set(prop, value) {
+            _proxiedProps[prop] = proxify(value);
+            onUpdate(this as any as GameObj<TextComp>);
+        },
+    });
 
     // @ts-ignore Deep check in text related methods
     return obj;

--- a/src/ecs/components/draw/text.ts
+++ b/src/ecs/components/draw/text.ts
@@ -192,7 +192,11 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
         textTransform: proxifyProp(opt.transform!),
     };
 
-    function update(obj: GameObj<TextComp | any>, reformat?: boolean) {
+    function update(
+        obj: GameObj<TextComp | any>,
+        reformat?: boolean,
+        isDynamic = false,
+    ) {
         const fOpt = {
             ..._renderProps,
             text: obj.text + "",
@@ -209,21 +213,21 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
 
         theFormattedText = reformat
             ? formatText(fOpt)
-            : transformFormattedText(theFormattedText, fOpt);
+            : transformFormattedText(theFormattedText, fOpt, isDynamic);
 
         if (!opt.width) obj.width = theFormattedText.width;
         obj.height = theFormattedText.height;
     }
 
-    function isDynamic(value?: Function | Object) {
-        return (
+    function isDynamic() {
+        return Object.values(_proxiedProps).some(value => (
             typeof value === "function"
             || (
                 value
                 && typeof value === "object"
                 && Object.values(value).some(v => typeof v === "function")
             )
-        );
+        ));
     }
 
     function refreshRenderProps(obj: GameObj<TextComp | any>): 0 | 1 | 2 {
@@ -249,9 +253,9 @@ export function text(t: string, opt: TextCompOpt = {}): TextComp {
     function onUpdate(obj: GameObj<TextComp | any>) {
         _updateController?.cancel();
 
-        if (Object.values(_proxiedProps).some(isDynamic)) {
+        if (isDynamic()) {
             _updateController = obj.onUpdate(() => {
-                update(obj, refreshRenderProps(obj) === 2);
+                update(obj, refreshRenderProps(obj) === 2, true);
             });
         }
         else {

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -12,3 +12,33 @@ export function getRenderProps(obj: GameObj<any>) {
         blend: obj.blend,
     };
 }
+
+export function defineReactiveProps<T extends object, O extends object>(
+    obj: O,
+    src: T,
+    opt: {
+        get?: <K extends keyof T>(this: O, key: K) => T[K];
+        set?: <K extends keyof T>(this: O, key: K, value: T[K]) => void;
+    },
+) {
+    for (const key of Object.keys(src) as Array<keyof T>) {
+        Object.defineProperty(obj, key, {
+            enumerable: true,
+            configurable: true,
+            get: opt.get
+                ? function(this: O) {
+                    return opt.get!.call(this, key);
+                }
+                : function() {
+                    return src[key];
+                },
+            ...(opt.set && {
+                set(this: O, value) {
+                    opt.set!.call(this, key, value);
+                },
+            }),
+        });
+    }
+
+    return obj;
+}

--- a/src/gfx/draw/drawFormattedText.ts
+++ b/src/gfx/draw/drawFormattedText.ts
@@ -3,6 +3,7 @@ import type { Uniform } from "../../assets/shader";
 import { Color } from "../../math/color";
 import type { Vec2 } from "../../math/Vec2";
 import { anchorPt } from "../anchor";
+import type { StyledTextInfo } from "../formatText";
 import type { Texture } from "../gfx";
 import {
     multRotate,
@@ -26,6 +27,7 @@ export type FormattedText = {
     chars: FormattedChar[];
     opt: DrawTextOpt;
     renderedText: string;
+    charStyleMap: StyledTextInfo["charStyleMap"];
 };
 
 /**
@@ -39,7 +41,9 @@ export interface FormattedChar {
     frame: Frame;
     width: number;
     height: number;
+    initPos: Vec2;
     pos: Vec2;
+    initScale: Vec2;
     scale: Vec2;
     skew: Vec2;
     angle: number;

--- a/src/gfx/draw/drawFormattedText.ts
+++ b/src/gfx/draw/drawFormattedText.ts
@@ -53,6 +53,7 @@ export interface FormattedChar {
     stretchInPlace: boolean;
     shader?: string;
     uniform?: Uniform;
+    textCursor: number;
 }
 
 // cSpell: ignore ftext

--- a/src/gfx/draw/drawFormattedText.ts
+++ b/src/gfx/draw/drawFormattedText.ts
@@ -27,7 +27,6 @@ export type FormattedText = {
     chars: FormattedChar[];
     opt: DrawTextOpt;
     renderedText: string;
-    charStyleMap: StyledTextInfo["charStyleMap"];
 };
 
 /**
@@ -54,6 +53,7 @@ export interface FormattedChar {
     shader?: string;
     uniform?: Uniform;
     textCursor: number;
+    styles: StyledTextInfo["charStyleMap"][number];
 }
 
 // cSpell: ignore ftext

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -128,28 +128,24 @@ export function compileStyledText(txt: any): StyledTextInfo {
 function applyTransform(
     transform: DrawTextOpt["transform"],
     fchar: FormattedChar,
-    cursor: number,
 ) {
     if (!transform) return;
 
     const tr = typeof transform === "function"
-        ? transform(cursor, fchar.ch, "")
+        ? transform(fchar.textCursor, fchar.ch, "")
         : transform;
     if (tr) applyCharTransform(fchar, tr);
 }
 
 function applyStyles(
-    charStyles: StyledTextInfo["charStyleMap"][number],
     stylesOpt: DrawTextOpt["styles"],
     fchar: FormattedChar,
-    cursor: number,
 ) {
-    if (!charStyles) return;
-
-    for (const [name, param] of charStyles) {
+    for (const [name, param] of fchar.styles) {
         const style = stylesOpt?.[name];
+
         const tr = typeof style === "function"
-            ? style(cursor, fchar.ch, param)
+            ? style(fchar.textCursor, fchar.ch, param)
             : style;
 
         if (tr) applyCharTransform(fchar, tr);
@@ -175,12 +171,10 @@ export function transformFormattedText(
             angle: 0,
         };
 
-        applyTransform(opt.transform, fchar, fchar.textCursor);
+        applyTransform(opt.transform, fchar);
         applyStyles(
-            formattedText.charStyleMap[fchar.textCursor],
             opt.styles,
             fchar,
-            fchar.textCursor,
         );
 
         if (reformatOnStretch && !fchar.stretchInPlace) {
@@ -321,7 +315,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
             chars: [],
             opt: opt,
             renderedText: "",
-            charStyleMap: {},
         };
     }
 
@@ -399,14 +392,13 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                 font: defaultFontValue,
                 stretchInPlace: true,
                 textCursor: cursor,
+                styles: charStyleMap[cursor] ?? [],
             };
 
-            applyTransform(opt.transform, theFChar as any, cursor);
+            applyTransform(opt.transform, theFChar as any);
             applyStyles(
-                charStyleMap[cursor],
                 opt.styles,
                 theFChar as any,
-                cursor,
             );
 
             const requestedFont = theFChar.font;
@@ -419,7 +411,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                     chars: [],
                     opt: opt,
                     renderedText: "",
-                    charStyleMap: {},
                 };
             }
             let requestedFontData = defGfxFont;
@@ -540,6 +531,5 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         chars: formattedChars,
         opt,
         renderedText: text,
-        charStyleMap,
     };
 }

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -174,8 +174,13 @@ export function transformFormattedText(
             angle: 0,
         };
 
-        applyTransform(opt.transform, fchar, i);
-        applyStyles(formattedText.charStyleMap[i], opt.styles, fchar, i);
+        applyTransform(opt.transform, fchar, fchar.textCursor);
+        applyStyles(
+            formattedText.charStyleMap[fchar.textCursor],
+            opt.styles,
+            fchar,
+            fchar.textCursor,
+        );
 
         if (!fchar.stretchInPlace) {
             formattedText = formatText(opt);
@@ -392,6 +397,7 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                 angle: 0,
                 font: defaultFontValue,
                 stretchInPlace: true,
+                textCursor: cursor,
             };
 
             applyTransform(opt.transform, theFChar as any, cursor);

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -159,6 +159,7 @@ function applyStyles(
 export function transformFormattedText(
     formattedText: FormattedText,
     opt: DrawTextOpt,
+    reformatOnStretch: Boolean = false,
 ): FormattedText {
     const chars: FormattedChar[] = [];
 
@@ -182,7 +183,7 @@ export function transformFormattedText(
             fchar.textCursor,
         );
 
-        if (!fchar.stretchInPlace) {
+        if (reformatOnStretch && !fchar.stretchInPlace) {
             formattedText = formatText(opt);
             return formattedText;
         }

--- a/src/gfx/formatText.ts
+++ b/src/gfx/formatText.ts
@@ -125,6 +125,70 @@ export function compileStyledText(txt: any): StyledTextInfo {
     };
 }
 
+function applyTransform(
+    transform: DrawTextOpt["transform"],
+    fchar: FormattedChar,
+    cursor: number,
+) {
+    if (!transform) return;
+
+    const tr = typeof transform === "function"
+        ? transform(cursor, fchar.ch, "")
+        : transform;
+    if (tr) applyCharTransform(fchar, tr);
+}
+
+function applyStyles(
+    charStyles: StyledTextInfo["charStyleMap"][number],
+    stylesOpt: DrawTextOpt["styles"],
+    fchar: FormattedChar,
+    cursor: number,
+) {
+    if (!charStyles) return;
+
+    for (const [name, param] of charStyles) {
+        const style = stylesOpt?.[name];
+        const tr = typeof style === "function"
+            ? style(cursor, fchar.ch, param)
+            : style;
+
+        if (tr) applyCharTransform(fchar, tr);
+    }
+}
+
+export function transformFormattedText(
+    formattedText: FormattedText,
+    opt: DrawTextOpt,
+): FormattedText {
+    const chars: FormattedChar[] = [];
+
+    for (let i = 0; i < formattedText.chars.length; i++) {
+        let fchar = formattedText.chars[i];
+        fchar = {
+            ...fchar,
+            pos: vec2(fchar.initPos),
+            opacity: opt.opacity ?? 1,
+            color: opt.color ?? Color.WHITE,
+            scale: fchar.initScale,
+            skew: vec2(0),
+            angle: 0,
+        };
+
+        applyTransform(opt.transform, fchar, i);
+        applyStyles(formattedText.charStyleMap[i], opt.styles, fchar, i);
+
+        if (!fchar.stretchInPlace) {
+            formattedText = formatText(opt);
+            return formattedText;
+        }
+
+        chars.push(fchar);
+    }
+
+    formattedText.chars = chars;
+    return formattedText;
+}
+
 function getFontName(font: FontData | string): string {
     return font instanceof FontData
         ? font.fontface.family
@@ -251,6 +315,7 @@ export function formatText(opt: DrawTextOpt): FormattedText {
             chars: [],
             opt: opt,
             renderedText: "",
+            charStyleMap: {},
         };
     }
 
@@ -317,9 +382,11 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                 "width" | "height" | "frame"
             > = {
                 ch: ch,
+                initPos: vec2(curX, 0),
                 pos: vec2(curX, 0),
                 opacity: opt.opacity ?? 1,
                 color: opt.color ?? Color.WHITE,
+                initScale: vec2(scale),
                 scale: vec2(scale),
                 skew: vec2(0),
                 angle: 0,
@@ -327,28 +394,13 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                 stretchInPlace: true,
             };
 
-            if (opt.transform) {
-                const tr = typeof opt.transform === "function"
-                    ? opt.transform(cursor, ch, "")
-                    : opt.transform;
-                if (tr) {
-                    applyCharTransform(theFChar as any, tr);
-                }
-            }
-
-            if (charStyleMap[cursor]) {
-                const styles = charStyleMap[cursor];
-                for (const [name, param] of styles) {
-                    const style = opt.styles?.[name];
-                    const tr = typeof style === "function"
-                        ? style(cursor, ch, param)
-                        : style;
-
-                    if (tr) {
-                        applyCharTransform(theFChar as any, tr);
-                    }
-                }
-            }
+            applyTransform(opt.transform, theFChar as any, cursor);
+            applyStyles(
+                charStyleMap[cursor],
+                opt.styles,
+                theFChar as any,
+                cursor,
+            );
 
             const requestedFont = theFChar.font;
             const resolvedFont = resolveFont(requestedFont);
@@ -360,6 +412,7 @@ export function formatText(opt: DrawTextOpt): FormattedText {
                     chars: [],
                     opt: opt,
                     renderedText: "",
+                    charStyleMap: {},
                 };
             }
             let requestedFontData = defGfxFont;
@@ -464,6 +517,7 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         let thisLineHeight = size;
         for (const { ch } of lines[i].chars) {
             ch.pos = ch.pos.add(ox, th - baselineCenterOffset);
+            ch.initPos = ch.pos;
             formattedChars.push(ch);
             thisLineHeight = Math.max(
                 thisLineHeight,
@@ -479,5 +533,6 @@ export function formatText(opt: DrawTextOpt): FormattedText {
         chars: formattedChars,
         opt,
         renderedText: text,
+        charStyleMap,
     };
 }

--- a/tests/playtests/textPages.js
+++ b/tests/playtests/textPages.js
@@ -1,0 +1,94 @@
+/**
+ * @file Pages of text
+ * @description Perf test of multiple text() comps with 6.3k chars total & styled
+ * @minver 3001.0
+ */
+
+// Up to alpha-27 it would drop by ~30 FPS and make PC fans go into turbojet mode
+
+kaplay({
+    font: "outfit",
+    pixelDensity: Math.min(2, devicePixelRatio),
+});
+
+debug.inspect = true;
+
+loadFont(
+    "outfit",
+    "https://cdn.jsdelivr.net/fontsource/fonts/outfit@5.2.8/latin-300-normal.ttf",
+    {
+        size: 32 * _k.globalOpt.pixelDensity,
+    },
+);
+
+loadFont(
+    "darumadrop-one",
+    "https://cdn.jsdelivr.net/fontsource/fonts/darumadrop-one@5.2.8/latin-400-normal.ttf",
+    {
+        size: 64 * _k.globalOpt.pixelDensity,
+    },
+);
+
+const PAGE_COUNT = 3;
+const PAGE_WIDTH = 595;
+const PAGE_HEIGHT = 842;
+
+setCamScale(Math.min(1, width() / (PAGE_COUNT * PAGE_WIDTH)));
+
+const pages = Array.from({ length: PAGE_COUNT }, (_, i) => {
+    const page = add([
+        pos(
+            Math.round(
+                center().x - (PAGE_WIDTH * PAGE_COUNT) / 2
+                    + (PAGE_WIDTH + 1) * i,
+            ),
+            Math.round(center().y - PAGE_HEIGHT / 2),
+        ),
+        rect(PAGE_WIDTH, PAGE_HEIGHT),
+    ]);
+
+    page.txt = page.add([
+        pos(24),
+        // 2100 chars
+        text(
+            `
+[h1][i]Lorem ipsum[/i] dolor sit amet[/h1]
+
+Consectetur adipiscing elit. Fusce turpis lacus, maximus eu malesuada in, laoreet in nibh. Nam quis diam blandit, bibendum quam at, efficitur ligula. Aenean tincidunt eget mi sit amet volutpat. Duis rutrum, tortor at porttitor dapibus, tellus lectus mollis mi, sed lacinia lorem dui vitae sapien. Morbi eget commodo augue. Fusce efficitur accumsan orci, at sollicitudin diam ornare eu. Pellentesque eget enim at ex vestibulum volutpat.
+
+[i]Vivamus convallis tempus eros volutpat mattis. Quisque risus neque, commodo eget lacus ac, fringilla rutrum dolor.[/i] Curabitur vestibulum ut massa et tincidunt. Praesent sed suscipit felis, ac iaculis mi. Duis id iaculis ex. Pellentesque a molestie velit. Suspendisse potenti. Nulla sit amet nulla nec enim viverra dapibus bibendum sit amet erat. Mauris auctor aliquet malesuada. In eu ex quis dolor fermentum interdum. Morbi id placerat sem, at sodales sapien. Nam ornare, eros in faucibus imperdiet, ligula ipsum tincidunt velit, at tincidunt metus velit id tellus. Donec cursus, elit eu feugiat maximus, quam velit imperdiet urna, et vestibulum orci justo id erat. Donec hendrerit imperdiet pulvinar. Vestibulum iaculis magna ac posuere dapibus. Donec ex ligula, faucibus eu consequat eu, ullamcorper vitae lorem.
+
+Phasellus lacus ipsum, pellentesque quis placerat a, dapibus et nibh. Integer nec ex tellus. Mauris fringilla, massa id ultrices congue, urna dolor tristique velit, vitae mattis felis dolor non risus. Donec et pellentesque libero, nec ullamcorper risus. Donec dictum velit justo, a commodo enim tincidunt eu. Integer viverra ac erat ac porta. Suspendisse potenti. Morbi vulputate arcu vel blandit vehicula. Morbi ut risus sed ex pulvinar ultrices.
+
+[s]Pellentesque sit amet nisl dictum, commodo erat in, malesuada justo. Vestibulum non erat in lectus blandit ullamcorper ut ut mauris. In erat mauris, ullamcorper ut erat vel, accumsan scelerisque tellus. Nunc ligula tellus, vulputate ut pulvinar at, tristique eu libero. Donec sit amet pretium lectus. In vel tellus et justo efficitur ultrices et in tellus porttitor.[/s]
+            `.trim(),
+            {
+                size: 16,
+                lineSpacing: 8,
+                width: page.width - 40,
+                styles: {
+                    "h1": {
+                        font: "darumadrop-one",
+                        pos: vec2(0, 8),
+                        scale: vec2(2),
+                        stretchInPlace: false,
+                    },
+                    "i": {
+                        color: MAGENTA.darken(100),
+                        skew: vec2(-8, 0),
+                        override: true,
+                    },
+                    "s": {
+                        scale: vec2(0.4),
+                        color: BLACK.lighten(50),
+                        stretchInPlace: false,
+                        override: true,
+                    },
+                },
+            },
+        ),
+        color(BLACK.lighten(25)),
+    ]);
+
+    return page;
+});

--- a/tests/playtests/textScale.js
+++ b/tests/playtests/textScale.js
@@ -1,0 +1,46 @@
+/**
+ * @file Text & Scale
+ * @description Test object dimensions that uses text & scale comps
+ * @minver 3001.0
+ */
+
+kaplay({ background: [0, 0, 0], font: "happy", logMax: 1 });
+
+loadHappy();
+
+debug.inspect = true;
+
+let w = 0;
+let h = 0;
+
+onLoad(async () => {
+    const txt = add([
+        text(
+            `
+Object width/height should stay
+the same & area should
+get bigger when
+scaled up!`.trim(),
+            {
+                align: "center",
+                size: 18,
+                lineSpacing: 6,
+            },
+        ),
+        pos(center()),
+        anchor("center"),
+        scale(1),
+        area(),
+    ]);
+
+    w = txt.width;
+    h = txt.height;
+
+    wait(1, () => txt.scale = vec2(2));
+
+    onUpdate(() =>
+        debug.log(`
+Before: ${w}x${h} | After: ${txt.width}x${txt.height} | Scale: ${txt.scale.x}
+└─ Before & After should stay the same ─┘`)
+    );
+});


### PR DESCRIPTION
Optimizes the text component performance significantly (by ~30 FPS for large amounts of text).

Fixes #1095 by separating the overall text formatting and transforming (char styles). Text comp now mostly uses transform (`transformFormattedText`), update is called manually when needed and reformat (`formatText`) happens only when required (changes in text, dimensions, renderProp anchor). `onUpdate` now (mostly) just checks for used `renderProps` changes first (can't avoid), so with no changes and text static nothing gets called/updated at all. Unless, there are dynamic text `styles`/`transform` passed, then again, transform will be called only. When there is `stretchInPlace` option set to or evaluates to `false`, it will get reformatted once. Perf is now basically the same as with `txtObj.paused = true` workaround.

Can test all playtests prefixed with **`text`** which should behave the same as before. Added a new **`textPages`** perf playtest with 6300 chars with styles that now maintains 60 FPS, previously it would drop to ~30 FPS and make PC fans go into turbojet mode.

Also, fixed wrong dimensions reported and object not scaled properly along when scale comp used as reported earlier on DC by @hinum. **`textScale`** playtest added for that. Can check the scale issue on [kaplayground](https://play.kaplayjs.com/?code=eJxlUs1u2zAMvuspuKAYZMDImh6GIUELbKcdNuxQ7FQUCCMzklpXMix5ceYZ2EPksOfLk0yS49RBCR9E8jO%2Fjz%2FPWJW45x1sUDzL2jamWMLDdQ7xe8xha41fwkxhVe1nOZRWfsd2CQvosxVjpcXia0zx6BW0aeRcG1eR8HALvm4ogsjDLrjXq%2FRUw5NZ8y38zdHtjQCewe0ddAyCCWucB9%2FGElgU%2FCFFo3lqPT970dbsx%2BYpsu104dUHRVoqD07ZpizAedwzrwgcvhC8B6wJTzkmg5KNlpJq2CkyzAksqYCmeree%2B1q%2F8Cy%2FIOouvGhYamnCaAQZT%2FUsfwNw%2BjeFSX16mym1ofsKhTZyCR8v8%2F2rO5FQWccHIp5NwmiEsjUfNUwyqR%2B%2BmGJD92NXj3Fd8RH3EiY9T%2BNbpZA6hYZZjjjUni%2Fy055iOhEE6C8SN%2FwmGwta87Mq0BNPyDP5cBrheviafaGtrcNkrrpd3151qoc%2F8Hkb9MfQWUxMvcqImPvIOGIS%2Fbzt2fFwOB7%2BwlA0LDlVml4AnC8g4I6Hf%2BssqQqC4wn%2FB8cb1Yo%3D&version=4000.0.0-alpha.27.1) (perf one is too long to share).

## Summary

- Improved `text` component performance by separating text transform and formatting, reducing update calls for both dynamic and (especially) static text
- Fixed objects with a `text` component reporting wrong dimensions when scaled using the `scale` component

- [x] Changeloged
