### PR TITLE
fix: Restored fixed canvas sizing and added clientToViewport

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -20,7 +20,7 @@ import type {
 } from "../events/eventMap";
 import { type KEventController, KEventHandler } from "../events/events";
 import { canvasToViewport } from "../gfx/viewport";
-import { map, vec2 } from "../math/math";
+import { vec2 } from "../math/math";
 import { Vec2 } from "../math/Vec2";
 import { _k } from "../shared";
 import { deprecateMsg } from "../utils/log";
@@ -999,6 +999,44 @@ export const initApp = (
         queueReleaseHeldInputs();
     }
 
+    const pixelDensity = opt.pixelDensity || 1;
+
+    function clientToViewport(clientX: number, clientY: number): Vec2 {
+        const box = state.canvas.getBoundingClientRect();
+        const canvasWidth = state.canvas.width / pixelDensity;
+        const canvasHeight = state.canvas.height / pixelDensity;
+        let x = box.x;
+        let y = box.y;
+        let width = box.width;
+        let height = box.height;
+
+        // Account for bars created by object-fit: contain
+        // It is used by the most user-agent stylesheets when element is put in fullscreen
+        // Or it can be set by the user
+        if (getComputedStyle(state.canvas).objectFit === "contain") {
+            const canvasAspectRatio = canvasWidth / canvasHeight;
+            const boxAspectRatio = width / height;
+
+            if (boxAspectRatio > canvasAspectRatio) {
+                const fittedWidth = height * canvasAspectRatio;
+                x += (width - fittedWidth) / 2;
+                width = fittedWidth;
+            }
+            else {
+                const fittedHeight = width / canvasAspectRatio;
+                y += (height - fittedHeight) / 2;
+                height = fittedHeight;
+            }
+        }
+
+        return canvasToViewport(
+            new Vec2(
+                (clientX - x) * canvasWidth / width,
+                (clientY - y) * canvasHeight / height,
+            ),
+        );
+    }
+
     canvasEvents.blur = () => {
         releaseHeldInputsOnFocusLoss();
     };
