### PR TITLE
Add a smooth/anti-aliasing rendering option

### DIFF
--- a/src/app/appEvents.ts
+++ b/src/app/appEvents.ts
@@ -34,6 +34,9 @@ export function initAppEvents() {
                 _k.gfx.ggl,
                 _k.gfx.ggl.gl.drawingBufferWidth,
                 _k.gfx.ggl.gl.drawingBufferHeight,
+                _k.globalOpt.crisp === "smooth"
+                    ? { filter: "linear" }
+                    : undefined,
             );
 
             _k.gfx.width = _k.gfx.ggl.gl.drawingBufferWidth

--- a/src/core/frameRendering.ts
+++ b/src/core/frameRendering.ts
@@ -80,14 +80,29 @@ export const createFrameRenderer = (
         gfx.width = gfx.gl.drawingBufferWidth / pixelDensity;
         gfx.height = gfx.gl.drawingBufferHeight / pixelDensity;
 
+        // When `crisp: "smooth"` is set and the user didn't apply their own
+        // post effect, upscale the game through the box-filter shader.
+        const upscaleShader = !gfx.postShader && gfx.smoothShader;
+
         drawTexture({
             flipY: true,
             tex: gfx.frameBuffer.tex,
             pos: new Vec2(gfx.viewport.x, gfx.viewport.y),
             width: gfx.viewport.width,
             height: gfx.viewport.height,
-            shader: gfx.postShader,
-            uniform: typeof gfx.postShaderUniform === "function"
+            shader: upscaleShader ? gfx.smoothShader : gfx.postShader,
+            uniform: upscaleShader
+                ? {
+                    u_texSize: new Vec2(
+                        gfx.frameBuffer.tex.width,
+                        gfx.frameBuffer.tex.height,
+                    ),
+                    u_resolution: new Vec2(
+                        gfx.viewport.width * pixelDensity,
+                        gfx.viewport.height * pixelDensity,
+                    ),
+                }
+                : typeof gfx.postShaderUniform === "function"
                 ? gfx.postShaderUniform()
                 : gfx.postShaderUniform,
             fixed: true,

--- a/src/gfx/canvas.ts
+++ b/src/gfx/canvas.ts
@@ -49,7 +49,8 @@ export const createCanvas = (gopt: MustKAPLAYOpt) => {
     }
 
     // Crisping
-    if (gopt.crisp) {
+    // "smooth" upscaling is done by the shader, not the browser. See frameRendering.ts
+    if (gopt.crisp === true) {
         // chrome only supports pixelated and firefox only supports crisp-edges
         styles.push("image-rendering: pixelated");
         styles.push("image-rendering: crisp-edges");

--- a/src/gfx/gfxApp.ts
+++ b/src/gfx/gfxApp.ts
@@ -9,10 +9,11 @@ import {
 import { type Color, rgb } from "../math/color";
 import { Mat23 } from "../math/math";
 import { Vec2 } from "../math/Vec2";
-import type { MustKAPLAYOpt } from "../types";
+import type { MustKAPLAYOpt, TextureOpt } from "../types";
 import type { FontAtlas } from "./formatText";
 import { FrameBuffer } from "./FrameBuffer";
 import { BatchRenderer, type GfxCtx, Texture } from "./gfx";
+import { SMOOTH_SCALE_FRAG } from "./shaders/smoothScale";
 import type { Frame } from "./TexPacker";
 
 export type AppGfxCtx = {
@@ -30,6 +31,8 @@ export type AppGfxCtx = {
     /** Post Shader, used in postEffect() */
     postShader: string | null;
     postShaderUniform: Uniform | (() => Uniform) | null;
+    /** Box-filter upscaling shader, used when `crisp: "smooth"` */
+    smoothShader: Shader | null;
     renderer: BatchRenderer;
     pixelDensity: number;
     transform: Mat23;
@@ -81,16 +84,24 @@ export const initAppGfx = (
     const pixelDensity = gopt.pixelDensity ?? 1;
     const { gl } = gfx;
 
+    // The smooth upscaler samples the frame texture directly when scaling
+    // down, so the texture needs linear filtering to resolve it
+    const frameBufferOpt: TextureOpt | undefined = gopt.crisp === "smooth"
+        ? { filter: "linear" }
+        : undefined;
+
     const frameBuffer = (gopt.width && gopt.height)
         ? new FrameBuffer(
             gfx,
             gopt.width * pixelDensity * gopt.scale,
             gopt.height * pixelDensity * gopt.scale,
+            frameBufferOpt,
         )
         : new FrameBuffer(
             gfx,
             gl.drawingBufferWidth,
             gl.drawingBufferHeight,
+            frameBufferOpt,
         );
 
     let bgColor: null | Color = null;
@@ -174,6 +185,9 @@ export const initAppGfx = (
         frameBuffer: frameBuffer,
         postShader: null as string | null,
         postShaderUniform: null as Uniform | (() => Uniform) | null,
+        smoothShader: gopt.crisp === "smooth"
+            ? makeShader(gfx, DEF_VERT, SMOOTH_SCALE_FRAG)
+            : null,
         renderer: renderer,
         pixelDensity: pixelDensity,
 

--- a/src/gfx/shaders/smoothScale.ts
+++ b/src/gfx/shaders/smoothScale.ts
@@ -1,0 +1,72 @@
+/**
+ * Box-filter upscaling shader for the rendered frame, used when
+ * `crisp: "smooth"`. Every destination pixel is the weighted average of the
+ * texels it covers, so pixels stay crisp while their edges are anti-aliased.
+ *
+ * Uniforms set by the frame renderer:
+ * - `u_texSize`: size of the rendered frame, in texels
+ * - `u_resolution`: size of the destination area, in canvas pixels
+ */
+export const SMOOTH_SCALE_FRAG = `
+// The template defaults to mediump, which is too coarse for texel indices on
+// high resolution games (few fp16 mantissa bits once multiplied by the texel
+// size). Prefer highp where the fragment stage supports it.
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#endif
+
+uniform vec2 u_texSize;
+uniform vec2 u_resolution;
+
+// Overlap of texel j with the destination pixel footprint [c - h, c + h]
+float smooth_overlap(float c, float h, float j) {
+    return clamp(min(c + h, j + 1.0) - max(c - h, j), 0.0, 1.0);
+}
+
+vec4 frag(vec2 pos, vec2 uv, vec4 color, sampler2D tex) {
+    // Destination pixel center and half footprint, in texel space
+    vec2 c = uv * u_texSize;
+    vec2 h = 0.5 * u_texSize / u_resolution;
+
+    // Scaling down: footprints wider than one texel need mip filtering to be
+    // resolved, which this upscaler doesn't do. Fall back to the regular
+    // sampling (the frame texture is linear-filtered in smooth mode).
+    if (h.x >= 0.5 || h.y >= 0.5) {
+        return def_frag();
+    }
+
+    // Covered texel indices, at most two per axis while the footprint is
+    // smaller than one texel
+    vec2 j0 = floor(c - h);
+    vec2 j1 = j0 + 1.0;
+
+    float wx0 = smooth_overlap(c.x, h.x, j0.x);
+    float wx1 = smooth_overlap(c.x, h.x, j1.x);
+    float wy0 = smooth_overlap(c.y, h.y, j0.y);
+    float wy1 = smooth_overlap(c.y, h.y, j1.y);
+
+    // Normalize, so footprints wider than one texel keep their full intensity
+    float wx = wx0 + wx1;
+    float wy = wy0 + wy1;
+    wx0 /= wx;
+    wx1 /= wx;
+    wy0 /= wy;
+    wy1 /= wy;
+
+    // Sample texel centers, making the result independent of the texture filter
+    vec2 lo = clamp(j0, vec2(0.0), u_texSize - 1.0);
+    vec2 hi = clamp(j1, vec2(0.0), u_texSize - 1.0);
+    vec2 loUv = (lo + 0.5) / u_texSize;
+    vec2 hiUv = (hi + 0.5) / u_texSize;
+
+    vec4 t00 = texture2D(tex, vec2(loUv.x, loUv.y));
+    vec4 t10 = texture2D(tex, vec2(hiUv.x, loUv.y));
+    vec4 t01 = texture2D(tex, vec2(loUv.x, hiUv.y));
+    vec4 t11 = texture2D(tex, vec2(hiUv.x, hiUv.y));
+
+    return t00 * (wx0 * wy0)
+        + t10 * (wx1 * wy0)
+        + t01 * (wx0 * wy1)
+        + t11 * (wx1 * wy1);
+}
+`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -316,10 +316,18 @@ export interface KAPLAYOpt {
      */
     pixelDensity?: number;
     /**
-     * Disable antialias and enable sharp pixel display. If you see rendering artifacts, set `pixelDensity`
+     * Disable antialias and enable sharp pixel display.
+     *
+     * - `true`/`false`: toggles the sharpening of the whole canvas with the CSS property `image-rendering`,
+     *   letting the browser upscale it as-is.
+     * - `"smooth"`: upscales the game with a box-filter shader, keeping pixels
+     *   crisp while anti-aliasing their edges. Good compromise when the canvas
+     *   scale isn't an integer (e.g. with `letterbox`).
+     *
+     * If you see rendering artifacts, set `pixelDensity`
      * param to `Math.min(devicePixelRatio, 2)` and `scale` to FHD resolution (e.g. 960x540 would need scale 2). Will result in up to 4K.
      */
-    crisp?: boolean;
+    crisp?: boolean | "smooth";
     /**
      * The canvas DOM element to use. If empty will create one.
      */

--- a/tests/integration/gfx/crispSmooth.spec.ts
+++ b/tests/integration/gfx/crispSmooth.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const GAME_WIDTH = 320;
+const GAME_HEIGHT = 180;
+
+type Crisp = "smooth" | boolean | undefined;
+
+/** Boots a game with the given `crisp` value and returns a canvas screenshot. */
+async function render(
+    page: Page,
+    crisp: Crisp,
+    viewport: { width: number; height: number },
+) {
+    await page.setViewportSize(viewport);
+    await page.addScriptTag({ path: "dist/kaplay.js" });
+    await page.evaluate(
+        ({ crisp, GAME_WIDTH, GAME_HEIGHT }) => {
+            const k = kaplay({
+                width: GAME_WIDTH,
+                height: GAME_HEIGHT,
+                letterbox: true,
+                debug: false,
+                crisp,
+            });
+
+            // Deterministic scene with lots of 1px-ish edges
+            for (let i = 0; i < 10; i++) {
+                k.add([
+                    k.rect(5, 18),
+                    k.pos(15 + i * 15, 20 + i * 12),
+                    k.color(255, 255, 255),
+                ]);
+            }
+        },
+        { crisp, GAME_WIDTH, GAME_HEIGHT },
+    );
+
+    // Let the loading screen go away and a few frames settle
+    await page.waitForTimeout(500);
+    return page.locator("canvas").screenshot();
+}
+
+test("only crisp: \"smooth\" creates the upscaling shader", async ({ context }) => {
+    const hasUpscaleShader = async (crisp: Crisp) => {
+        const page = await context.newPage();
+        await page.addScriptTag({ path: "dist/kaplay.js" });
+        const has = await page.evaluate(
+            ({ crisp, width, height }) => {
+                const k = kaplay({
+                    width,
+                    height,
+                    debug: false,
+                    crisp,
+                });
+                return !!k._k.gfx.smoothShader;
+            },
+            { crisp, width: GAME_WIDTH, height: GAME_HEIGHT },
+        );
+        await page.close();
+        return has;
+    };
+
+    expect(await hasUpscaleShader("smooth")).toBe(true);
+    expect(await hasUpscaleShader(true)).toBe(false);
+    expect(await hasUpscaleShader(false)).toBe(false);
+    expect(await hasUpscaleShader(undefined)).toBe(false);
+});
+
+test("smooth matches nearest at an integer scale", async ({ context }) => {
+    // 320x180 in 640x360 is exactly 2x
+    const viewport = { width: 640, height: 360 };
+
+    const smooth = await render(await context.newPage(), "smooth", viewport);
+    const nearest = await render(await context.newPage(), true, viewport);
+
+    expect(smooth.equals(nearest)).toBe(true);
+});
+
+test("smooth differs from nearest at a fractional scale", async ({ context }) => {
+    // 320x180 in 700x394 is ~2.19x
+    const viewport = { width: 700, height: 394 };
+
+    const smooth = await render(await context.newPage(), "smooth", viewport);
+    const nearest = await render(await context.newPage(), true, viewport);
+
+    expect(smooth.equals(nearest)).toBe(false);
+});

--- a/tests/playtests/crispSmooth.js
+++ b/tests/playtests/crispSmooth.js
@@ -1,0 +1,89 @@
+/**
+ * @file Crisp smooth scaling
+ * @description Test the `crisp: "smooth"` upscaling on a fractional scale,
+ * cycled with the space bar (?crisp=true|false|smooth).
+ * @difficulty 2
+ * @tags rendering
+ * @minver 4000.0
+ */
+
+// Cycle order: smooth -> true -> false -> smooth
+const ORDER = ["smooth", "true", "false"];
+const param = new URLSearchParams(location.search).get("crisp");
+const crispMode = ORDER.includes(param) ? param : "smooth";
+
+const crisp = crispMode === "true"
+    ? true
+    : crispMode === "false"
+    ? false
+    : "smooth";
+
+window.addEventListener("keydown", (e) => {
+    if (e.key !== " ") return;
+    e.preventDefault();
+    const next = ORDER[(ORDER.indexOf(crispMode) + 1) % ORDER.length];
+    const url = new URL(location.href);
+    url.searchParams.set("crisp", next);
+    location.href = url.toString();
+});
+
+kaplay({
+    width: 960,
+    height: 540,
+    letterbox: true,
+    crisp,
+    background: "#444444",
+});
+
+loadBean();
+
+onLoad(() => {
+    add([sprite("bean"), pos(100, 60), anchor("center"), scale(1)]);
+    add([sprite("bean"), pos(100, 150), anchor("center"), scale(2)]);
+    add([sprite("bean"), pos(100, 300), anchor("center"), scale(3)]);
+
+    add([
+        text(`crisp: ${crispMode}`, { size: 20 }),
+        pos(20, 440),
+        color(255, 255, 255),
+    ]);
+
+    add([
+        text("Press space: smooth -> true -> false (page reloads)", {
+            size: 12,
+        }),
+        pos(20, 470),
+        color(180, 180, 200),
+    ]);
+});
+
+onDraw(() => {
+    // 1px vertical lines: nearest makes their widths alternate, smooth doesn't
+    for (let i = 0; i < 40; i++) {
+        drawRect({
+            pos: vec2(300 + i * 6, 40),
+            width: 1,
+            height: 120,
+            color: rgb(255, 255, 255),
+        });
+    }
+
+    // Diagonals: stair-steps show aliasing vs soft edges
+    for (let i = 0; i < 12; i++) {
+        drawLine({
+            p1: vec2(300, 210 + i * 9),
+            p2: vec2(540, 200 + i * 9),
+            width: 1,
+            color: rgb(255, 220, 100),
+        });
+    }
+
+    // Circle outlines: jaggies vs anti-aliased edges
+    for (let i = 0; i < 6; i++) {
+        drawCircle({
+            pos: vec2(650 + (i % 3) * 110, 110 + Math.floor(i / 3) * 110),
+            radius: 32 + i * 4,
+            outline: { width: 1, color: rgb(255, 0, 255) },
+        });
+    }
+});


### PR DESCRIPTION
# PR Overview

This PR adds a third option to `KAPLAYOpt.crisp`: `"smooth"`. This will apply a shader that adds anti-aliasing to pixel edges, while maintaining their crispiness. This is especially noticeable on labels, thin lines, and more generally "big pixel" sprites that are rendered unevenly when the scaling is not an integer.

Disclaimer: this was mostly written by AI, out of a personal need. I understand what's going on but rendering and shaders aren't my thing at all, so I absolutely won't take it personally if it's rejected because of it :)

## List of changes

- New setting value for `KAPLAYOpt.crisp`
- New anti-aliasing shader + related demo page and basic integration tests
- This new render option needs to be integrated relatively deeply, but the changes are (I think) quite straightforward.

Comparison screenshots:

crisp = "smooth"
<img width="1822" height="970" alt="image" src="https://github.com/user-attachments/assets/3576e43c-dba9-4a60-99a4-97f455038f7c" />

crisp = false
<img width="1822" height="970" alt="image" src="https://github.com/user-attachments/assets/24d9dd9b-82f5-4ae5-bc3a-c8b25c09a291" />


## Contributor Checks

- [x] I'm aware of the
      [contributing guidelines](https://github.com/kaplayjs/kaplay/blob/master/CONTRIBUTING.md).

## Reviewer Checks

**Don't modify this section.** It is for reviewers to check when reviewing the PR.

- [ ] Changes include a changelog.
- [ ] Breaking changes are marked in the changelog.
- [ ] Changes include `/tests/integration` tests. 
- [ ] Changes include `/tests/unit` tests.
- [ ] Additional reviewers are assigned to the PR.
