### PR TITLE
fix: layer at index 0 returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ So your change should look like:
   (#1101) - @Stanko
 - Fixed objects with a `text` component reporting wrong dimensions when scaled
   using the `scale` component (#1125) - @imaginarny
+- Fixed the `layer` component property returning `null` when the layer index was
+  `0` (#1127) - @imaginarny
 
 ## [4000.0.0-alpha.27.1] - 2026-05-12
 

--- a/src/ecs/components/transform/layer.ts
+++ b/src/ecs/components/transform/layer.ts
@@ -33,7 +33,7 @@ export interface LayerComp extends Comp {
 
 export function layer(layer: string): LayerComp {
     let _layerIndex = _k.game.layers?.indexOf(layer);
-    if (_layerIndex == -1) {
+    if (_layerIndex == null || _layerIndex === -1) {
         throw new Error(`Layer "${layer}" does not exist`);
     }
 
@@ -43,14 +43,13 @@ export function layer(layer: string): LayerComp {
             return _layerIndex ?? null;
         },
         get layer(): string | null {
-            if (!_layerIndex) return null;
-
+            if (_layerIndex == null || _layerIndex === -1) return null;
             return _k.game.layers?.[_layerIndex] ?? null;
         },
         set layer(value: string) {
             _layerIndex = _k.game.layers?.indexOf(value);
 
-            if (_layerIndex == -1) {
+            if (_layerIndex == null || _layerIndex === -1) {
                 throw new Error(`Layer "${value}" does not exist`);
             }
         },


### PR DESCRIPTION
Layer that is at index `0` of defined layers returns `null` since the simple check used is falsy in that case. Can be seen in [kaplayground](https://play.kaplayjs.com/?code=eJxFT0EKgzAQvPuKRXpYQUTozdIHFHrsTQQTs41p1YiJFBH%2F3tUGuqfZ2Rlm9i3GTiy4Qmf1w%2FRUwG14msH4BbbkEkWK5KwzM7iRGg9X8NNMTDvyd7HQ5LCMtegprlL4gd3U2MF5sPLFBqEUlhHwdLsBgyo9qNE6zAOeOAA%2FRvkWkxRaMrr1mISjHUXDnTDPzoEREwkWRtW%2FJb%2BA9ZFSwGnl%2BOxYthTk7MG1du4USApFazZ%2BAddyTDY%3D&version=4000.0.0-alpha.27.1). Similarly, the error conditions weren't catching the case when layers are `null`/`undefined`.

## Summary

Fixed the `layer` component property returning `null` when the layer index was `0`

- [x] Changeloged