@@ -1008,9 +1046,7 @@ export const initApp = (
         // Letterbox creates some black bars so we need to remove that for calculating
         // mouse position
 
-        // Ironically, e.offsetX and e.offsetY are the mouse position. Is not
-        // related to what we call the "offset" in this code
-        const mousePos = canvasToViewport(new Vec2(e.offsetX, e.offsetY));
+        const mousePos = clientToViewport(e.clientX, e.clientY);
         const mouseDeltaPos = new Vec2(e.movementX, e.movementY);
 
         state.lastInputDevice = "mouse";
@@ -1118,14 +1154,11 @@ export const initApp = (
 
         state.events.onOnce("input", () => {
             const touches = [...e.changedTouches];
-            const box = state.canvas.getBoundingClientRect();
 
             if (opt.touchToMouse !== false) {
-                state.mousePos = canvasToViewport(
-                    new Vec2(
-                        touches[0].clientX - box.x,
-                        touches[0].clientY - box.y,
-                    ),
+                state.mousePos = clientToViewport(
+                    touches[0].clientX,
+                    touches[0].clientY,
                 );
                 state.lastInputDevice = "mouse";
                 state.buttonHandler.processMousedown("left", state);
@@ -1135,12 +1168,7 @@ export const initApp = (
             touches.forEach((t) => {
                 state.events.trigger(
                     "touchStart",
-                    canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
-                    ),
+                    clientToViewport(t.clientX, t.clientY),
                     t,
                 );
             });
@@ -1152,15 +1180,12 @@ export const initApp = (
         e.preventDefault();
         state.events.onOnce("input", () => {
             const touches = [...e.changedTouches];
-            const box = state.canvas.getBoundingClientRect();
 
             if (opt.touchToMouse !== false) {
                 const lastMousePos = state.mousePos;
-                state.mousePos = canvasToViewport(
-                    new Vec2(
-                        touches[0].clientX - box.x,
-                        touches[0].clientY - box.y,
-                    ),
+                state.mousePos = clientToViewport(
+                    touches[0].clientX,
+                    touches[0].clientY,
                 );
                 state.mouseDeltaPos = state.mousePos.sub(lastMousePos);
                 state.events.trigger("mouseMove");
@@ -1169,12 +1194,7 @@ export const initApp = (
             touches.forEach((t) => {
                 state.events.trigger(
                     "touchMove",
-                    canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
-                    ),
+                    clientToViewport(t.clientX, t.clientY),
                     t,
                 );
             });
@@ -1184,14 +1204,11 @@ export const initApp = (
     canvasEvents.touchend = (e) => {
         state.events.onOnce("input", () => {
             const touches = [...e.changedTouches];
-            const box = state.canvas.getBoundingClientRect();
 
             if (opt.touchToMouse != false) {
-                state.mousePos = canvasToViewport(
-                    new Vec2(
-                        touches[0].clientX - box.x,
-                        touches[0].clientY - box.y,
-                    ),
+                state.mousePos = clientToViewport(
+                    touches[0].clientX,
+                    touches[0].clientY,
                 );
                 state.mouseDeltaPos = new Vec2(0, 0);
                 state.buttonHandler.processMouseup("left", state);
@@ -1201,12 +1218,7 @@ export const initApp = (
             touches.forEach((t) => {
                 state.events.trigger(
                     "touchEnd",
-                    canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
-                    ),
+                    clientToViewport(t.clientX, t.clientY),
                     t,
                 );
             });
@@ -1216,14 +1228,11 @@ export const initApp = (
     canvasEvents.touchcancel = (e) => {
         state.events.onOnce("input", () => {
             const touches = [...e.changedTouches];
-            const box = state.canvas.getBoundingClientRect();
 
             if (opt.touchToMouse !== false) {
-                state.mousePos = canvasToViewport(
-                    new Vec2(
-                        touches[0].clientX - box.x,
-                        touches[0].clientY - box.y,
-                    ),
+                state.mousePos = clientToViewport(
+                    touches[0].clientX,
+                    touches[0].clientY,
                 );
                 state.mouseState.release("left", state);
             }
@@ -1231,12 +1240,7 @@ export const initApp = (
             touches.forEach((t) => {
                 state.events.trigger(
                     "touchEnd",
-                    canvasToViewport(
-                        new Vec2(
-                            t.clientX - box.x,
-                            t.clientY - box.y,
-                        ),
-                    ),
+                    clientToViewport(t.clientX, t.clientY),
                     t,
                 );
             });

--- a/src/app/appEvents.ts
+++ b/src/app/appEvents.ts
@@ -19,10 +19,15 @@ export function initAppEvents() {
     });
 
     _k.app.onResize(() => {
+        const fixedSize = _k.globalOpt.width && _k.globalOpt.height;
+        if (fixedSize && !_k.globalOpt.letterbox) {
+            return;
+        }
+
         _k.canvas.width = _k.canvas.offsetWidth * _k.gfx.pixelDensity;
         _k.canvas.height = _k.canvas.offsetHeight * _k.gfx.pixelDensity;
 
-        if (!_k.globalOpt.width || !_k.globalOpt.height) {
+        if (!fixedSize) {
             _k.gfx.frameBuffer.free();
             _k.gfx.frameBuffer = new FrameBuffer(
                 _k.gfx.ggl,

--- a/src/gfx/canvas.ts
+++ b/src/gfx/canvas.ts
@@ -30,15 +30,8 @@ export const createCanvas = (gopt: MustKAPLAYOpt) => {
         // check if isFixed
         gopt.width && gopt.height && !gopt.letterbox
     ) {
-        // check if already styled, 300x150 is the default intrinsic size
-        if (canvas.offsetWidth !== 300 || canvas.offsetHeight !== 150) {
-            canvas.width = canvas.offsetWidth;
-            canvas.height = canvas.offsetHeight;
-        }
-        else {
-            canvas.width = gopt.width * gopt.scale;
-            canvas.height = gopt.height * gopt.scale;
-        }
+        canvas.width = gopt.width * gopt.scale;
+        canvas.height = gopt.height * gopt.scale;
         styles.push(`width: ${canvas.width}px`);
         styles.push(`height: ${canvas.height}px`);
     }

--- a/src/gfx/viewport.ts
+++ b/src/gfx/viewport.ts
@@ -36,14 +36,13 @@ export function updateViewport() {
     let viewportWidth = canvasWidth;
     let viewportHeight = canvasHeight;
 
-    if (!desiredWidth || !desiredHeight) {
-        if (_k.globalOpt.letterbox) {
+    if (_k.globalOpt.letterbox) {
+        if (!desiredWidth || !desiredHeight) {
             throw new Error(
                 "Letterboxing requires width and height defined.",
             );
         }
-    }
-    else {
+
         const canvasAspectRatio = canvasWidth / canvasHeight;
         const desiredAspectRatio = desiredWidth / desiredHeight;
 

--- a/tests/auto/canvasSizing.spec.ts
+++ b/tests/auto/canvasSizing.spec.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+describe("fixed canvas sizing and input coordinates", () => {
+    beforeEach(async () => {
+        await page.goto("about:blank");
+        await page.addScriptTag({ path: "dist/kaplay.js" });
+    });
+
+    test("explicit dimensions override a supplied canvas CSS size", async () => {
+        const size = await page.evaluate(() => {
+            const canvas = document.createElement("canvas");
+            canvas.style.width = "320px";
+            canvas.style.height = "180px";
+            document.body.appendChild(canvas);
+
+            const k = kaplay({
+                global: false,
+                canvas,
+                width: 480,
+                height: 270,
+                scale: 2,
+            });
+            const result = {
+                width: canvas.width,
+                height: canvas.height,
+            };
+
+            k.quit();
+            canvas.remove();
+            return result;
+        });
+
+        expect(size).toEqual({ width: 960, height: 540 });
+    });
+
+    test("CSS scaling does not resize a fixed backing store", async () => {
+        const size = await page.evaluate(async () => {
+            const k = kaplay({
+                global: false,
+                width: 480,
+                height: 270,
+                scale: 2,
+            });
+            const canvas = k._k.canvas;
+            canvas.style.width = "640px";
+            canvas.style.height = "360px";
+
+            await new Promise(requestAnimationFrame);
+            await new Promise(requestAnimationFrame);
+
+            const result = {
+                width: canvas.width,
+                height: canvas.height,
+            };
+
+            k.quit();
+            canvas.remove();
+            return result;
+        });
+
+        expect(size).toEqual({ width: 960, height: 540 });
+    });
+
+    test("mouse and touch account for CSS contain bars", async () => {
+        await page.setViewport({ width: 800, height: 600 }); // 1.33 ratio
+        await page.evaluate(() => {
+            document.body.style.margin = "0";
+            const k = kaplay({
+                global: false,
+                width: 480,
+                height: 270, // 1.77 ratio
+                scale: 2,
+            });
+            const canvas = k._k.canvas;
+            canvas.style.setProperty("width", "100vw", "important");
+            canvas.style.setProperty("height", "100vh", "important");
+            canvas.style.objectFit = "contain";
+
+            // @ts-ignore Expose context for the next evaluation
+            window.testCtx = k;
+        });
+
+        // Canvas will be rendered at 800x450
+        // Vertical bars are 75px tall
+        await page.mouse.move(
+            200, // 25% of the canvas
+            75 + 225, // Bar + 50% od the canvas height
+        );
+        await page.evaluate(() => new Promise(requestAnimationFrame));
+
+        // It should map to
+        const expected = {
+            x: 120, // 480 * 25%
+            y: 135, // 270 * 50%
+        };
+
+        const positions = await page.evaluate(async () => {
+            // @ts-ignore Test context was created in the previous evaluation
+            const k = window.testCtx;
+            const mouse = k.mousePos();
+            let touch = null;
+
+            k.onTouchStart((pos: { x: number; y: number }) => {
+                touch = { x: pos.x, y: pos.y };
+            });
+
+            const event = new Event("touchstart", {
+                bubbles: true,
+                cancelable: true,
+            });
+            Object.defineProperty(event, "changedTouches", {
+                value: [{ clientX: 200, clientY: 75 + 225 }],
+            });
+            k._k.canvas.dispatchEvent(event);
+
+            await new Promise(requestAnimationFrame);
+
+            const result = {
+                canvas: {
+                    width: k._k.canvas.width,
+                    height: k._k.canvas.height,
+                },
+                mouse: { x: mouse.x, y: mouse.y },
+                touch,
+            };
+
+            k.quit();
+            k._k.canvas.remove();
+            return result;
+        });
+
+        expect(positions.canvas).toEqual({ width: 960, height: 540 });
+        expect(positions.mouse.x).toBeCloseTo(expected.x);
+        expect(positions.mouse.y).toBeCloseTo(expected.y);
+        expect(positions.touch).toEqual(expected);
+    });
+});

--- a/tests/playtests/mouseSizeObjectFitContain.js
+++ b/tests/playtests/mouseSizeObjectFitContain.js
@@ -1,0 +1,29 @@
+// To test touch, enable touch simulation in dev tools responsive design mode
+// then press and hold mouse down and move around
+// ensure that red dot follows correctly in windowed mode as well as in fullscreen (F)
+
+document.head.innerHTML += `<style>
+canvas {
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: contain;
+}
+</style>`;
+
+const k = kaplay({ width: 600, height: 400 });
+
+const redDot = add([
+    anchor("center"),
+    circle(3),
+    color(RED),
+    pos(),
+    area(),
+]);
+
+onMouseMove(pos => {
+    redDot.pos = toWorld(pos);
+});
+
+onKeyPress("f", () => {
+    setFullscreen(!isFullscreen());
+});


### PR DESCRIPTION
@imaginarny these are my suggested changes for #1106

- Restored fixed canvas sizing
- Respored aspect ratio fitting when letterbox is passed
- Added `clientToViewport` helper for both touch and mouse pos
- Handled `object-fit: contain` which I use, but it is also used in user agent stylesheets when element is put in fullscreen 

Important thing is that it still doesn't calculate properly in some edge cases like:
- Adding border or padding to the canvas element itself
- Using object-fit `cover` or `scale-down`

But I think it is fine as these are not real scenarios for a game canvas. It should be mentioned in the docs though.

EDIT: Full disclosure - I used LLM for generating the tests and then cleaned them up by hand

## Contributor Checks

- [x] I'm aware of the
      [contributing guidelines](https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md).

## Reviewer Checks

> For reviewer use only. Delete not applicable checkboxes.

- [ ] Changes include e2e tests
- [ ] Changes include unit tests
