### PR TITLE
chore: add missing allow script package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
   "engines": {
     "node": ">=24.0.0"
   },
+  "allowScripts": {
+    "dprint@0.55.2": true,
+    "dprint@0.49.1": true,
+    "esbuild@0.28.2": true,
+    "puppeteer@25.7.0": true
+  },
   "overrides": {
     "axios@>=1.0.0 <1.15.0": ">=1.15.0",
     "basic-ftp@<=5.2.1": ">=5.2.2",


### PR DESCRIPTION
# PR Overview

Allow scripts that were in pnpm workspace but forgot to include when originally migrating to npm in #1147

Created this pr from vscode isn't that cool

## Contributor Checks

- [x] I'm aware of the
      [contributing guidelines](https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md).

## Reviewer Checks

> For reviewer use only. Delete not applicable checkboxes.

- [ ] Changes include e2e tests
- [ ] Changes include unit tests