### PR TITLE
Video component, on init render black rect instead of white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ So your change should look like:
   text (#1125) - @imaginarny
 - Debug keys, keys defined with the Buttons API, and keyboard input captured by
   e.g. focused `textInput` now use `preventDefault()` (#1114) - @imaginarny
+- Video component - Render black rectangle (instead of white one) before the
+  video has been played (#1145) - @Stanko
 
 ### Fixed
 

--- a/examples/video-blank-state.js
+++ b/examples/video-blank-state.js
@@ -1,0 +1,39 @@
+// Test if the video is rendered as a black rectangle before it is played
+// Test if the video color is working when video is loaded and played
+
+kaplay({ scale: 2, background: "#a32858", font: "happy" });
+
+loadHappy();
+
+const vid = add([
+    pos(center()),
+    video("/videos/dance.mp4", {
+        width: 320,
+        height: 200,
+    }),
+    anchor("center"),
+    // Changing the color to test if it is rendered properly
+    color(rgb(100, 100, 255)),
+]);
+
+// Events
+
+let playing = false;
+onMousePress(() => {
+    playing = !playing;
+    console.log(playing);
+    if (playing) {
+        vid.play();
+    }
+    else {
+        vid.pause();
+    }
+});
+
+add([
+    pos(center().x, 50),
+    text("click to play/pause the video", {
+        size: 20,
+    }),
+    anchor("center"),
+]);

--- a/src/ecs/components/draw/video.ts
+++ b/src/ecs/components/draw/video.ts
@@ -3,6 +3,7 @@ import { getRenderProps } from "../../../game/utils";
 import { drawRect } from "../../../gfx/draw/drawRect";
 import { drawUVQuad } from "../../../gfx/draw/drawUVQuad";
 import { Texture } from "../../../gfx/gfx";
+import { Color } from "../../../math/color";
 import { Rect, vec2 } from "../../../math/math";
 import { _k } from "../../../shared";
 import type { Comp, GameObj } from "../../../types";
@@ -185,6 +186,7 @@ export function video(
                 drawRect(Object.assign(getRenderProps(this), {
                     width: this.width,
                     height: this.height,
+                    color: Color.BLACK,
                 }));
             }
         },


### PR DESCRIPTION
Video component used to render a white rectangle before the video was played, because the color was inherited from `getRenderProps`. Changed it to always render black rectangle before the video is first played.

## Contributor Checks

- [x] I'm aware of the
      [contributing guidelines](https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md).

## Reviewer Checks

- [x] Changes include a changelog