### PR TITLE
feat: Added loop and onEnd to the video component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ So your change should look like:
 - Added a `repack: false` option to `loadSpite()` and a repack parameter to
   `loadSpriteAtlas()`, for faster loading if you're packing stuff at build-time
   (#1063) - @dragoncoder047
+- Added `loop` parameter and `onEnd` event to the video component (#1129) - @Stanko
 
 ### Changed
 
@@ -91,6 +92,7 @@ So your change should look like:
   @dragoncoder047
 - Added padding around edges of spritesheet to prevent stretch if uv ends up out
   of bounds (#1076) - @dragoncoder047
+- **(!)** Renamed video `mute` parameter to `muted` to match the native API (#1129) - @Stanko
 
 ### Fixed
 

--- a/examples/video.js
+++ b/examples/video.js
@@ -24,8 +24,8 @@ const vid = add([
     anchor("center"),
 ]);
 
-onMousePress(() => {
-    vid.play();
+vid.onEnd(() => {
+    console.log("Video ended");
 });
 
 /* 🥊 Challenge #1 🥊
@@ -36,10 +36,45 @@ Videos are cool! Try replacing the video url by this one:
 And see how your mind blows
 */
 
+// Events
+
+onMousePress(() => {
+    vid.play();
+});
+
+onKeyPress("space", () => {
+    vid.loop = !vid.loop;
+    loopLabel.text = `loop: ${vid.loop}`;
+});
+
+onUpdate(() => {
+    progressLabel.text = `${Math.round(vid.currentTime)}/${
+        Math.round(vid.duration)
+    }s`;
+});
+
 // Other visual elements
 
 add([
     pos(center().x, 50),
-    text("click to play video"),
+    text("click to play video\nspace to toggle loop", {
+        size: 20,
+    }),
+    anchor("center"),
+]);
+
+const loopLabel = add([
+    pos(center().x, 100),
+    text("loop: true", {
+        size: 10,
+    }),
+    anchor("center"),
+]);
+
+const progressLabel = add([
+    pos(center().x, 130),
+    text("", {
+        size: 10,
+    }),
     anchor("center"),
 ]);

--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -997,14 +997,14 @@ export interface KAPLAYCtx {
      * Draws a video.
      *
      * @param url - The video to play. Needs to be on the same webserver due to CORS.
-     * @param opt - The video component options
+     * @param opt - The video component options. You need to provide at least video `width` and `height`.
      *
      * @returns The video comp.
      * @since v4000.0
      * @group Components
      * @subgroup Rendering
      */
-    video(url: string, opt?: VideoCompOpt): VideoComp;
+    video(url: string, opt: VideoCompOpt): VideoComp;
     /**
      * Draws a picture, using the Picture API.
      *

--- a/src/ecs/components/draw/video.ts
+++ b/src/ecs/components/draw/video.ts
@@ -1,3 +1,4 @@
+import { KEvent, type KEventController } from "../../../events/events";
 import { getRenderProps } from "../../../game/utils";
 import { drawRect } from "../../../gfx/draw/drawRect";
 import { drawUVQuad } from "../../../gfx/draw/drawUVQuad";
@@ -15,13 +16,17 @@ export interface VideoComp extends Comp {
     duration: number;
     play(): void;
     pause(): void;
-    mute: boolean;
+    muted: boolean;
+    loop: boolean;
+    onEnd(action: () => void): KEventController;
     renderArea(): Rect;
 }
 
 export type VideoCompOpt = {
     width: number;
     height: number;
+    muted?: boolean;
+    loop?: boolean;
 };
 
 // region video
@@ -29,6 +34,7 @@ export function video(
     url: string,
     opt: VideoCompOpt,
 ): VideoComp & { _renderAreaVersion: number } {
+    const onEndEvents = new KEvent();
     const _video: HTMLVideoElement = document.createElement("video");
     let _playing = false;
     let _timeupdate = false;
@@ -74,16 +80,25 @@ export function video(
         pause() {
             _video.pause();
         },
-        get mute() {
+        get muted() {
             return _video.muted;
         },
-        set mute(value) {
+        set muted(value) {
             _video.muted = value;
+        },
+        get loop() {
+            return _video.loop;
+        },
+        set loop(value) {
+            _video.loop = value;
+        },
+        onEnd(action: () => void) {
+            return onEndEvents.add(action);
         },
         add() {
             _video.playsInline = true;
-            // _video.muted = true; Don't use this, sound will not work
-            _video.loop = true;
+            _video.muted = opt.muted ?? true;
+            _video.loop = opt.loop ?? true;
             _video.autoplay = false;
             _video.crossOrigin = "anonymous";
 
@@ -100,6 +115,18 @@ export function video(
                 "timeupdate",
                 () => {
                     _timeupdate = true;
+                    updateCopyFlag();
+                },
+                true,
+            );
+
+            _video.addEventListener(
+                "ended",
+                () => {
+                    onEndEvents.trigger();
+
+                    _playing = false;
+                    _timeupdate = false;
                     updateCopyFlag();
                 },
                 true,


### PR DESCRIPTION
- Added `loop` parameter and `onEnd` event to the video component.
- Renamed video `mute` to `muted` to match the native API and added it to `VideoCompOpt`
- Updated the public API to match `opt: VideoCompOpt` being required
- Updated the video example 

## Summary

- [x] Changeloged
