### PR TITLE
docs: add missing forward slashes

### DIFF
--- a/src/core/contextType.ts
+++ b/src/core/contextType.ts
@@ -363,7 +363,7 @@ export interface KAPLAYCtx {
      *
      * // Example 2: using onClick() or other functions with readd().
      * // If you comment out the first example, and use this readd() with a function like onClick(), you
-     * can keep switching which sprite is above the other ( click on edge of face ).
+     * // can keep switching which sprite is above the other ( click on edge of face ).
      *
      * purpleBean.onClick(() => {
      *     readd(greenBean);


### PR DESCRIPTION
# PR Overview

Hi 👋  - tiny PR that adds missing forward slashes. I noticed this when going through the kaplay's documentation (awesome lib btw! 🙂).

<img width="380" height="234" alt="image" src="https://github.com/user-attachments/assets/3df75ee4-e353-4f40-86d7-dbbe891d2ed3" />

### List of changes

- Edited source comment to include forward slashes so it renders as a comment in the documentation.

## Contributor Checks

- [x] I'm aware of the
      [contributing guidelines](https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md).