### PR TITLE
Fixed test server not being up before its address is requested

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,6 +1,7 @@
 // @ts-check
 
 import fs from "fs";
+import { once } from "node:events";
 import path from "path";
 import puppeteer from "puppeteer";
 import { serve } from "./dev/serve.ts";
@@ -10,8 +11,9 @@ import { wait } from "./lib/util.ts";
 await build(true);
 
 const server = serve();
-const adress = server.address();
-const port = typeof adress == "object" ? adress?.port : "unknown";
+await once(server, "listening");
+const address = server.address();
+const port = typeof address == "object" ? address?.port : "unknown";
 
 let failed = false;
 


### PR DESCRIPTION
When running tests puppeteer couldn't reach the dev server. It took me more time than I'm willing to admit, but I found the error - it was a race condition because `server.address()` is read right after `serve()` and server wasn't broadcasted the "listening" event resulting in `http://localhost:unknown/ai`

The fix is to wait for the "listening" event before proceeding.

- [x] Changeloged
